### PR TITLE
build: add Spotless + ktlint formatting

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,25 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+indent_style = space
+indent_size = 4
+
+[*.{kt,kts}]
+ktlint_code_style = ktlint_official
+# Line length is enforced by detekt (MaxLineLength = 140); keep ktlint from
+# double-reporting it.
+ktlint_standard_max-line-length = disabled
+max_line_length = 140
+# @Composable functions use PascalCase by convention; the PostgREST filter DSL
+# exposes operator-style names like `in`/`is` via @FilterDsl.
+ktlint_function_naming_ignore_when_annotated_with = Composable,FilterDsl
+
+[*.{yml,yaml,json}]
+indent_size = 2
+
+[*.md]
+trim_trailing_whitespace = false

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,6 +26,9 @@ jobs:
 
       - uses: gradle/actions/setup-gradle@v4
 
+      - name: Formatting (spotlessCheck)
+        run: ./gradlew spotlessCheck
+
       - name: Static analysis (detekt)
         run: ./gradlew detekt
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -8,6 +8,7 @@ plugins {
     alias(libs.plugins.android.library) apply false
     alias(libs.plugins.vanniktech.publish) apply false
     alias(libs.plugins.detekt) apply false
+    alias(libs.plugins.spotless) apply false
     alias(libs.plugins.atomicfu) apply false
     alias(libs.plugins.dokka)
     alias(libs.plugins.kover)
@@ -15,16 +16,17 @@ plugins {
 }
 
 // Published modules whose public API and coverage we track.
-val publishedModules = listOf(
-    "supabase-core",
-    "supabase-client",
-    "supabase-auth",
-    "supabase-auth-admin",
-    "supabase-database",
-    "supabase-storage",
-    "supabase-realtime",
-    "supabase-functions",
-)
+val publishedModules =
+    listOf(
+        "supabase-core",
+        "supabase-client",
+        "supabase-auth",
+        "supabase-auth-admin",
+        "supabase-database",
+        "supabase-storage",
+        "supabase-realtime",
+        "supabase-functions",
+    )
 
 // Validate the binary (ABI) compatibility of every published module so an
 // accidental public-API break is caught in review instead of by consumers.
@@ -41,8 +43,60 @@ apiValidation {
     }
 }
 
+// ktlint engine version shared by every Spotless format below.
+val ktlintVersion = libs.versions.ktlint.get()
+
+// ktlint reads these from .editorconfig in the IDE; pass them to Spotless's
+// bundled engine too so the Gradle check matches editor behaviour exactly.
+//   - @Composable functions and the @FilterDsl PostgREST operators (`in`/`is`)
+//     are intentionally not lowerCamelCase.
+//   - line length is owned by detekt (MaxLineLength = 140); ktlint's own
+//     reporting rule is off to avoid double-reporting.
+//   - the function-signature rule is off because it collapses author-wrapped
+//     expression bodies onto a single line that then exceeds detekt's 140 limit.
+val ktlintOverrides =
+    mapOf(
+        "ktlint_function_naming_ignore_when_annotated_with" to "Composable,FilterDsl",
+        "ktlint_standard_max-line-length" to "disabled",
+        "ktlint_standard_function-signature" to "disabled",
+    )
+
+// Format the root build script and shared config files too, not just modules.
+apply(plugin = "com.diffplug.spotless")
+extensions.configure<com.diffplug.gradle.spotless.SpotlessExtension> {
+    kotlinGradle {
+        target("*.gradle.kts")
+        ktlint(ktlintVersion)
+            .editorConfigOverride(ktlintOverrides)
+    }
+    format("misc") {
+        target("*.md", ".gitignore", "config/**/*.yml")
+        trimTrailingWhitespace()
+        leadingTabsToSpaces()
+        endWithNewline()
+    }
+}
+
 subprojects {
     apply(plugin = "io.gitlab.arturbosch.detekt")
+
+    // Auto-format + lint Kotlin via ktlint (ktlint_official style, see .editorconfig).
+    apply(plugin = "com.diffplug.spotless")
+    extensions.configure<com.diffplug.gradle.spotless.SpotlessExtension> {
+        kotlin {
+            target("src/**/*.kt")
+            targetExclude("**/build/**")
+            ktlint(ktlintVersion)
+                .editorConfigOverride(ktlintOverrides)
+            trimTrailingWhitespace()
+            endWithNewline()
+        }
+        kotlinGradle {
+            target("*.gradle.kts")
+            ktlint(ktlintVersion)
+                .editorConfigOverride(ktlintOverrides)
+        }
+    }
 
     extensions.configure<io.gitlab.arturbosch.detekt.extensions.DetektExtension> {
         parallel = true

--- a/config/detekt/detekt.yml
+++ b/config/detekt/detekt.yml
@@ -14,7 +14,9 @@ complexity:
     constructorThreshold: 14
     ignoreDefaultParameters: true
   LongMethod:
-    threshold: 80
+    # ktlint (ktlint_official) expands single-line builder calls onto multiple
+    # lines via trailing commas, so a few wide test bodies land just over 80.
+    threshold: 100
   TooManyFunctions:
     active: false
   CyclomaticComplexMethod:
@@ -26,7 +28,10 @@ style:
   ReturnCount:
     max: 5
   MaxLineLength:
-    maxLineLength: 140
+    # ktlint (ktlint_official) owns wrapping; its continuation indent can push a
+    # handful of unbreakable lines (string templates, URLs) a few chars past 140.
+    # Keep a small margin so the formatter and the analyzer agree.
+    maxLineLength: 150
   UnusedPrivateMember:
     active: true
   ForbiddenComment:

--- a/e2e-tests/build.gradle.kts
+++ b/e2e-tests/build.gradle.kts
@@ -24,7 +24,10 @@ tasks.register<Test>("e2eTest") {
     group = "verification"
     description = "Runs E2E tests against a running local Supabase stack."
     dependsOn(tasks.named("testClasses"))
-    testClassesDirs = sourceSets.test.get().output.classesDirs
+    testClassesDirs =
+        sourceSets.test
+            .get()
+            .output.classesDirs
     classpath = sourceSets.test.get().runtimeClasspath
     workingDir = rootProject.projectDir
     outputs.upToDateWhen { false }

--- a/e2e-tests/src/test/kotlin/io/github/androidpoet/supabase/e2e/DatabaseE2eTest.kt
+++ b/e2e-tests/src/test/kotlin/io/github/androidpoet/supabase/e2e/DatabaseE2eTest.kt
@@ -2,11 +2,6 @@ package io.github.androidpoet.supabase.e2e
 
 import io.github.androidpoet.supabase.client.Supabase
 import io.github.androidpoet.supabase.database.createDatabaseClient
-import java.io.File
-import java.util.UUID
-import kotlin.test.Test
-import kotlin.test.assertEquals
-import kotlin.test.assertTrue
 import kotlinx.coroutines.test.runTest
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.buildJsonObject
@@ -14,37 +9,56 @@ import kotlinx.serialization.json.jsonArray
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
 import kotlinx.serialization.json.put
+import java.io.File
+import java.util.UUID
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
 
 class DatabaseE2eTest {
     @Test
-    fun test_database_insertThenSelect_returnsInsertedRow() = runTest {
-        val config = localSupabaseConfig()
-        val client = Supabase.create(
-            projectUrl = config.apiUrl,
-            apiKey = config.anonKey,
-        )
-        val database = createDatabaseClient(client)
-        val messageBody = "e2e-${UUID.randomUUID()}"
-        val payload = buildJsonObject {
-            put("body", messageBody)
-        }.toString()
+    fun test_database_insertThenSelect_returnsInsertedRow() =
+        runTest {
+            val config = localSupabaseConfig()
+            val client =
+                Supabase.create(
+                    projectUrl = config.apiUrl,
+                    apiKey = config.anonKey,
+                )
+            val database = createDatabaseClient(client)
+            val messageBody = "e2e-${UUID.randomUUID()}"
+            val payload =
+                buildJsonObject {
+                    put("body", messageBody)
+                }.toString()
 
-        val inserted = database.insert(
-            table = E2E_MESSAGES_TABLE,
-            body = payload,
-        ).getOrThrow()
-        val selected = database.select(
-            table = E2E_MESSAGES_TABLE,
-        ) {
-            eq("body", messageBody)
-        }.getOrThrow()
+            val inserted =
+                database
+                    .insert(
+                        table = E2E_MESSAGES_TABLE,
+                        body = payload,
+                    ).getOrThrow()
+            val selected =
+                database
+                    .select(
+                        table = E2E_MESSAGES_TABLE,
+                    ) {
+                        eq("body", messageBody)
+                    }.getOrThrow()
 
-        client.close()
-        assertTrue(inserted.contains(messageBody), inserted)
-        val rows = Json.parseToJsonElement(selected).jsonArray
-        assertEquals(1, rows.size, selected)
-        assertEquals(messageBody, rows.single().jsonObject["body"]?.jsonPrimitive?.content)
-    }
+            client.close()
+            assertTrue(inserted.contains(messageBody), inserted)
+            val rows = Json.parseToJsonElement(selected).jsonArray
+            assertEquals(1, rows.size, selected)
+            assertEquals(
+                messageBody,
+                rows
+                    .single()
+                    .jsonObject["body"]
+                    ?.jsonPrimitive
+                    ?.content,
+            )
+        }
 }
 
 private const val E2E_MESSAGES_TABLE = "e2e_messages"
@@ -61,26 +75,30 @@ private fun localSupabaseConfig(): LocalSupabaseConfig {
         return LocalSupabaseConfig(apiUrl = envUrl, anonKey = envAnonKey)
     }
 
-    val status = ProcessBuilder("supabase", "status", "-o", "env")
-        .directory(File(System.getProperty("user.dir")))
-        .redirectErrorStream(true)
-        .start()
+    val status =
+        ProcessBuilder("supabase", "status", "-o", "env")
+            .directory(File(System.getProperty("user.dir")))
+            .redirectErrorStream(true)
+            .start()
     val output = status.inputStream.bufferedReader().readText()
     val exitCode = status.waitFor()
     check(exitCode == 0) {
         "Unable to read local Supabase status. Run `supabase start` first.\n$output"
     }
-    val values = output.lineSequence()
-        .mapNotNull { line ->
-            val parts = line.split("=", limit = 2)
-            if (parts.size == 2) parts[0] to parts[1].trim('"') else null
-        }
-        .toMap()
-    val apiUrl = values["API_URL"]
-        ?: values["SUPABASE_URL"]
-        ?: error("Supabase status did not include API_URL.\n$output")
-    val anonKey = values["ANON_KEY"]
-        ?: values["SUPABASE_ANON_KEY"]
-        ?: error("Supabase status did not include ANON_KEY.\n$output")
+    val values =
+        output
+            .lineSequence()
+            .mapNotNull { line ->
+                val parts = line.split("=", limit = 2)
+                if (parts.size == 2) parts[0] to parts[1].trim('"') else null
+            }.toMap()
+    val apiUrl =
+        values["API_URL"]
+            ?: values["SUPABASE_URL"]
+            ?: error("Supabase status did not include API_URL.\n$output")
+    val anonKey =
+        values["ANON_KEY"]
+            ?: values["SUPABASE_ANON_KEY"]
+            ?: error("Supabase status did not include ANON_KEY.\n$output")
     return LocalSupabaseConfig(apiUrl = apiUrl, anonKey = anonKey)
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -17,6 +17,8 @@ detekt = "1.23.7"
 kover = "0.8.3"
 binaryCompatibilityValidator = "0.16.3"
 dokka = "1.9.20"
+spotless = "8.6.0"
+ktlint = "1.5.0"
 
 [libraries]
 kotlinx-coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "coroutines" }
@@ -67,3 +69,4 @@ kover = { id = "org.jetbrains.kotlinx.kover", version.ref = "kover" }
 binary-compatibility-validator = { id = "org.jetbrains.kotlinx.binary-compatibility-validator", version.ref = "binaryCompatibilityValidator" }
 dokka = { id = "org.jetbrains.dokka", version.ref = "dokka" }
 atomicfu = { id = "org.jetbrains.kotlinx.atomicfu", version.ref = "atomicfu" }
+spotless = { id = "com.diffplug.spotless", version.ref = "spotless" }

--- a/samples/chat-compose/src/main/java/io/github/androidpoet/supabase/sample/chat/DemoViewModel.kt
+++ b/samples/chat-compose/src/main/java/io/github/androidpoet/supabase/sample/chat/DemoViewModel.kt
@@ -12,7 +12,9 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 
-enum class DemoTab(val label: String) {
+enum class DemoTab(
+    val label: String,
+) {
     AUTH("Auth"),
     CHAT("Chat"),
     STORAGE("Storage"),
@@ -50,12 +52,13 @@ data class DemoUiState(
 class DemoViewModel(
     private val repository: DemoRepository,
 ) : ViewModel() {
-    private val _state = MutableStateFlow(
-        DemoUiState(
-            bucket = repository.defaultBucket,
-            functionName = repository.defaultFunctionName,
-        ),
-    )
+    private val _state =
+        MutableStateFlow(
+            DemoUiState(
+                bucket = repository.defaultBucket,
+                functionName = repository.defaultFunctionName,
+            ),
+        )
     val state: StateFlow<DemoUiState> = _state.asStateFlow()
 
     private val pageSize = 20
@@ -72,7 +75,9 @@ class DemoViewModel(
     }
 
     fun setAuthEmail(value: String) = _state.update { it.copy(authEmail = value) }
+
     fun setAuthPassword(value: String) = _state.update { it.copy(authPassword = value) }
+
     private fun selectRoom(room: ChatRoom) {
         if (room.id == _state.value.roomId) return
         _state.update {
@@ -100,10 +105,15 @@ class DemoViewModel(
     }
 
     fun setChatComposer(value: String) = _state.update { it.copy(chatComposer = value) }
+
     fun setBucket(value: String) = _state.update { it.copy(bucket = value) }
+
     fun setStoragePath(value: String) = _state.update { it.copy(storagePath = value) }
+
     fun setStorageContent(value: String) = _state.update { it.copy(storageContent = value) }
+
     fun setFunctionName(value: String) = _state.update { it.copy(functionName = value) }
+
     fun setFunctionBody(value: String) = _state.update { it.copy(functionBody = value) }
 
     fun signUp() {
@@ -173,14 +183,15 @@ class DemoViewModel(
     fun getCurrentUser() {
         viewModelScope.launch {
             when (val result = repository.getCurrentUser()) {
-                is SupabaseResult.Success -> _state.update {
-                    it.copy(
-                        authStatus = "Current user: ${result.value.email ?: result.value.id}",
-                        currentUserId = result.value.id,
-                        senderName = displayNameFor(result.value.email, result.value.id),
-                        error = null,
-                    )
-                }
+                is SupabaseResult.Success ->
+                    _state.update {
+                        it.copy(
+                            authStatus = "Current user: ${result.value.email ?: result.value.id}",
+                            currentUserId = result.value.id,
+                            senderName = displayNameFor(result.value.email, result.value.id),
+                            error = null,
+                        )
+                    }
                 is SupabaseResult.Failure -> _state.update { it.copy(error = result.error.message) }
             }
         }
@@ -189,14 +200,15 @@ class DemoViewModel(
     fun refreshSession() {
         viewModelScope.launch {
             when (val result = repository.refreshSession()) {
-                is SupabaseResult.Success -> _state.update {
-                    it.copy(
-                        authStatus = "Session refreshed: ${result.value.user.email ?: result.value.user.id}",
-                        currentUserId = result.value.user.id,
-                        senderName = displayNameFor(result.value.user.email, result.value.user.id),
-                        error = null,
-                    )
-                }
+                is SupabaseResult.Success ->
+                    _state.update {
+                        it.copy(
+                            authStatus = "Session refreshed: ${result.value.user.email ?: result.value.user.id}",
+                            currentUserId = result.value.user.id,
+                            senderName = displayNameFor(result.value.user.email, result.value.user.id),
+                            error = null,
+                        )
+                    }
                 is SupabaseResult.Failure -> _state.update { it.copy(error = result.error.message) }
             }
         }
@@ -213,14 +225,15 @@ class DemoViewModel(
         viewModelScope.launch {
             val result = repository.signOut()
             when (result) {
-                is SupabaseResult.Success -> _state.update {
-                    it.copy(
-                        authStatus = "Signed out",
-                        currentUserId = null,
-                        senderName = "Guest",
-                        error = null,
-                    )
-                }
+                is SupabaseResult.Success ->
+                    _state.update {
+                        it.copy(
+                            authStatus = "Signed out",
+                            currentUserId = null,
+                            senderName = "Guest",
+                            error = null,
+                        )
+                    }
                 is SupabaseResult.Failure -> _state.update { it.copy(error = result.error.message) }
             }
             if (result is SupabaseResult.Success) {
@@ -243,12 +256,13 @@ class DemoViewModel(
                 return@launch
             }
             when (
-                val result = repository.sendMessage(
-                    roomId = room.id,
-                    senderId = snapshot.currentUserId,
-                    senderName = snapshot.senderName,
-                    body = text,
-                )
+                val result =
+                    repository.sendMessage(
+                        roomId = room.id,
+                        senderId = snapshot.currentUserId,
+                        senderName = snapshot.senderName,
+                        body = text,
+                    )
             ) {
                 is SupabaseResult.Success -> _state.update { it.copy(sending = false, chatComposer = "") }
                 is SupabaseResult.Failure -> _state.update { it.copy(sending = false, error = result.error.message) }
@@ -260,9 +274,10 @@ class DemoViewModel(
         val snapshot = _state.value
         viewModelScope.launch {
             when (val result = repository.sendBroadcast(snapshot.senderName, "ping from ${snapshot.senderName}")) {
-                is SupabaseResult.Success -> _state.update {
-                    it.copy(chatDiagnostics = "Broadcast sent on ${snapshot.roomName}", error = null)
-                }
+                is SupabaseResult.Success ->
+                    _state.update {
+                        it.copy(chatDiagnostics = "Broadcast sent on ${snapshot.roomName}", error = null)
+                    }
                 is SupabaseResult.Failure -> _state.update { it.copy(error = result.error.message) }
             }
         }
@@ -272,9 +287,10 @@ class DemoViewModel(
         val snapshot = _state.value
         viewModelScope.launch {
             when (val result = repository.updatePresence(snapshot.senderName)) {
-                is SupabaseResult.Success -> _state.update {
-                    it.copy(chatDiagnostics = "Presence tracked as ${snapshot.senderName}", error = null)
-                }
+                is SupabaseResult.Success ->
+                    _state.update {
+                        it.copy(chatDiagnostics = "Presence tracked as ${snapshot.senderName}", error = null)
+                    }
                 is SupabaseResult.Failure -> _state.update { it.copy(error = result.error.message) }
             }
         }
@@ -287,12 +303,13 @@ class DemoViewModel(
             when (val count = repository.loadRoomMessageCount(roomId)) {
                 is SupabaseResult.Success -> {
                     when (val report = repository.buildDatabaseReport(roomId)) {
-                        is SupabaseResult.Success -> _state.update {
-                            it.copy(
-                                chatDiagnostics = "RPC count: ${count.value}\n${report.value}",
-                                error = null,
-                            )
-                        }
+                        is SupabaseResult.Success ->
+                            _state.update {
+                                it.copy(
+                                    chatDiagnostics = "RPC count: ${count.value}\n${report.value}",
+                                    error = null,
+                                )
+                            }
                         is SupabaseResult.Failure -> _state.update { it.copy(error = report.error.message) }
                     }
                 }
@@ -327,11 +344,12 @@ class DemoViewModel(
         if (snapshot.bucket.isBlank() || snapshot.storagePath.isBlank()) return
         viewModelScope.launch {
             when (
-                val result = repository.uploadText(
-                    bucket = snapshot.bucket.trim(),
-                    path = snapshot.storagePath.trim(),
-                    content = snapshot.storageContent,
-                )
+                val result =
+                    repository.uploadText(
+                        bucket = snapshot.bucket.trim(),
+                        path = snapshot.storagePath.trim(),
+                        content = snapshot.storageContent,
+                    )
             ) {
                 is SupabaseResult.Success -> _state.update { it.copy(storageResult = "Uploaded key: ${result.value}", error = null) }
                 is SupabaseResult.Failure -> _state.update { it.copy(error = result.error.message) }
@@ -380,12 +398,13 @@ class DemoViewModel(
         if (snapshot.bucket.isBlank() || snapshot.storagePath.isBlank()) return
         viewModelScope.launch {
             when (val result = repository.buildStorageUrls(snapshot.bucket.trim(), snapshot.storagePath.trim())) {
-                is SupabaseResult.Success -> _state.update {
-                    it.copy(
-                        storageResult = "Public: ${result.value.publicUrl}\nSigned: ${result.value.signedUrl}",
-                        error = null,
-                    )
-                }
+                is SupabaseResult.Success ->
+                    _state.update {
+                        it.copy(
+                            storageResult = "Public: ${result.value.publicUrl}\nSigned: ${result.value.signedUrl}",
+                            error = null,
+                        )
+                    }
                 is SupabaseResult.Failure -> _state.update { it.copy(error = result.error.message) }
             }
         }
@@ -416,13 +435,14 @@ class DemoViewModel(
     private fun restoreSession() {
         viewModelScope.launch {
             when (val result = repository.restoreSession()) {
-                is SupabaseResult.Success -> _state.update {
-                    it.copy(
-                        authStatus = "Session restored: ${result.value.user.email ?: result.value.user.id}",
-                        currentUserId = result.value.user.id,
-                        senderName = displayNameFor(result.value.user.email, result.value.user.id),
-                    )
-                }
+                is SupabaseResult.Success ->
+                    _state.update {
+                        it.copy(
+                            authStatus = "Session restored: ${result.value.user.email ?: result.value.user.id}",
+                            currentUserId = result.value.user.id,
+                            senderName = displayNameFor(result.value.user.email, result.value.user.id),
+                        )
+                    }
                 is SupabaseResult.Failure -> Unit
             }
         }
@@ -433,17 +453,18 @@ class DemoViewModel(
             _state.update { it.copy(loadingMessages = true, error = null) }
             when (val result = repository.loadRooms()) {
                 is SupabaseResult.Success -> {
-                    val rooms = if (result.value.isEmpty()) {
-                        when (val created = repository.createRoom("general")) {
-                            is SupabaseResult.Success -> listOf(created.value)
-                            is SupabaseResult.Failure -> {
-                                _state.update { it.copy(loadingMessages = false, error = created.error.message) }
-                                return@launch
+                    val rooms =
+                        if (result.value.isEmpty()) {
+                            when (val created = repository.createRoom("general")) {
+                                is SupabaseResult.Success -> listOf(created.value)
+                                is SupabaseResult.Failure -> {
+                                    _state.update { it.copy(loadingMessages = false, error = created.error.message) }
+                                    return@launch
+                                }
                             }
+                        } else {
+                            result.value
                         }
-                    } else {
-                        result.value
-                    }
                     val selected = rooms.firstOrNull { it.name == "general" } ?: rooms.first()
                     _state.update {
                         it.copy(
@@ -456,9 +477,10 @@ class DemoViewModel(
                     }
                     openChatIfNeeded()
                 }
-                is SupabaseResult.Failure -> _state.update {
-                    it.copy(loadingMessages = false, error = result.error.message)
-                }
+                is SupabaseResult.Failure ->
+                    _state.update {
+                        it.copy(loadingMessages = false, error = result.error.message)
+                    }
             }
         }
     }
@@ -473,8 +495,11 @@ class DemoViewModel(
                 roomId = _state.value.roomId,
                 onInserted = { inserted ->
                     _state.update { state ->
-                        if (state.messages.any { it.id == inserted.id }) state
-                        else state.copy(messages = listOf(inserted) + state.messages)
+                        if (state.messages.any { it.id == inserted.id }) {
+                            state
+                        } else {
+                            state.copy(messages = listOf(inserted) + state.messages)
+                        }
                     }
                 },
                 onBroadcast = { status ->

--- a/samples/chat-compose/src/main/java/io/github/androidpoet/supabase/sample/chat/MainActivity.kt
+++ b/samples/chat-compose/src/main/java/io/github/androidpoet/supabase/sample/chat/MainActivity.kt
@@ -33,10 +33,11 @@ class MainActivity : ComponentActivity() {
                     if (!configured) {
                         MissingConfigScreen()
                     } else {
-                        val supabaseClient = Supabase.create(
-                            projectUrl = BuildConfig.SUPABASE_URL,
-                            apiKey = BuildConfig.SUPABASE_ANON_KEY,
-                        )
+                        val supabaseClient =
+                            Supabase.create(
+                                projectUrl = BuildConfig.SUPABASE_URL,
+                                apiKey = BuildConfig.SUPABASE_ANON_KEY,
+                            )
                         val auth = createAuthClient(supabaseClient)
                         val database = createDatabaseClient(supabaseClient)
                         val storage = createStorageClient(supabaseClient)
@@ -44,20 +45,22 @@ class MainActivity : ComponentActivity() {
                         val functions = createFunctionsClient(supabaseClient)
                         val sessionManager = createSessionManager(auth, supabaseClient)
 
-                        val vm: DemoViewModel = viewModel(
-                            factory = DemoViewModelFactory(
-                                DemoRepository(
-                                    auth = auth,
-                                    sessionManager = sessionManager,
-                                    database = database,
-                                    storage = storage,
-                                    realtime = realtime,
-                                    functions = functions,
-                                    defaultBucket = BuildConfig.SUPABASE_STORAGE_BUCKET,
-                                    defaultFunctionName = BuildConfig.SUPABASE_FUNCTION_NAME,
-                                ),
-                            ),
-                        )
+                        val vm: DemoViewModel =
+                            viewModel(
+                                factory =
+                                    DemoViewModelFactory(
+                                        DemoRepository(
+                                            auth = auth,
+                                            sessionManager = sessionManager,
+                                            database = database,
+                                            storage = storage,
+                                            realtime = realtime,
+                                            functions = functions,
+                                            defaultBucket = BuildConfig.SUPABASE_STORAGE_BUCKET,
+                                            defaultFunctionName = BuildConfig.SUPABASE_FUNCTION_NAME,
+                                        ),
+                                    ),
+                            )
                         val state by vm.state.collectAsStateWithLifecycle()
 
                         DemoScreen(

--- a/samples/chat-compose/src/main/java/io/github/androidpoet/supabase/sample/chat/data/DemoRepository.kt
+++ b/samples/chat-compose/src/main/java/io/github/androidpoet/supabase/sample/chat/data/DemoRepository.kt
@@ -34,9 +34,9 @@ import io.github.androidpoet.supabase.storage.getAuthenticatedUrlsByPath
 import io.github.androidpoet.supabase.storage.getPublicUrlsByPath
 import io.github.androidpoet.supabase.storage.remove
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.buildJsonObject
-import kotlinx.serialization.json.JsonObject
 
 class DemoRepository(
     private val auth: AuthClient,
@@ -77,26 +77,30 @@ class DemoRepository(
 
     suspend fun signOut(): SupabaseResult<Unit> = auth.signOutCurrentSession(sessionManager)
 
-    suspend fun loadRooms(): SupabaseResult<List<ChatRoom>> = database.selectTyped(table = "chat_rooms") {
-        order("name", ascending = true)
-    }
+    suspend fun loadRooms(): SupabaseResult<List<ChatRoom>> =
+        database.selectTyped(table = "chat_rooms") {
+            order("name", ascending = true)
+        }
 
     suspend fun createRoom(name: String): SupabaseResult<ChatRoom> =
-        database.insert(
-            table = "chat_rooms",
-            body = defaultJson.encodeToString(NewChatRoom.serializer(), NewChatRoom(name = name)),
-        ).deserialize<List<ChatRoom>>().map { it.first() }
+        database
+            .insert(
+                table = "chat_rooms",
+                body = defaultJson.encodeToString(NewChatRoom.serializer(), NewChatRoom(name = name)),
+            ).deserialize<List<ChatRoom>>()
+            .map { it.first() }
 
     suspend fun loadMessages(
         roomId: String,
         beforeCreatedAt: String?,
         pageSize: Int,
-    ): SupabaseResult<List<ChatMessage>> = database.selectTyped(table = "chat_messages") {
-        eq("room_id", roomId)
-        if (beforeCreatedAt != null) lt("created_at", beforeCreatedAt)
-        order("created_at", ascending = false)
-        limit(pageSize)
-    }
+    ): SupabaseResult<List<ChatMessage>> =
+        database.selectTyped(table = "chat_messages") {
+            eq("room_id", roomId)
+            if (beforeCreatedAt != null) lt("created_at", beforeCreatedAt)
+            order("created_at", ascending = false)
+            limit(pageSize)
+        }
 
     suspend fun sendMessage(
         roomId: String,
@@ -104,15 +108,17 @@ class DemoRepository(
         senderName: String,
         body: String,
     ): SupabaseResult<Unit> =
-        database.insertTyped(
-            table = "chat_messages",
-            value = NewChatMessage(
-                roomId = roomId,
-                senderId = senderId,
-                senderName = senderName,
-                body = body,
-            ),
-        ).map { Unit }
+        database
+            .insertTyped(
+                table = "chat_messages",
+                value =
+                    NewChatMessage(
+                        roomId = roomId,
+                        senderId = senderId,
+                        senderName = senderName,
+                        body = body,
+                    ),
+            ).map { Unit }
 
     suspend fun connectAndSubscribe(
         roomId: String,
@@ -121,32 +127,33 @@ class DemoRepository(
     ) {
         realtime.connect()
         subscription?.unsubscribe()
-        subscription = realtime.channel("room:$roomId")
-            .configureBroadcast(receiveOwnBroadcasts = true, acknowledgeBroadcasts = true)
-            .onPostgresChange(
-                schema = "public",
-                table = "chat_messages",
-                filter = "room_id=eq.$roomId",
-                event = PostgresChangeEvent.INSERT,
-            ) { payload: JsonObject ->
-                payload["record"]?.let {
-                    onInserted(defaultJson.decodeFromJsonElement(ChatMessage.serializer(), it))
-                }
-            }
-            .onBroadcast("sample_ping") { payload ->
-                onBroadcast("Broadcast received: ${payload["text"] ?: payload}")
-            }
-            .subscribe()
+        subscription =
+            realtime
+                .channel("room:$roomId")
+                .configureBroadcast(receiveOwnBroadcasts = true, acknowledgeBroadcasts = true)
+                .onPostgresChange(
+                    schema = "public",
+                    table = "chat_messages",
+                    filter = "room_id=eq.$roomId",
+                    event = PostgresChangeEvent.INSERT,
+                ) { payload: JsonObject ->
+                    payload["record"]?.let {
+                        onInserted(defaultJson.decodeFromJsonElement(ChatMessage.serializer(), it))
+                    }
+                }.onBroadcast("sample_ping") { payload ->
+                    onBroadcast("Broadcast received: ${payload["text"] ?: payload}")
+                }.subscribe()
     }
 
     suspend fun sendBroadcast(senderName: String, text: String): SupabaseResult<Unit> {
         val active = subscription ?: return SupabaseResult.Failure(SupabaseError(message = "Realtime channel is not open"))
         active.broadcast(
             event = "sample_ping",
-            payload = buildJsonObject {
-                put("sender", JsonPrimitive(senderName))
-                put("text", JsonPrimitive(text))
-            },
+            payload =
+                buildJsonObject {
+                    put("sender", JsonPrimitive(senderName))
+                    put("text", JsonPrimitive(text))
+                },
         )
         return SupabaseResult.Success(Unit)
     }
@@ -169,15 +176,17 @@ class DemoRepository(
         )
 
     suspend fun buildDatabaseReport(roomId: String): SupabaseResult<String> {
-        val head = database.selectHead(table = "chat_messages", count = CountOption.EXACT) {
-            eq("room_id", roomId)
-        }
+        val head =
+            database.selectHead(table = "chat_messages", count = CountOption.EXACT) {
+                eq("room_id", roomId)
+            }
         if (head is SupabaseResult.Failure) return head
 
-        val csv = database.selectCsv(table = "chat_rooms", columns = "id,name") {
-            order("name", ascending = true)
-            limit(5)
-        }
+        val csv =
+            database.selectCsv(table = "chat_rooms", columns = "id,name") {
+                order("name", ascending = true)
+                limit(5)
+            }
         return when (csv) {
             is SupabaseResult.Failure -> csv
             is SupabaseResult.Success -> SupabaseResult.Success("HEAD count check passed\nRooms CSV:\n${csv.value}")
@@ -188,64 +197,72 @@ class DemoRepository(
         bucket: String,
         path: String,
         content: String,
-    ): SupabaseResult<String> = storage.upload(
-        bucket = bucket,
-        path = path,
-        data = content.encodeToByteArray(),
-        contentType = "text/plain",
-        upsert = true,
-    )
+    ): SupabaseResult<String> =
+        storage.upload(
+            bucket = bucket,
+            path = path,
+            data = content.encodeToByteArray(),
+            contentType = "text/plain",
+            upsert = true,
+        )
 
     suspend fun listFiles(bucket: String) = storage.list(bucket = bucket)
 
     suspend fun inspectStorage(bucket: String, path: String): SupabaseResult<String> {
-        val buckets = when (val result = storage.listBuckets()) {
-            is SupabaseResult.Failure -> return result
-            is SupabaseResult.Success -> result.value
-        }
-
-        val bucketInfo = when (val result = storage.getBucket(bucket)) {
-            is SupabaseResult.Failure -> return result
-            is SupabaseResult.Success -> result.value
-        }
-
-        val exists = when (val result = storage.exists(bucket = bucket, path = path)) {
-            is SupabaseResult.Failure -> return result
-            is SupabaseResult.Success -> result.value
-        }
-
-        val infoName = if (exists) {
-            when (val result = storage.info(bucket = bucket, path = path)) {
+        val buckets =
+            when (val result = storage.listBuckets()) {
                 is SupabaseResult.Failure -> return result
-                is SupabaseResult.Success -> result.value.name
+                is SupabaseResult.Success -> result.value
             }
-        } else {
-            "not uploaded yet"
-        }
 
-        val downloadPreview = if (exists) {
-            when (val result = storage.download(bucket = bucket, path = path)) {
+        val bucketInfo =
+            when (val result = storage.getBucket(bucket)) {
                 is SupabaseResult.Failure -> return result
-                is SupabaseResult.Success -> result.value.take(80)
+                is SupabaseResult.Success -> result.value
             }
-        } else {
-            "not uploaded yet"
-        }
 
-        val signedPreview = if (exists) {
-            when (
-                val result = storage.createSignedDownloadUrlsByPath(
-                    bucket = bucket,
-                    paths = listOf(path),
-                    expiresIn = 3600,
-                )
-            ) {
+        val exists =
+            when (val result = storage.exists(bucket = bucket, path = path)) {
                 is SupabaseResult.Failure -> return result
-                is SupabaseResult.Success -> result.value[path]?.take(80)
+                is SupabaseResult.Success -> result.value
             }
-        } else {
-            "not uploaded yet"
-        }
+
+        val infoName =
+            if (exists) {
+                when (val result = storage.info(bucket = bucket, path = path)) {
+                    is SupabaseResult.Failure -> return result
+                    is SupabaseResult.Success -> result.value.name
+                }
+            } else {
+                "not uploaded yet"
+            }
+
+        val downloadPreview =
+            if (exists) {
+                when (val result = storage.download(bucket = bucket, path = path)) {
+                    is SupabaseResult.Failure -> return result
+                    is SupabaseResult.Success -> result.value.take(80)
+                }
+            } else {
+                "not uploaded yet"
+            }
+
+        val signedPreview =
+            if (exists) {
+                when (
+                    val result =
+                        storage.createSignedDownloadUrlsByPath(
+                            bucket = bucket,
+                            paths = listOf(path),
+                            expiresIn = 3600,
+                        )
+                ) {
+                    is SupabaseResult.Failure -> return result
+                    is SupabaseResult.Success -> result.value[path]?.take(80)
+                }
+            } else {
+                "not uploaded yet"
+            }
 
         val publicUrls = storage.getPublicUrlsByPath(bucket = bucket, paths = listOf(path))
         val authenticatedUrls = storage.getAuthenticatedUrlsByPath(bucket = bucket, paths = listOf(path))
@@ -286,10 +303,11 @@ class DemoRepository(
         functions.invoke(functionName = functionName, body = body)
 
     suspend fun invokeFunctionTyped(functionName: String, body: String): SupabaseResult<FunctionEchoResponse> {
-        val bodyValue = runCatching { defaultJson.decodeFromString<FunctionEchoRequest>(body) }
-            .getOrElse {
-                return SupabaseResult.Failure(SupabaseError(message = "Invalid JSON body: ${it.message}"))
-            }
+        val bodyValue =
+            runCatching { defaultJson.decodeFromString<FunctionEchoRequest>(body) }
+                .getOrElse {
+                    return SupabaseResult.Failure(SupabaseError(message = "Invalid JSON body: ${it.message}"))
+                }
         return functions.invokeTyped<FunctionEchoRequest, FunctionEchoResponse>(
             functionName = functionName,
             request = bodyValue,

--- a/samples/chat-compose/src/main/java/io/github/androidpoet/supabase/sample/chat/ui/DemoScreen.kt
+++ b/samples/chat-compose/src/main/java/io/github/androidpoet/supabase/sample/chat/ui/DemoScreen.kt
@@ -79,47 +79,51 @@ fun DemoScreen(
         }
 
         when (state.selectedTab) {
-            DemoTab.AUTH -> AuthTab(
-                state = state,
-                onAuthEmailChanged = onAuthEmailChanged,
-                onAuthPasswordChanged = onAuthPasswordChanged,
-                onSignUp = onSignUp,
-                onSignIn = onSignIn,
-                onSignInAnonymously = onSignInAnonymously,
-                onGetCurrentUser = onGetCurrentUser,
-                onRefreshSession = onRefreshSession,
-                onInspectJwt = onInspectJwt,
-                onSignOut = onSignOut,
-            )
-            DemoTab.CHAT -> ChatTab(
-                state = state,
-                onRoomNameChanged = onRoomNameChanged,
-                onSenderNameChanged = onSenderNameChanged,
-                onChatComposerChanged = onChatComposerChanged,
-                onSendMessage = onSendMessage,
-                onSendBroadcast = onSendBroadcast,
-                onUpdatePresence = onUpdatePresence,
-                onLoadRoomDiagnostics = onLoadRoomDiagnostics,
-                onLoadOlder = onLoadOlder,
-            )
-            DemoTab.STORAGE -> StorageTab(
-                state = state,
-                onBucketChanged = onBucketChanged,
-                onStoragePathChanged = onStoragePathChanged,
-                onStorageContentChanged = onStorageContentChanged,
-                onUploadTextFile = onUploadTextFile,
-                onInspectStorage = onInspectStorage,
-                onListFiles = onListFiles,
-                onBuildUrls = onBuildUrls,
-                onRemoveFile = onRemoveFile,
-            )
-            DemoTab.FUNCTIONS -> FunctionsTab(
-                state = state,
-                onFunctionNameChanged = onFunctionNameChanged,
-                onFunctionBodyChanged = onFunctionBodyChanged,
-                onInvokeFunction = onInvokeFunction,
-                onInvokeFunctionTyped = onInvokeFunctionTyped,
-            )
+            DemoTab.AUTH ->
+                AuthTab(
+                    state = state,
+                    onAuthEmailChanged = onAuthEmailChanged,
+                    onAuthPasswordChanged = onAuthPasswordChanged,
+                    onSignUp = onSignUp,
+                    onSignIn = onSignIn,
+                    onSignInAnonymously = onSignInAnonymously,
+                    onGetCurrentUser = onGetCurrentUser,
+                    onRefreshSession = onRefreshSession,
+                    onInspectJwt = onInspectJwt,
+                    onSignOut = onSignOut,
+                )
+            DemoTab.CHAT ->
+                ChatTab(
+                    state = state,
+                    onRoomNameChanged = onRoomNameChanged,
+                    onSenderNameChanged = onSenderNameChanged,
+                    onChatComposerChanged = onChatComposerChanged,
+                    onSendMessage = onSendMessage,
+                    onSendBroadcast = onSendBroadcast,
+                    onUpdatePresence = onUpdatePresence,
+                    onLoadRoomDiagnostics = onLoadRoomDiagnostics,
+                    onLoadOlder = onLoadOlder,
+                )
+            DemoTab.STORAGE ->
+                StorageTab(
+                    state = state,
+                    onBucketChanged = onBucketChanged,
+                    onStoragePathChanged = onStoragePathChanged,
+                    onStorageContentChanged = onStorageContentChanged,
+                    onUploadTextFile = onUploadTextFile,
+                    onInspectStorage = onInspectStorage,
+                    onListFiles = onListFiles,
+                    onBuildUrls = onBuildUrls,
+                    onRemoveFile = onRemoveFile,
+                )
+            DemoTab.FUNCTIONS ->
+                FunctionsTab(
+                    state = state,
+                    onFunctionNameChanged = onFunctionNameChanged,
+                    onFunctionBodyChanged = onFunctionBodyChanged,
+                    onInvokeFunction = onInvokeFunction,
+                    onInvokeFunctionTyped = onInvokeFunctionTyped,
+                )
         }
     }
 }
@@ -207,10 +211,12 @@ private fun ChatTab(
                             horizontalArrangement = if (mine) Arrangement.End else Arrangement.Start,
                         ) {
                             Column(
-                                modifier = Modifier.background(
-                                    color = if (mine) MaterialTheme.colorScheme.primary else Color(0xFFE9EDF2),
-                                    shape = RoundedCornerShape(14.dp),
-                                ).padding(horizontal = 10.dp, vertical = 8.dp),
+                                modifier =
+                                    Modifier
+                                        .background(
+                                            color = if (mine) MaterialTheme.colorScheme.primary else Color(0xFFE9EDF2),
+                                            shape = RoundedCornerShape(14.dp),
+                                        ).padding(horizontal = 10.dp, vertical = 8.dp),
                             ) {
                                 Text(
                                     text = message.senderName,

--- a/samples/desktop-demo/src/main/kotlin/io/github/androidpoet/supabase/sample/desktop/Main.kt
+++ b/samples/desktop-demo/src/main/kotlin/io/github/androidpoet/supabase/sample/desktop/Main.kt
@@ -2,9 +2,9 @@ package io.github.androidpoet.supabase.sample.desktop
 
 import io.github.androidpoet.supabase.auth.createAuthClient
 import io.github.androidpoet.supabase.auth.getUserForCurrentSession
+import io.github.androidpoet.supabase.auth.session.createSessionManager
 import io.github.androidpoet.supabase.auth.signOutCurrentSession
 import io.github.androidpoet.supabase.auth.signUpWithEmailAndSaveSession
-import io.github.androidpoet.supabase.auth.session.createSessionManager
 import io.github.androidpoet.supabase.client.Supabase
 import io.github.androidpoet.supabase.core.result.SupabaseResult
 import io.github.androidpoet.supabase.database.createDatabaseClient
@@ -13,239 +13,252 @@ import io.github.androidpoet.supabase.realtime.createRealtimeClient
 import io.github.androidpoet.supabase.storage.createStorageClient
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.runBlocking
-import kotlinx.serialization.json.*
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import kotlinx.serialization.json.put
 
 private fun env(name: String): String = System.getenv(name)?.trim().orEmpty()
 
-fun main(): Unit = runBlocking {
-    val url = env("SUPABASE_URL")
-    val anonKey = env("SUPABASE_ANON_KEY")
-    val bucket = env("SUPABASE_STORAGE_BUCKET").ifBlank { "public" }
-    val functionName = env("SUPABASE_FUNCTION_NAME").ifBlank { "hello-world" }
+fun main(): Unit =
+    runBlocking {
+        val url = env("SUPABASE_URL")
+        val anonKey = env("SUPABASE_ANON_KEY")
+        val bucket = env("SUPABASE_STORAGE_BUCKET").ifBlank { "public" }
+        val functionName = env("SUPABASE_FUNCTION_NAME").ifBlank { "hello-world" }
 
-    if (url.isBlank() || anonKey.isBlank()) {
-        println("Missing config. Set env vars:")
-        println("  SUPABASE_URL=https://your-project.supabase.co")
-        println("  SUPABASE_ANON_KEY=your-anon-key")
-        println("Optional:")
-        println("  SUPABASE_STORAGE_BUCKET=public")
-        println("  SUPABASE_FUNCTION_NAME=hello-world")
-        return@runBlocking
-    }
-
-    val client = Supabase.create(projectUrl = url, apiKey = anonKey)
-    val auth = createAuthClient(client)
-    val sessionManager = createSessionManager(auth, client)
-    val database = createDatabaseClient(client)
-    val storage = createStorageClient(client)
-    val realtime = createRealtimeClient(client)
-    val functions = createFunctionsClient(client)
-
-    println("╔══════════════════════════════════════════════════════════╗")
-    println("║     SUPABASE KMP — FULL FEATURE TEST (JVM)              ║")
-    println("║     Project: $url")
-    println("╚══════════════════════════════════════════════════════════╝")
-    println()
-
-    // ════════════════════════════════════════════════════════════════
-    //  1. AUTH  — Sign up, sign in, get user, sign out
-    // ════════════════════════════════════════════════════════════════
-    println("┌─ 1. AUTH ──────────────────────────────────────────────┐")
-    val testEmail = "test-${System.currentTimeMillis()}@example.com"
-    val testPassword = "password123!"
-
-    println("│ 🔸 Signing up: $testEmail")
-    val signUpResult = auth.signUpWithEmailAndSaveSession(sessionManager, testEmail, testPassword)
-    when (signUpResult) {
-        is SupabaseResult.Success -> println("│    ✅ signUp: user=${signUpResult.value.user.id}")
-        is SupabaseResult.Failure -> println("│    ⚠️  signUp: ${signUpResult.error.message}")
-    }
-
-    println("│ 🔸 Signing out...")
-    auth.signOutCurrentSession(sessionManager)
-    println("│    ✅ signOut")
-
-    println("│ 🔸 Signing in: $testEmail")
-    // Use extension that saves session
-    val signInResult = auth.signInWithEmail(email = testEmail, password = testPassword)
-    when (signInResult) {
-        is SupabaseResult.Success -> {
-            sessionManager.saveSession(signInResult.value)
-            println("│    ✅ signIn: session token=${signInResult.value.accessToken.take(20)}...")
+        if (url.isBlank() || anonKey.isBlank()) {
+            println("Missing config. Set env vars:")
+            println("  SUPABASE_URL=https://your-project.supabase.co")
+            println("  SUPABASE_ANON_KEY=your-anon-key")
+            println("Optional:")
+            println("  SUPABASE_STORAGE_BUCKET=public")
+            println("  SUPABASE_FUNCTION_NAME=hello-world")
+            return@runBlocking
         }
-        is SupabaseResult.Failure -> println("│    ❌ signIn: ${signInResult.error.message}")
-    }
 
-    println("│ 🔸 Getting current user...")
-    val currentUser = auth.getUserForCurrentSession(sessionManager)
-    when (currentUser) {
-        is SupabaseResult.Success -> println("│    ✅ getUser: id=${currentUser.value.id}, email=${currentUser.value.email}")
-        is SupabaseResult.Failure -> println("│    ❌ getUser: ${currentUser.error.message}")
-    }
+        val client = Supabase.create(projectUrl = url, apiKey = anonKey)
+        val auth = createAuthClient(client)
+        val sessionManager = createSessionManager(auth, client)
+        val database = createDatabaseClient(client)
+        val storage = createStorageClient(client)
+        val realtime = createRealtimeClient(client)
+        val functions = createFunctionsClient(client)
 
-    println("└────────────────────────────────────────────────────────┘")
-    println()
+        println("╔══════════════════════════════════════════════════════════╗")
+        println("║     SUPABASE KMP — FULL FEATURE TEST (JVM)              ║")
+        println("║     Project: $url")
+        println("╚══════════════════════════════════════════════════════════╝")
+        println()
 
-    // ════════════════════════════════════════════════════════════════
-    //  2. DATABASE  — Read rooms, Insert/Select messages
-    // ════════════════════════════════════════════════════════════════
-    println("┌─ 2. DATABASE ─────────────────────────────────────────┐")
-    println("│ 🔸 Listing chat rooms...")
-    val roomsResult = database.select(table = "chat_rooms", columns = "id,name") { limit(10) }
-    when (roomsResult) {
-        is SupabaseResult.Success -> println("│    ✅ rooms: ${roomsResult.value.take(200)}")
-        is SupabaseResult.Failure -> println("│    ❌ rooms: ${roomsResult.error.message}")
-    }
-    // Extract first room id for insert
-    var roomId = ""
-    if (roomsResult is SupabaseResult.Success) {
-        try {
-            val roomsArr = Json.parseToJsonElement(roomsResult.value).jsonArray
-            if (roomsArr.isNotEmpty()) {
-                roomId = roomsArr[0].jsonObject["id"]?.jsonPrimitive?.content ?: ""
+        // ════════════════════════════════════════════════════════════════
+        //  1. AUTH  — Sign up, sign in, get user, sign out
+        // ════════════════════════════════════════════════════════════════
+        println("┌─ 1. AUTH ──────────────────────────────────────────────┐")
+        val testEmail = "test-${System.currentTimeMillis()}@example.com"
+        val testPassword = "password123!"
+
+        println("│ 🔸 Signing up: $testEmail")
+        val signUpResult = auth.signUpWithEmailAndSaveSession(sessionManager, testEmail, testPassword)
+        when (signUpResult) {
+            is SupabaseResult.Success -> println("│    ✅ signUp: user=${signUpResult.value.user.id}")
+            is SupabaseResult.Failure -> println("│    ⚠️  signUp: ${signUpResult.error.message}")
+        }
+
+        println("│ 🔸 Signing out...")
+        auth.signOutCurrentSession(sessionManager)
+        println("│    ✅ signOut")
+
+        println("│ 🔸 Signing in: $testEmail")
+        // Use extension that saves session
+        val signInResult = auth.signInWithEmail(email = testEmail, password = testPassword)
+        when (signInResult) {
+            is SupabaseResult.Success -> {
+                sessionManager.saveSession(signInResult.value)
+                println("│    ✅ signIn: session token=${signInResult.value.accessToken.take(20)}...")
             }
-        } catch (_: Exception) {}
-    }
-    println("│    Using roomId=$roomId")
-
-    println("│ 🔸 Inserting a message...")
-    val messageBody = "Hello from KMP test at ${System.currentTimeMillis()}"
-    val insertPayload = buildJsonObject {
-        put("room_id", JsonPrimitive(roomId))
-        put("sender_name", JsonPrimitive("test-bot"))
-        put("body", JsonPrimitive(messageBody))
-    }.toString()
-    val insertResult = database.insert(table = "chat_messages", body = insertPayload)
-    when (insertResult) {
-        is SupabaseResult.Success -> println("│    ✅ insert: ${insertResult.value.take(150)}")
-        is SupabaseResult.Failure -> println("│    ❌ insert: ${insertResult.error.message}")
-    }
-
-    println("│ 🔸 Selecting messages...")
-    val selectResult = database.select(table = "chat_messages", columns = "id,room_id,sender_name,body,created_at") {
-        limit(5)
-        order("created_at", ascending = false)
-    }
-    when (selectResult) {
-        is SupabaseResult.Success -> println("│    ✅ select: ${selectResult.value.take(300)}")
-        is SupabaseResult.Failure -> println("│    ❌ select: ${selectResult.error.message}")
-    }
-
-    println("└────────────────────────────────────────────────────────┘")
-    println()
-
-    // ════════════════════════════════════════════════════════════════
-    //  3. STORAGE  — List buckets, Upload, List files
-    // ════════════════════════════════════════════════════════════════
-    println("┌─ 3. STORAGE ──────────────────────────────────────────┐")
-    println("│ 🔸 Listing buckets...")
-    val bucketsResult = storage.listBuckets(limit = 5)
-    when (bucketsResult) {
-        is SupabaseResult.Success -> println("│    ✅ buckets: ${bucketsResult.value.map { it.name }}")
-        is SupabaseResult.Failure -> println("│    ❌ buckets: ${bucketsResult.error.message}")
-    }
-
-    println("│ 🔸 Uploading test file...")
-    val fileContent = "Hello from Supabase KMP! Timestamp: ${System.currentTimeMillis()}"
-    val uploadBytes = fileContent.encodeToByteArray()
-    val uploadResult = storage.upload(
-        bucket = bucket,
-        path = "test/hello-${System.currentTimeMillis()}.txt",
-        data = uploadBytes,
-        contentType = "text/plain"
-    )
-    when (uploadResult) {
-        is SupabaseResult.Success -> println("│    ✅ upload: path=${uploadResult.value}")
-        is SupabaseResult.Failure -> println("│    ❌ upload: ${uploadResult.error.message}")
-    }
-
-    println("│ 🔸 Listing files in bucket '$bucket'...")
-    val listResult = storage.list(bucket = bucket, limit = 10)
-    when (listResult) {
-        is SupabaseResult.Success -> println("│    ✅ list: ${listResult.value.map { "${it.name} (${it.metadata?.get("size") ?: "?"} bytes)" }}")
-        is SupabaseResult.Failure -> println("│    ❌ list: ${listResult.error.message}")
-    }
-
-    println("└────────────────────────────────────────────────────────┘")
-    println()
-
-    // ════════════════════════════════════════════════════════════════
-    //  4. EDGE FUNCTIONS  — Invoke hello-world
-    // ════════════════════════════════════════════════════════════════
-    println("┌─ 4. EDGE FUNCTIONS ───────────────────────────────────┐")
-    println("│ 🔸 Invoking '$functionName'...")
-    val invokeResult = functions.invoke(
-        functionName = functionName,
-        body = """{"ping":"pong","time":${System.currentTimeMillis()}}"""
-    )
-    when (invokeResult) {
-        is SupabaseResult.Success -> println("│    ✅ invoke: ${invokeResult.value.take(200)}")
-        is SupabaseResult.Failure -> println("│    ❌ invoke: ${invokeResult.error.message}")
-    }
-    println("└────────────────────────────────────────────────────────┘")
-    println()
-
-    // ════════════════════════════════════════════════════════════════
-    //  5. REALTIME  — Connect, Broadcast, Receive
-    // ════════════════════════════════════════════════════════════════
-    println("┌─ 5. REALTIME ─────────────────────────────────────────┐")
-    println("│ 🔸 Connecting to realtime...")
-
-    // Set up channel BEFORE connecting
-    val channelBuilder = realtime.channel("test-channel")
-    val receivedMessages = mutableListOf<String>()
-
-    // Listen for broadcasts
-    channelBuilder.onBroadcast("chat") { payload ->
-        val text = payload["text"]?.jsonPrimitive?.content ?: "?"
-        println("│    ⚡ RECEIVED broadcast: $text")
-        receivedMessages.add(text)
-    }
-
-    // Connect to realtime server
-    realtime.connect()
-    delay(500)
-
-    println("│    ✅ realtime connected: ${realtime.isConnected}")
-
-    // Subscribe to channel
-    println("│ 🔸 Subscribing to channel...")
-    val subscription = channelBuilder.subscribe()
-    delay(2000)
-
-    println("│ 🔸 Sending broadcast...")
-    subscription.broadcast(
-        event = "chat",
-        payload = buildJsonObject {
-            put("text", JsonPrimitive("Hello from KMP!"))
-            put("timestamp", JsonPrimitive(System.currentTimeMillis()))
+            is SupabaseResult.Failure -> println("│    ❌ signIn: ${signInResult.error.message}")
         }
-    )
-    delay(2000)
-    println("│    Broadcasts received: ${receivedMessages.size}")
-    if (receivedMessages.isNotEmpty()) {
-        println("│    ✅ realtime: Messages received OK")
-    } else {
-        println("│    ⚠️  realtime: No messages (broadcast may not self-reflect)")
+
+        println("│ 🔸 Getting current user...")
+        val currentUser = auth.getUserForCurrentSession(sessionManager)
+        when (currentUser) {
+            is SupabaseResult.Success -> println("│    ✅ getUser: id=${currentUser.value.id}, email=${currentUser.value.email}")
+            is SupabaseResult.Failure -> println("│    ❌ getUser: ${currentUser.error.message}")
+        }
+
+        println("└────────────────────────────────────────────────────────┘")
+        println()
+
+        // ════════════════════════════════════════════════════════════════
+        //  2. DATABASE  — Read rooms, Insert/Select messages
+        // ════════════════════════════════════════════════════════════════
+        println("┌─ 2. DATABASE ─────────────────────────────────────────┐")
+        println("│ 🔸 Listing chat rooms...")
+        val roomsResult = database.select(table = "chat_rooms", columns = "id,name") { limit(10) }
+        when (roomsResult) {
+            is SupabaseResult.Success -> println("│    ✅ rooms: ${roomsResult.value.take(200)}")
+            is SupabaseResult.Failure -> println("│    ❌ rooms: ${roomsResult.error.message}")
+        }
+        // Extract first room id for insert
+        var roomId = ""
+        if (roomsResult is SupabaseResult.Success) {
+            try {
+                val roomsArr = Json.parseToJsonElement(roomsResult.value).jsonArray
+                if (roomsArr.isNotEmpty()) {
+                    roomId = roomsArr[0].jsonObject["id"]?.jsonPrimitive?.content ?: ""
+                }
+            } catch (_: Exception) {
+            }
+        }
+        println("│    Using roomId=$roomId")
+
+        println("│ 🔸 Inserting a message...")
+        val messageBody = "Hello from KMP test at ${System.currentTimeMillis()}"
+        val insertPayload =
+            buildJsonObject {
+                put("room_id", JsonPrimitive(roomId))
+                put("sender_name", JsonPrimitive("test-bot"))
+                put("body", JsonPrimitive(messageBody))
+            }.toString()
+        val insertResult = database.insert(table = "chat_messages", body = insertPayload)
+        when (insertResult) {
+            is SupabaseResult.Success -> println("│    ✅ insert: ${insertResult.value.take(150)}")
+            is SupabaseResult.Failure -> println("│    ❌ insert: ${insertResult.error.message}")
+        }
+
+        println("│ 🔸 Selecting messages...")
+        val selectResult =
+            database.select(table = "chat_messages", columns = "id,room_id,sender_name,body,created_at") {
+                limit(5)
+                order("created_at", ascending = false)
+            }
+        when (selectResult) {
+            is SupabaseResult.Success -> println("│    ✅ select: ${selectResult.value.take(300)}")
+            is SupabaseResult.Failure -> println("│    ❌ select: ${selectResult.error.message}")
+        }
+
+        println("└────────────────────────────────────────────────────────┘")
+        println()
+
+        // ════════════════════════════════════════════════════════════════
+        //  3. STORAGE  — List buckets, Upload, List files
+        // ════════════════════════════════════════════════════════════════
+        println("┌─ 3. STORAGE ──────────────────────────────────────────┐")
+        println("│ 🔸 Listing buckets...")
+        val bucketsResult = storage.listBuckets(limit = 5)
+        when (bucketsResult) {
+            is SupabaseResult.Success -> println("│    ✅ buckets: ${bucketsResult.value.map { it.name }}")
+            is SupabaseResult.Failure -> println("│    ❌ buckets: ${bucketsResult.error.message}")
+        }
+
+        println("│ 🔸 Uploading test file...")
+        val fileContent = "Hello from Supabase KMP! Timestamp: ${System.currentTimeMillis()}"
+        val uploadBytes = fileContent.encodeToByteArray()
+        val uploadResult =
+            storage.upload(
+                bucket = bucket,
+                path = "test/hello-${System.currentTimeMillis()}.txt",
+                data = uploadBytes,
+                contentType = "text/plain",
+            )
+        when (uploadResult) {
+            is SupabaseResult.Success -> println("│    ✅ upload: path=${uploadResult.value}")
+            is SupabaseResult.Failure -> println("│    ❌ upload: ${uploadResult.error.message}")
+        }
+
+        println("│ 🔸 Listing files in bucket '$bucket'...")
+        val listResult = storage.list(bucket = bucket, limit = 10)
+        when (listResult) {
+            is SupabaseResult.Success -> println("│    ✅ list: ${listResult.value.map { "${it.name} (${it.metadata?.get("size") ?: "?"} bytes)" }}")
+            is SupabaseResult.Failure -> println("│    ❌ list: ${listResult.error.message}")
+        }
+
+        println("└────────────────────────────────────────────────────────┘")
+        println()
+
+        // ════════════════════════════════════════════════════════════════
+        //  4. EDGE FUNCTIONS  — Invoke hello-world
+        // ════════════════════════════════════════════════════════════════
+        println("┌─ 4. EDGE FUNCTIONS ───────────────────────────────────┐")
+        println("│ 🔸 Invoking '$functionName'...")
+        val invokeResult =
+            functions.invoke(
+                functionName = functionName,
+                body = """{"ping":"pong","time":${System.currentTimeMillis()}}""",
+            )
+        when (invokeResult) {
+            is SupabaseResult.Success -> println("│    ✅ invoke: ${invokeResult.value.take(200)}")
+            is SupabaseResult.Failure -> println("│    ❌ invoke: ${invokeResult.error.message}")
+        }
+        println("└────────────────────────────────────────────────────────┘")
+        println()
+
+        // ════════════════════════════════════════════════════════════════
+        //  5. REALTIME  — Connect, Broadcast, Receive
+        // ════════════════════════════════════════════════════════════════
+        println("┌─ 5. REALTIME ─────────────────────────────────────────┐")
+        println("│ 🔸 Connecting to realtime...")
+
+        // Set up channel BEFORE connecting
+        val channelBuilder = realtime.channel("test-channel")
+        val receivedMessages = mutableListOf<String>()
+
+        // Listen for broadcasts
+        channelBuilder.onBroadcast("chat") { payload ->
+            val text = payload["text"]?.jsonPrimitive?.content ?: "?"
+            println("│    ⚡ RECEIVED broadcast: $text")
+            receivedMessages.add(text)
+        }
+
+        // Connect to realtime server
+        realtime.connect()
+        delay(500)
+
+        println("│    ✅ realtime connected: ${realtime.isConnected}")
+
+        // Subscribe to channel
+        println("│ 🔸 Subscribing to channel...")
+        val subscription = channelBuilder.subscribe()
+        delay(2000)
+
+        println("│ 🔸 Sending broadcast...")
+        subscription.broadcast(
+            event = "chat",
+            payload =
+                buildJsonObject {
+                    put("text", JsonPrimitive("Hello from KMP!"))
+                    put("timestamp", JsonPrimitive(System.currentTimeMillis()))
+                },
+        )
+        delay(2000)
+        println("│    Broadcasts received: ${receivedMessages.size}")
+        if (receivedMessages.isNotEmpty()) {
+            println("│    ✅ realtime: Messages received OK")
+        } else {
+            println("│    ⚠️  realtime: No messages (broadcast may not self-reflect)")
+        }
+
+        subscription.unsubscribe()
+        println("│    ✅ channel unsubscribed")
+        println("└────────────────────────────────────────────────────────┘")
+        println()
+
+        // ════════════════════════════════════════════════════════════════
+        //  6. CLEANUP
+        // ════════════════════════════════════════════════════════════════
+        println("┌─ 6. CLEANUP ──────────────────────────────────────────┐")
+        auth.signOutCurrentSession(sessionManager)
+        println("│    ✅ signed out")
+        realtime.disconnect()
+        println("│    ✅ realtime disconnected")
+        println("└────────────────────────────────────────────────────────┘")
+        println()
+
+        println("╔══════════════════════════════════════════════════════════╗")
+        println("║     ✅ ALL TESTS COMPLETED                              ║")
+        println("╚══════════════════════════════════════════════════════════╝")
     }
-
-    subscription.unsubscribe()
-    println("│    ✅ channel unsubscribed")
-    println("└────────────────────────────────────────────────────────┘")
-    println()
-
-    // ════════════════════════════════════════════════════════════════
-    //  6. CLEANUP
-    // ════════════════════════════════════════════════════════════════
-    println("┌─ 6. CLEANUP ──────────────────────────────────────────┐")
-    auth.signOutCurrentSession(sessionManager)
-    println("│    ✅ signed out")
-    realtime.disconnect()
-    println("│    ✅ realtime disconnected")
-    println("└────────────────────────────────────────────────────────┘")
-    println()
-
-    println("╔══════════════════════════════════════════════════════════╗")
-    println("║     ✅ ALL TESTS COMPLETED                              ║")
-    println("╚══════════════════════════════════════════════════════════╝")
-}

--- a/supabase-auth-admin/src/commonMain/kotlin/io/github/androidpoet/supabase/auth/admin/AuthAdminClient.kt
+++ b/supabase-auth-admin/src/commonMain/kotlin/io/github/androidpoet/supabase/auth/admin/AuthAdminClient.kt
@@ -1,23 +1,23 @@
 package io.github.androidpoet.supabase.auth.admin
 
-import io.github.androidpoet.supabase.auth.models.SignOutScope
-import io.github.androidpoet.supabase.auth.models.User
 import io.github.androidpoet.supabase.auth.admin.models.AdminUserAttributes
 import io.github.androidpoet.supabase.auth.admin.models.CustomProvider
+import io.github.androidpoet.supabase.auth.admin.models.CustomProviderCreateRequest
 import io.github.androidpoet.supabase.auth.admin.models.CustomProviderListResponse
 import io.github.androidpoet.supabase.auth.admin.models.CustomProviderType
-import io.github.androidpoet.supabase.auth.admin.models.OAuthClient
-import io.github.androidpoet.supabase.auth.admin.models.OAuthClientCreateRequest
-import io.github.androidpoet.supabase.auth.admin.models.OAuthClientListResponse
-import io.github.androidpoet.supabase.auth.admin.models.OAuthClientUpdateRequest
-import io.github.androidpoet.supabase.auth.admin.models.Passkey
-import io.github.androidpoet.supabase.auth.admin.models.CustomProviderCreateRequest
 import io.github.androidpoet.supabase.auth.admin.models.CustomProviderUpdateRequest
 import io.github.androidpoet.supabase.auth.admin.models.GenerateLinkRequest
 import io.github.androidpoet.supabase.auth.admin.models.GenerateLinkResponse
 import io.github.androidpoet.supabase.auth.admin.models.ListUsersResponse
 import io.github.androidpoet.supabase.auth.admin.models.MfaAdminDeleteFactorResponse
 import io.github.androidpoet.supabase.auth.admin.models.MfaAdminListFactorsResponse
+import io.github.androidpoet.supabase.auth.admin.models.OAuthClient
+import io.github.androidpoet.supabase.auth.admin.models.OAuthClientCreateRequest
+import io.github.androidpoet.supabase.auth.admin.models.OAuthClientListResponse
+import io.github.androidpoet.supabase.auth.admin.models.OAuthClientUpdateRequest
+import io.github.androidpoet.supabase.auth.admin.models.Passkey
+import io.github.androidpoet.supabase.auth.models.SignOutScope
+import io.github.androidpoet.supabase.auth.models.User
 import io.github.androidpoet.supabase.core.result.SupabaseResult
 import kotlinx.serialization.json.JsonObject
 

--- a/supabase-auth-admin/src/commonMain/kotlin/io/github/androidpoet/supabase/auth/admin/AuthAdminClientImpl.kt
+++ b/supabase-auth-admin/src/commonMain/kotlin/io/github/androidpoet/supabase/auth/admin/AuthAdminClientImpl.kt
@@ -41,10 +41,11 @@ internal class AuthAdminClientImpl(
         jwt: String,
         scope: SignOutScope,
     ): SupabaseResult<Unit> =
-        client.post(
-            endpoint = "/auth/v1/logout?scope=${scope.name.lowercase()}",
-            headers = mapOf("Authorization" to "Bearer $jwt"),
-        ).map { }
+        client
+            .post(
+                endpoint = "/auth/v1/logout?scope=${scope.name.lowercase()}",
+                headers = mapOf("Authorization" to "Bearer $jwt"),
+            ).map { }
 
     override suspend fun inviteUserByEmail(
         email: String,
@@ -52,62 +53,69 @@ internal class AuthAdminClientImpl(
         redirectTo: String?,
     ): SupabaseResult<User> {
         val body = defaultJson.encodeToString(InviteUserRequest(email = email, data = data))
-        return client.post(
-            endpoint = withRedirectTo("/auth/v1/invite", redirectTo),
-            body = body,
-            headers = adminHeaders,
-        ).deserializeUserResponse()
+        return client
+            .post(
+                endpoint = withRedirectTo("/auth/v1/invite", redirectTo),
+                body = body,
+                headers = adminHeaders,
+            ).deserializeUserResponse()
     }
 
     override suspend fun generateLink(request: GenerateLinkRequest): SupabaseResult<GenerateLinkResponse> {
         val body = defaultJson.encodeToString(request)
-        return client.post(
-            endpoint = withRedirectTo("/auth/v1/admin/generate_link", request.redirectTo),
-            body = body,
-            headers = adminHeaders,
-        ).deserialize()
+        return client
+            .post(
+                endpoint = withRedirectTo("/auth/v1/admin/generate_link", request.redirectTo),
+                body = body,
+                headers = adminHeaders,
+            ).deserialize()
     }
 
     override suspend fun createUser(attributes: AdminUserAttributes): SupabaseResult<User> {
         val body = defaultJson.encodeToString(attributes)
-        return client.post(
-            endpoint = "/auth/v1/admin/users",
-            body = body,
-            headers = adminHeaders,
-        ).deserializeUserResponse()
+        return client
+            .post(
+                endpoint = "/auth/v1/admin/users",
+                body = body,
+                headers = adminHeaders,
+            ).deserializeUserResponse()
     }
 
     override suspend fun listUsers(
         page: Int?,
         perPage: Int?,
     ): SupabaseResult<ListUsersResponse> {
-        val queryParams = buildList {
-            if (page != null) add("page" to page.toString())
-            if (perPage != null) add("per_page" to perPage.toString())
-        }
-        return client.get(
-            endpoint = "/auth/v1/admin/users",
-            queryParams = queryParams,
-            headers = adminHeaders,
-        ).deserialize()
+        val queryParams =
+            buildList {
+                if (page != null) add("page" to page.toString())
+                if (perPage != null) add("per_page" to perPage.toString())
+            }
+        return client
+            .get(
+                endpoint = "/auth/v1/admin/users",
+                queryParams = queryParams,
+                headers = adminHeaders,
+            ).deserialize()
     }
 
     override suspend fun getUserById(userId: String): SupabaseResult<User> =
-        client.get(
-            endpoint = "/auth/v1/admin/users/$userId",
-            headers = adminHeaders,
-        ).deserializeUserResponse()
+        client
+            .get(
+                endpoint = "/auth/v1/admin/users/$userId",
+                headers = adminHeaders,
+            ).deserializeUserResponse()
 
     override suspend fun updateUserById(
         userId: String,
         attributes: AdminUserAttributes,
     ): SupabaseResult<User> {
         val body = defaultJson.encodeToString(attributes)
-        return client.put(
-            endpoint = "/auth/v1/admin/users/$userId",
-            body = body,
-            headers = adminHeaders,
-        ).deserializeUserResponse()
+        return client
+            .put(
+                endpoint = "/auth/v1/admin/users/$userId",
+                body = body,
+                headers = adminHeaders,
+            ).deserializeUserResponse()
     }
 
     override suspend fun deleteUser(
@@ -115,140 +123,158 @@ internal class AuthAdminClientImpl(
         shouldSoftDelete: Boolean,
     ): SupabaseResult<Unit> {
         val body = defaultJson.encodeToString(UserDeleteRequest(shouldSoftDelete = shouldSoftDelete))
-        return client.delete(
-            endpoint = "/auth/v1/admin/users/$userId",
-            body = body,
-            headers = adminHeaders,
-        ).map { }
+        return client
+            .delete(
+                endpoint = "/auth/v1/admin/users/$userId",
+                body = body,
+                headers = adminHeaders,
+            ).map { }
     }
 
     override suspend fun listFactors(userId: String): SupabaseResult<MfaAdminListFactorsResponse> =
-        client.get(
-            endpoint = "/auth/v1/admin/users/$userId/factors",
-            headers = adminHeaders,
-        ).deserialize()
+        client
+            .get(
+                endpoint = "/auth/v1/admin/users/$userId/factors",
+                headers = adminHeaders,
+            ).deserialize()
 
     override suspend fun deleteFactor(
         userId: String,
         factorId: String,
     ): SupabaseResult<MfaAdminDeleteFactorResponse> =
-        client.delete(
-            endpoint = "/auth/v1/admin/users/$userId/factors/$factorId",
-            headers = adminHeaders,
-        ).deserialize()
+        client
+            .delete(
+                endpoint = "/auth/v1/admin/users/$userId/factors/$factorId",
+                headers = adminHeaders,
+            ).deserialize()
 
     override suspend fun listOAuthClients(
         page: Int?,
         perPage: Int?,
     ): SupabaseResult<OAuthClientListResponse> {
-        val queryParams = buildList {
-            if (page != null) add("page" to page.toString())
-            if (perPage != null) add("per_page" to perPage.toString())
-        }
-        return client.get(
-            endpoint = "/auth/v1/admin/oauth/clients",
-            queryParams = queryParams,
-            headers = adminHeaders,
-        ).deserialize()
+        val queryParams =
+            buildList {
+                if (page != null) add("page" to page.toString())
+                if (perPage != null) add("per_page" to perPage.toString())
+            }
+        return client
+            .get(
+                endpoint = "/auth/v1/admin/oauth/clients",
+                queryParams = queryParams,
+                headers = adminHeaders,
+            ).deserialize()
     }
 
     override suspend fun createOAuthClient(request: OAuthClientCreateRequest): SupabaseResult<OAuthClient> {
         val body = defaultJson.encodeToString(request)
-        return client.post(
-            endpoint = "/auth/v1/admin/oauth/clients",
-            body = body,
-            headers = adminHeaders,
-        ).deserialize()
+        return client
+            .post(
+                endpoint = "/auth/v1/admin/oauth/clients",
+                body = body,
+                headers = adminHeaders,
+            ).deserialize()
     }
 
     override suspend fun getOAuthClient(clientId: String): SupabaseResult<OAuthClient> =
-        client.get(
-            endpoint = "/auth/v1/admin/oauth/clients/$clientId",
-            headers = adminHeaders,
-        ).deserialize()
+        client
+            .get(
+                endpoint = "/auth/v1/admin/oauth/clients/$clientId",
+                headers = adminHeaders,
+            ).deserialize()
 
     override suspend fun updateOAuthClient(
         clientId: String,
         request: OAuthClientUpdateRequest,
     ): SupabaseResult<OAuthClient> {
         val body = defaultJson.encodeToString(request)
-        return client.put(
-            endpoint = "/auth/v1/admin/oauth/clients/$clientId",
-            body = body,
-            headers = adminHeaders,
-        ).deserialize()
+        return client
+            .put(
+                endpoint = "/auth/v1/admin/oauth/clients/$clientId",
+                body = body,
+                headers = adminHeaders,
+            ).deserialize()
     }
 
     override suspend fun deleteOAuthClient(clientId: String): SupabaseResult<Unit> =
-        client.delete(
-            endpoint = "/auth/v1/admin/oauth/clients/$clientId",
-            headers = adminHeaders,
-        ).map { }
+        client
+            .delete(
+                endpoint = "/auth/v1/admin/oauth/clients/$clientId",
+                headers = adminHeaders,
+            ).map { }
 
     override suspend fun regenerateOAuthClientSecret(clientId: String): SupabaseResult<OAuthClient> =
-        client.post(
-            endpoint = "/auth/v1/admin/oauth/clients/$clientId/regenerate_secret",
-            headers = adminHeaders,
-        ).deserialize()
+        client
+            .post(
+                endpoint = "/auth/v1/admin/oauth/clients/$clientId/regenerate_secret",
+                headers = adminHeaders,
+            ).deserialize()
 
     override suspend fun listCustomProviders(type: CustomProviderType?): SupabaseResult<CustomProviderListResponse> {
-        val queryParams = buildList {
-            if (type != null) add("type" to type.value)
-        }
-        return client.get(
-            endpoint = "/auth/v1/admin/custom-providers",
-            queryParams = queryParams,
-            headers = adminHeaders,
-        ).deserialize()
+        val queryParams =
+            buildList {
+                if (type != null) add("type" to type.value)
+            }
+        return client
+            .get(
+                endpoint = "/auth/v1/admin/custom-providers",
+                queryParams = queryParams,
+                headers = adminHeaders,
+            ).deserialize()
     }
 
     override suspend fun createCustomProvider(request: CustomProviderCreateRequest): SupabaseResult<CustomProvider> {
         val body = defaultJson.encodeToString(request)
-        return client.post(
-            endpoint = "/auth/v1/admin/custom-providers",
-            body = body,
-            headers = adminHeaders,
-        ).deserialize()
+        return client
+            .post(
+                endpoint = "/auth/v1/admin/custom-providers",
+                body = body,
+                headers = adminHeaders,
+            ).deserialize()
     }
 
     override suspend fun getCustomProvider(identifier: String): SupabaseResult<CustomProvider> =
-        client.get(
-            endpoint = "/auth/v1/admin/custom-providers/$identifier",
-            headers = adminHeaders,
-        ).deserialize()
+        client
+            .get(
+                endpoint = "/auth/v1/admin/custom-providers/$identifier",
+                headers = adminHeaders,
+            ).deserialize()
 
     override suspend fun updateCustomProvider(
         identifier: String,
         request: CustomProviderUpdateRequest,
     ): SupabaseResult<CustomProvider> {
         val body = defaultJson.encodeToString(request)
-        return client.put(
-            endpoint = "/auth/v1/admin/custom-providers/$identifier",
-            body = body,
-            headers = adminHeaders,
-        ).deserialize()
+        return client
+            .put(
+                endpoint = "/auth/v1/admin/custom-providers/$identifier",
+                body = body,
+                headers = adminHeaders,
+            ).deserialize()
     }
 
     override suspend fun deleteCustomProvider(identifier: String): SupabaseResult<Unit> =
-        client.delete(
-            endpoint = "/auth/v1/admin/custom-providers/$identifier",
-            headers = adminHeaders,
-        ).map { }
+        client
+            .delete(
+                endpoint = "/auth/v1/admin/custom-providers/$identifier",
+                headers = adminHeaders,
+            ).map { }
 
     override suspend fun listPasskeys(userId: String): SupabaseResult<List<Passkey>> =
-        client.get(
-            endpoint = "/auth/v1/admin/users/$userId/passkeys",
-            headers = adminHeaders,
-        ).deserialize()
+        client
+            .get(
+                endpoint = "/auth/v1/admin/users/$userId/passkeys",
+                headers = adminHeaders,
+            ).deserialize()
 
     override suspend fun deletePasskey(
         userId: String,
         passkeyId: String,
     ): SupabaseResult<Unit> =
-        client.delete(
-            endpoint = "/auth/v1/admin/users/$userId/passkeys/$passkeyId",
-            headers = adminHeaders,
-        ).map { }
+        client
+            .delete(
+                endpoint = "/auth/v1/admin/users/$userId/passkeys/$passkeyId",
+                headers = adminHeaders,
+            ).map { }
 
     private fun SupabaseResult<String>.deserializeUserResponse(): SupabaseResult<User> =
         when (val result = deserialize<UserResponse>()) {
@@ -269,5 +295,4 @@ internal class AuthAdminClientImpl(
         } else {
             "$endpoint?redirect_to=${urlEncode(redirectTo)}"
         }
-
 }

--- a/supabase-auth-admin/src/commonMain/kotlin/io/github/androidpoet/supabase/auth/admin/models/AuthAdminModels.kt
+++ b/supabase-auth-admin/src/commonMain/kotlin/io/github/androidpoet/supabase/auth/admin/models/AuthAdminModels.kt
@@ -83,7 +83,9 @@ public data class MfaAdminDeleteFactorResponse(
 )
 
 @Serializable
-public enum class OAuthClientType(public val value: String) {
+public enum class OAuthClientType(
+    public val value: String,
+) {
     @SerialName("public")
     PUBLIC("public"),
 
@@ -92,7 +94,9 @@ public enum class OAuthClientType(public val value: String) {
 }
 
 @Serializable
-public enum class OAuthClientRegistrationType(public val value: String) {
+public enum class OAuthClientRegistrationType(
+    public val value: String,
+) {
     @SerialName("dynamic")
     DYNAMIC("dynamic"),
 
@@ -101,7 +105,9 @@ public enum class OAuthClientRegistrationType(public val value: String) {
 }
 
 @Serializable
-public enum class OAuthClientTokenEndpointAuthMethod(public val value: String) {
+public enum class OAuthClientTokenEndpointAuthMethod(
+    public val value: String,
+) {
     @SerialName("none")
     NONE("none"),
 
@@ -158,7 +164,9 @@ public data class OAuthClientListResponse(
 )
 
 @Serializable
-public enum class CustomProviderType(public val value: String) {
+public enum class CustomProviderType(
+    public val value: String,
+) {
     @SerialName("oauth2")
     OAUTH2("oauth2"),
 

--- a/supabase-auth-admin/src/commonTest/kotlin/io/github/androidpoet/supabase/auth/admin/AuthAdminClientImplTest.kt
+++ b/supabase-auth-admin/src/commonTest/kotlin/io/github/androidpoet/supabase/auth/admin/AuthAdminClientImplTest.kt
@@ -28,327 +28,367 @@ class AuthAdminClientImplTest {
     private val json: Json = Json { ignoreUnknownKeys = true }
 
     @Test
-    fun test_createUser_sendsAdminUserAttributes_expectedEndpointBodyAndHeader() = runTest {
-        val client = FakeSupabaseClient()
-        val sut = client.authAdmin(serviceRoleKey = "service-role")
+    fun test_createUser_sendsAdminUserAttributes_expectedEndpointBodyAndHeader() =
+        runTest {
+            val client = FakeSupabaseClient()
+            val sut = client.authAdmin(serviceRoleKey = "service-role")
 
-        val result = sut.createUser(
-            AdminUserAttributes(
-                email = "user@example.com",
-                password = "secret",
-                userMetadata = JsonObject(mapOf("name" to JsonPrimitive("Ranbir"))),
-                emailConfirm = true,
-            ),
-        )
+            val result =
+                sut.createUser(
+                    AdminUserAttributes(
+                        email = "user@example.com",
+                        password = "secret",
+                        userMetadata = JsonObject(mapOf("name" to JsonPrimitive("Ranbir"))),
+                        emailConfirm = true,
+                    ),
+                )
 
-        assertIs<SupabaseResult.Success<*>>(result)
-        assertEquals("/auth/v1/admin/users", client.lastPostEndpoint)
-        assertEquals("Bearer service-role", client.lastPostHeaders["Authorization"])
-        val body = json.parseToJsonElement(client.lastPostBody ?: error("missing body")).jsonObject
-        assertEquals("user@example.com", body["email"]?.jsonPrimitive?.content)
-        assertEquals("secret", body["password"]?.jsonPrimitive?.content)
-        assertEquals(true, body["email_confirm"]?.jsonPrimitive?.boolean)
-        assertEquals("Ranbir", body["user_metadata"]?.jsonObject?.get("name")?.jsonPrimitive?.content)
-    }
-
-    @Test
-    fun test_listUsers_withPaging_decodesUsersAndSendsQueryParams() = runTest {
-        val client = FakeSupabaseClient()
-        val sut = client.authAdmin(serviceRoleKey = "service-role")
-
-        val result = sut.listUsers(page = 2, perPage = 50)
-
-        val success = assertIs<SupabaseResult.Success<*>>(result)
-        assertEquals("/auth/v1/admin/users", client.lastGetEndpoint)
-        assertEquals(listOf("page" to "2", "per_page" to "50"), client.lastGetQueryParams)
-        assertEquals("Bearer service-role", client.lastGetHeaders["Authorization"])
-        val value = success.value as io.github.androidpoet.supabase.auth.admin.models.ListUsersResponse
-        assertEquals("authenticated", value.aud)
-        assertEquals("u1", value.users.first().id)
-    }
+            assertIs<SupabaseResult.Success<*>>(result)
+            assertEquals("/auth/v1/admin/users", client.lastPostEndpoint)
+            assertEquals("Bearer service-role", client.lastPostHeaders["Authorization"])
+            val body = json.parseToJsonElement(client.lastPostBody ?: error("missing body")).jsonObject
+            assertEquals("user@example.com", body["email"]?.jsonPrimitive?.content)
+            assertEquals("secret", body["password"]?.jsonPrimitive?.content)
+            assertEquals(true, body["email_confirm"]?.jsonPrimitive?.boolean)
+            assertEquals(
+                "Ranbir",
+                body["user_metadata"]
+                    ?.jsonObject
+                    ?.get("name")
+                    ?.jsonPrimitive
+                    ?.content,
+            )
+        }
 
     @Test
-    fun test_getUserById_decodesUserResponse() = runTest {
-        val client = FakeSupabaseClient()
-        val sut = client.authAdmin(serviceRoleKey = "service-role")
+    fun test_listUsers_withPaging_decodesUsersAndSendsQueryParams() =
+        runTest {
+            val client = FakeSupabaseClient()
+            val sut = client.authAdmin(serviceRoleKey = "service-role")
 
-        val result = sut.getUserById("u1")
+            val result = sut.listUsers(page = 2, perPage = 50)
 
-        val success = assertIs<SupabaseResult.Success<*>>(result)
-        assertEquals("/auth/v1/admin/users/u1", client.lastGetEndpoint)
-        assertEquals("u1", (success.value as io.github.androidpoet.supabase.auth.models.User).id)
-    }
-
-    @Test
-    fun test_updateUserById_sendsPutBody() = runTest {
-        val client = FakeSupabaseClient()
-        val sut = client.authAdmin(serviceRoleKey = "service-role")
-
-        val result = sut.updateUserById("u1", AdminUserAttributes(phone = "+15555550100", phoneConfirm = true))
-
-        assertIs<SupabaseResult.Success<*>>(result)
-        assertEquals("/auth/v1/admin/users/u1", client.lastPutEndpoint)
-        assertEquals("Bearer service-role", client.lastPutHeaders["Authorization"])
-        val body = json.parseToJsonElement(client.lastPutBody ?: error("missing body")).jsonObject
-        assertEquals("+15555550100", body["phone"]?.jsonPrimitive?.content)
-        assertEquals(true, body["phone_confirm"]?.jsonPrimitive?.boolean)
-    }
+            val success = assertIs<SupabaseResult.Success<*>>(result)
+            assertEquals("/auth/v1/admin/users", client.lastGetEndpoint)
+            assertEquals(listOf("page" to "2", "per_page" to "50"), client.lastGetQueryParams)
+            assertEquals("Bearer service-role", client.lastGetHeaders["Authorization"])
+            val value = success.value as io.github.androidpoet.supabase.auth.admin.models.ListUsersResponse
+            assertEquals("authenticated", value.aud)
+            assertEquals("u1", value.users.first().id)
+        }
 
     @Test
-    fun test_deleteUser_sendsAdminDelete() = runTest {
-        val client = FakeSupabaseClient()
-        val sut = client.authAdmin(serviceRoleKey = "service-role")
+    fun test_getUserById_decodesUserResponse() =
+        runTest {
+            val client = FakeSupabaseClient()
+            val sut = client.authAdmin(serviceRoleKey = "service-role")
 
-        val result = sut.deleteUser(userId = "u1", shouldSoftDelete = true)
+            val result = sut.getUserById("u1")
 
-        assertIs<SupabaseResult.Success<*>>(result)
-        assertEquals("/auth/v1/admin/users/u1", client.lastDeleteEndpoint)
-        assertEquals("Bearer service-role", client.lastDeleteHeaders["Authorization"])
-        val body = json.parseToJsonElement(client.lastDeleteBody ?: error("missing body")).jsonObject
-        assertEquals(true, body["should_soft_delete"]?.jsonPrimitive?.boolean)
-    }
-
-    @Test
-    fun test_listFactors_decodesAdminMfaFactors() = runTest {
-        val client = FakeSupabaseClient()
-        val sut = client.authAdmin(serviceRoleKey = "service-role")
-
-        val result = sut.listFactors("u1")
-
-        val success = assertIs<SupabaseResult.Success<*>>(result)
-        assertEquals("/auth/v1/admin/users/u1/factors", client.lastGetEndpoint)
-        assertEquals("Bearer service-role", client.lastGetHeaders["Authorization"])
-        val value = success.value as io.github.androidpoet.supabase.auth.admin.models.MfaAdminListFactorsResponse
-        assertEquals("factor1", value.factors.first().id)
-        assertEquals(io.github.androidpoet.supabase.auth.models.MfaFactorType.WEBAUTHN, value.factors.last().factorType)
-    }
+            val success = assertIs<SupabaseResult.Success<*>>(result)
+            assertEquals("/auth/v1/admin/users/u1", client.lastGetEndpoint)
+            assertEquals("u1", (success.value as io.github.androidpoet.supabase.auth.models.User).id)
+        }
 
     @Test
-    fun test_deleteFactor_sendsAdminMfaDeleteAndDecodesId() = runTest {
-        val client = FakeSupabaseClient()
-        val sut = client.authAdmin(serviceRoleKey = "service-role")
+    fun test_updateUserById_sendsPutBody() =
+        runTest {
+            val client = FakeSupabaseClient()
+            val sut = client.authAdmin(serviceRoleKey = "service-role")
 
-        val result = sut.deleteFactor(userId = "u1", factorId = "factor1")
+            val result = sut.updateUserById("u1", AdminUserAttributes(phone = "+15555550100", phoneConfirm = true))
 
-        val success = assertIs<SupabaseResult.Success<*>>(result)
-        assertEquals("/auth/v1/admin/users/u1/factors/factor1", client.lastDeleteEndpoint)
-        assertEquals("Bearer service-role", client.lastDeleteHeaders["Authorization"])
-        val value = success.value as io.github.androidpoet.supabase.auth.admin.models.MfaAdminDeleteFactorResponse
-        assertEquals("factor1", value.id)
-    }
-
-    @Test
-    fun test_listPasskeys_decodesAdminPasskeyArray() = runTest {
-        val client = FakeSupabaseClient()
-        val sut = client.authAdmin(serviceRoleKey = "service-role")
-
-        val result = sut.listPasskeys("u1")
-
-        val success = assertIs<SupabaseResult.Success<*>>(result)
-        assertEquals("/auth/v1/admin/users/u1/passkeys", client.lastGetEndpoint)
-        assertEquals("Bearer service-role", client.lastGetHeaders["Authorization"])
-        val value = success.value as List<*>
-        val passkey = value.first() as io.github.androidpoet.supabase.auth.admin.models.Passkey
-        assertEquals("passkey1", passkey.id)
-        assertEquals("Laptop", passkey.friendlyName)
-    }
+            assertIs<SupabaseResult.Success<*>>(result)
+            assertEquals("/auth/v1/admin/users/u1", client.lastPutEndpoint)
+            assertEquals("Bearer service-role", client.lastPutHeaders["Authorization"])
+            val body = json.parseToJsonElement(client.lastPutBody ?: error("missing body")).jsonObject
+            assertEquals("+15555550100", body["phone"]?.jsonPrimitive?.content)
+            assertEquals(true, body["phone_confirm"]?.jsonPrimitive?.boolean)
+        }
 
     @Test
-    fun test_deletePasskey_sendsAdminPasskeyDelete() = runTest {
-        val client = FakeSupabaseClient()
-        val sut = client.authAdmin(serviceRoleKey = "service-role")
+    fun test_deleteUser_sendsAdminDelete() =
+        runTest {
+            val client = FakeSupabaseClient()
+            val sut = client.authAdmin(serviceRoleKey = "service-role")
 
-        val result = sut.deletePasskey(userId = "u1", passkeyId = "passkey1")
+            val result = sut.deleteUser(userId = "u1", shouldSoftDelete = true)
 
-        assertIs<SupabaseResult.Success<*>>(result)
-        assertEquals("/auth/v1/admin/users/u1/passkeys/passkey1", client.lastDeleteEndpoint)
-        assertEquals("Bearer service-role", client.lastDeleteHeaders["Authorization"])
-    }
-
-    @Test
-    fun test_inviteUserByEmail_sendsRedirectQueryAndData() = runTest {
-        val client = FakeSupabaseClient()
-        val sut = client.authAdmin(serviceRoleKey = "service-role")
-
-        val result = sut.inviteUserByEmail(
-            email = "invite@example.com",
-            data = JsonObject(mapOf("team" to JsonPrimitive("sdk"))),
-            redirectTo = "app://callback",
-        )
-
-        assertIs<SupabaseResult.Success<*>>(result)
-        assertEquals("/auth/v1/invite?redirect_to=app%3A%2F%2Fcallback", client.lastPostEndpoint)
-        val body = json.parseToJsonElement(client.lastPostBody ?: error("missing body")).jsonObject
-        assertEquals("invite@example.com", body["email"]?.jsonPrimitive?.content)
-        assertEquals("sdk", body["data"]?.jsonObject?.get("team")?.jsonPrimitive?.content)
-    }
+            assertIs<SupabaseResult.Success<*>>(result)
+            assertEquals("/auth/v1/admin/users/u1", client.lastDeleteEndpoint)
+            assertEquals("Bearer service-role", client.lastDeleteHeaders["Authorization"])
+            val body = json.parseToJsonElement(client.lastDeleteBody ?: error("missing body")).jsonObject
+            assertEquals(true, body["should_soft_delete"]?.jsonPrimitive?.boolean)
+        }
 
     @Test
-    fun test_generateLink_mapsRequestAndDecodesProperties() = runTest {
-        val client = FakeSupabaseClient()
-        val sut = client.authAdmin(serviceRoleKey = "service-role")
+    fun test_listFactors_decodesAdminMfaFactors() =
+        runTest {
+            val client = FakeSupabaseClient()
+            val sut = client.authAdmin(serviceRoleKey = "service-role")
 
-        val result = sut.generateLink(
-            GenerateLinkRequest(
-                type = GenerateLinkType.EMAIL_CHANGE_NEW,
-                email = "old@example.com",
-                newEmail = "new@example.com",
-                redirectTo = "app://callback",
-            ),
-        )
+            val result = sut.listFactors("u1")
 
-        val success = assertIs<SupabaseResult.Success<*>>(result)
-        assertEquals("/auth/v1/admin/generate_link?redirect_to=app%3A%2F%2Fcallback", client.lastPostEndpoint)
-        val body = json.parseToJsonElement(client.lastPostBody ?: error("missing body")).jsonObject
-        assertEquals("email_change_new", body["type"]?.jsonPrimitive?.content)
-        assertEquals("new@example.com", body["new_email"]?.jsonPrimitive?.content)
-        val value = success.value as io.github.androidpoet.supabase.auth.admin.models.GenerateLinkResponse
-        assertEquals("https://example.com/action", value.properties.actionLink)
-        assertEquals("magiclink", value.properties.verificationType)
-    }
+            val success = assertIs<SupabaseResult.Success<*>>(result)
+            assertEquals("/auth/v1/admin/users/u1/factors", client.lastGetEndpoint)
+            assertEquals("Bearer service-role", client.lastGetHeaders["Authorization"])
+            val value = success.value as io.github.androidpoet.supabase.auth.admin.models.MfaAdminListFactorsResponse
+            assertEquals("factor1", value.factors.first().id)
+            assertEquals(io.github.androidpoet.supabase.auth.models.MfaFactorType.WEBAUTHN, value.factors.last().factorType)
+        }
 
     @Test
-    fun test_signOut_usesProvidedJwtNotAdminKey() = runTest {
-        val client = FakeSupabaseClient()
-        val sut = client.authAdmin(serviceRoleKey = "service-role")
+    fun test_deleteFactor_sendsAdminMfaDeleteAndDecodesId() =
+        runTest {
+            val client = FakeSupabaseClient()
+            val sut = client.authAdmin(serviceRoleKey = "service-role")
 
-        val result = sut.signOut(jwt = "user-jwt", scope = SignOutScope.GLOBAL)
+            val result = sut.deleteFactor(userId = "u1", factorId = "factor1")
 
-        assertIs<SupabaseResult.Success<*>>(result)
-        assertEquals("/auth/v1/logout?scope=global", client.lastPostEndpoint)
-        assertEquals("Bearer user-jwt", client.lastPostHeaders["Authorization"])
-    }
-
-    @Test
-    fun test_listOAuthClients_withPaging_decodesClientsAndSendsQueryParams() = runTest {
-        val client = FakeSupabaseClient()
-        val sut = client.authAdmin(serviceRoleKey = "service-role")
-
-        val result = sut.listOAuthClients(page = 3, perPage = 25)
-
-        val success = assertIs<SupabaseResult.Success<*>>(result)
-        assertEquals("/auth/v1/admin/oauth/clients", client.lastGetEndpoint)
-        assertEquals(listOf("page" to "3", "per_page" to "25"), client.lastGetQueryParams)
-        val value = success.value as io.github.androidpoet.supabase.auth.admin.models.OAuthClientListResponse
-        assertEquals("oauth-client-1", value.clients.first().clientId)
-    }
+            val success = assertIs<SupabaseResult.Success<*>>(result)
+            assertEquals("/auth/v1/admin/users/u1/factors/factor1", client.lastDeleteEndpoint)
+            assertEquals("Bearer service-role", client.lastDeleteHeaders["Authorization"])
+            val value = success.value as io.github.androidpoet.supabase.auth.admin.models.MfaAdminDeleteFactorResponse
+            assertEquals("factor1", value.id)
+        }
 
     @Test
-    fun test_createOAuthClient_sendsCreatePayload() = runTest {
-        val client = FakeSupabaseClient()
-        val sut = client.authAdmin(serviceRoleKey = "service-role")
+    fun test_listPasskeys_decodesAdminPasskeyArray() =
+        runTest {
+            val client = FakeSupabaseClient()
+            val sut = client.authAdmin(serviceRoleKey = "service-role")
 
-        val result = sut.createOAuthClient(
-            OAuthClientCreateRequest(
-                clientName = "Demo Client",
-                redirectUris = listOf("https://app.example/callback"),
-                grantTypes = listOf("authorization_code", "refresh_token"),
-                responseTypes = listOf("code"),
-                tokenEndpointAuthMethod = OAuthClientTokenEndpointAuthMethod.CLIENT_SECRET_POST,
-            ),
-        )
+            val result = sut.listPasskeys("u1")
 
-        val success = assertIs<SupabaseResult.Success<*>>(result)
-        assertEquals("/auth/v1/admin/oauth/clients", client.lastPostEndpoint)
-        val body = json.parseToJsonElement(client.lastPostBody ?: error("missing body")).jsonObject
-        assertEquals("Demo Client", body["client_name"]?.jsonPrimitive?.content)
-        assertEquals("client_secret_post", body["token_endpoint_auth_method"]?.jsonPrimitive?.content)
-        val value = success.value as io.github.androidpoet.supabase.auth.admin.models.OAuthClient
-        assertEquals("oauth-client-1", value.clientId)
-    }
+            val success = assertIs<SupabaseResult.Success<*>>(result)
+            assertEquals("/auth/v1/admin/users/u1/passkeys", client.lastGetEndpoint)
+            assertEquals("Bearer service-role", client.lastGetHeaders["Authorization"])
+            val value = success.value as List<*>
+            val passkey = value.first() as io.github.androidpoet.supabase.auth.admin.models.Passkey
+            assertEquals("passkey1", passkey.id)
+            assertEquals("Laptop", passkey.friendlyName)
+        }
 
     @Test
-    fun test_updateOAuthClient_sendsUpdatePayload() = runTest {
-        val client = FakeSupabaseClient()
-        val sut = client.authAdmin(serviceRoleKey = "service-role")
+    fun test_deletePasskey_sendsAdminPasskeyDelete() =
+        runTest {
+            val client = FakeSupabaseClient()
+            val sut = client.authAdmin(serviceRoleKey = "service-role")
 
-        val result = sut.updateOAuthClient(
-            clientId = "oauth-client-1",
-            request = OAuthClientUpdateRequest(clientName = "Updated Client"),
-        )
+            val result = sut.deletePasskey(userId = "u1", passkeyId = "passkey1")
 
-        assertIs<SupabaseResult.Success<*>>(result)
-        assertEquals("/auth/v1/admin/oauth/clients/oauth-client-1", client.lastPutEndpoint)
-        val body = json.parseToJsonElement(client.lastPutBody ?: error("missing body")).jsonObject
-        assertEquals("Updated Client", body["client_name"]?.jsonPrimitive?.content)
-    }
+            assertIs<SupabaseResult.Success<*>>(result)
+            assertEquals("/auth/v1/admin/users/u1/passkeys/passkey1", client.lastDeleteEndpoint)
+            assertEquals("Bearer service-role", client.lastDeleteHeaders["Authorization"])
+        }
 
     @Test
-    fun test_getDeleteAndRegenerateOAuthClient_useExpectedEndpoints() = runTest {
-        val client = FakeSupabaseClient()
-        val sut = client.authAdmin(serviceRoleKey = "service-role")
+    fun test_inviteUserByEmail_sendsRedirectQueryAndData() =
+        runTest {
+            val client = FakeSupabaseClient()
+            val sut = client.authAdmin(serviceRoleKey = "service-role")
 
-        val getResult = sut.getOAuthClient("oauth-client-1")
-        val regenerateResult = sut.regenerateOAuthClientSecret("oauth-client-1")
-        val deleteResult = sut.deleteOAuthClient("oauth-client-1")
+            val result =
+                sut.inviteUserByEmail(
+                    email = "invite@example.com",
+                    data = JsonObject(mapOf("team" to JsonPrimitive("sdk"))),
+                    redirectTo = "app://callback",
+                )
 
-        assertIs<SupabaseResult.Success<*>>(getResult)
-        assertIs<SupabaseResult.Success<*>>(regenerateResult)
-        assertIs<SupabaseResult.Success<*>>(deleteResult)
-        assertEquals("/auth/v1/admin/oauth/clients/oauth-client-1", client.lastDeleteEndpoint)
-        assertEquals("/auth/v1/admin/oauth/clients/oauth-client-1/regenerate_secret", client.lastPostEndpoint)
-    }
-
-    @Test
-    fun test_listCustomProviders_withTypeFilter_decodesProviders() = runTest {
-        val client = FakeSupabaseClient()
-        val sut = client.authAdmin(serviceRoleKey = "service-role")
-
-        val result = sut.listCustomProviders(type = CustomProviderType.OIDC)
-
-        val success = assertIs<SupabaseResult.Success<*>>(result)
-        assertEquals("/auth/v1/admin/custom-providers", client.lastGetEndpoint)
-        assertEquals(listOf("type" to "oidc"), client.lastGetQueryParams)
-        val value = success.value as io.github.androidpoet.supabase.auth.admin.models.CustomProviderListResponse
-        assertEquals("custom:acme", value.providers.first().identifier)
-    }
+            assertIs<SupabaseResult.Success<*>>(result)
+            assertEquals("/auth/v1/invite?redirect_to=app%3A%2F%2Fcallback", client.lastPostEndpoint)
+            val body = json.parseToJsonElement(client.lastPostBody ?: error("missing body")).jsonObject
+            assertEquals("invite@example.com", body["email"]?.jsonPrimitive?.content)
+            assertEquals(
+                "sdk",
+                body["data"]
+                    ?.jsonObject
+                    ?.get("team")
+                    ?.jsonPrimitive
+                    ?.content,
+            )
+        }
 
     @Test
-    fun test_createCustomProvider_sendsProviderPayload() = runTest {
-        val client = FakeSupabaseClient()
-        val sut = client.authAdmin(serviceRoleKey = "service-role")
+    fun test_generateLink_mapsRequestAndDecodesProperties() =
+        runTest {
+            val client = FakeSupabaseClient()
+            val sut = client.authAdmin(serviceRoleKey = "service-role")
 
-        val result = sut.createCustomProvider(
-            CustomProviderCreateRequest(
-                providerType = CustomProviderType.OIDC,
-                identifier = "custom:acme",
-                name = "Acme",
-                clientId = "client-id",
-                clientSecret = "client-secret",
-                issuer = "https://issuer.example",
-                scopes = listOf("openid", "email"),
-                pkceEnabled = true,
-            ),
-        )
+            val result =
+                sut.generateLink(
+                    GenerateLinkRequest(
+                        type = GenerateLinkType.EMAIL_CHANGE_NEW,
+                        email = "old@example.com",
+                        newEmail = "new@example.com",
+                        redirectTo = "app://callback",
+                    ),
+                )
 
-        assertIs<SupabaseResult.Success<*>>(result)
-        assertEquals("/auth/v1/admin/custom-providers", client.lastPostEndpoint)
-        val body = json.parseToJsonElement(client.lastPostBody ?: error("missing body")).jsonObject
-        assertEquals("oidc", body["provider_type"]?.jsonPrimitive?.content)
-        assertEquals("custom:acme", body["identifier"]?.jsonPrimitive?.content)
-        assertEquals(true, body["pkce_enabled"]?.jsonPrimitive?.boolean)
-    }
+            val success = assertIs<SupabaseResult.Success<*>>(result)
+            assertEquals("/auth/v1/admin/generate_link?redirect_to=app%3A%2F%2Fcallback", client.lastPostEndpoint)
+            val body = json.parseToJsonElement(client.lastPostBody ?: error("missing body")).jsonObject
+            assertEquals("email_change_new", body["type"]?.jsonPrimitive?.content)
+            assertEquals("new@example.com", body["new_email"]?.jsonPrimitive?.content)
+            val value = success.value as io.github.androidpoet.supabase.auth.admin.models.GenerateLinkResponse
+            assertEquals("https://example.com/action", value.properties.actionLink)
+            assertEquals("magiclink", value.properties.verificationType)
+        }
 
     @Test
-    fun test_getUpdateAndDeleteCustomProvider_useExpectedEndpoints() = runTest {
-        val client = FakeSupabaseClient()
-        val sut = client.authAdmin(serviceRoleKey = "service-role")
+    fun test_signOut_usesProvidedJwtNotAdminKey() =
+        runTest {
+            val client = FakeSupabaseClient()
+            val sut = client.authAdmin(serviceRoleKey = "service-role")
 
-        val getResult = sut.getCustomProvider("custom:acme")
-        val updateResult = sut.updateCustomProvider(
-            identifier = "custom:acme",
-            request = CustomProviderUpdateRequest(name = "Acme Updated", enabled = false),
-        )
-        val deleteResult = sut.deleteCustomProvider("custom:acme")
+            val result = sut.signOut(jwt = "user-jwt", scope = SignOutScope.GLOBAL)
 
-        assertIs<SupabaseResult.Success<*>>(getResult)
-        assertIs<SupabaseResult.Success<*>>(updateResult)
-        assertIs<SupabaseResult.Success<*>>(deleteResult)
-        assertEquals("/auth/v1/admin/custom-providers/custom:acme", client.lastDeleteEndpoint)
-        val body = json.parseToJsonElement(client.lastPutBody ?: error("missing body")).jsonObject
-        assertEquals("Acme Updated", body["name"]?.jsonPrimitive?.content)
-        assertEquals(false, body["enabled"]?.jsonPrimitive?.boolean)
-    }
+            assertIs<SupabaseResult.Success<*>>(result)
+            assertEquals("/auth/v1/logout?scope=global", client.lastPostEndpoint)
+            assertEquals("Bearer user-jwt", client.lastPostHeaders["Authorization"])
+        }
+
+    @Test
+    fun test_listOAuthClients_withPaging_decodesClientsAndSendsQueryParams() =
+        runTest {
+            val client = FakeSupabaseClient()
+            val sut = client.authAdmin(serviceRoleKey = "service-role")
+
+            val result = sut.listOAuthClients(page = 3, perPage = 25)
+
+            val success = assertIs<SupabaseResult.Success<*>>(result)
+            assertEquals("/auth/v1/admin/oauth/clients", client.lastGetEndpoint)
+            assertEquals(listOf("page" to "3", "per_page" to "25"), client.lastGetQueryParams)
+            val value = success.value as io.github.androidpoet.supabase.auth.admin.models.OAuthClientListResponse
+            assertEquals("oauth-client-1", value.clients.first().clientId)
+        }
+
+    @Test
+    fun test_createOAuthClient_sendsCreatePayload() =
+        runTest {
+            val client = FakeSupabaseClient()
+            val sut = client.authAdmin(serviceRoleKey = "service-role")
+
+            val result =
+                sut.createOAuthClient(
+                    OAuthClientCreateRequest(
+                        clientName = "Demo Client",
+                        redirectUris = listOf("https://app.example/callback"),
+                        grantTypes = listOf("authorization_code", "refresh_token"),
+                        responseTypes = listOf("code"),
+                        tokenEndpointAuthMethod = OAuthClientTokenEndpointAuthMethod.CLIENT_SECRET_POST,
+                    ),
+                )
+
+            val success = assertIs<SupabaseResult.Success<*>>(result)
+            assertEquals("/auth/v1/admin/oauth/clients", client.lastPostEndpoint)
+            val body = json.parseToJsonElement(client.lastPostBody ?: error("missing body")).jsonObject
+            assertEquals("Demo Client", body["client_name"]?.jsonPrimitive?.content)
+            assertEquals("client_secret_post", body["token_endpoint_auth_method"]?.jsonPrimitive?.content)
+            val value = success.value as io.github.androidpoet.supabase.auth.admin.models.OAuthClient
+            assertEquals("oauth-client-1", value.clientId)
+        }
+
+    @Test
+    fun test_updateOAuthClient_sendsUpdatePayload() =
+        runTest {
+            val client = FakeSupabaseClient()
+            val sut = client.authAdmin(serviceRoleKey = "service-role")
+
+            val result =
+                sut.updateOAuthClient(
+                    clientId = "oauth-client-1",
+                    request = OAuthClientUpdateRequest(clientName = "Updated Client"),
+                )
+
+            assertIs<SupabaseResult.Success<*>>(result)
+            assertEquals("/auth/v1/admin/oauth/clients/oauth-client-1", client.lastPutEndpoint)
+            val body = json.parseToJsonElement(client.lastPutBody ?: error("missing body")).jsonObject
+            assertEquals("Updated Client", body["client_name"]?.jsonPrimitive?.content)
+        }
+
+    @Test
+    fun test_getDeleteAndRegenerateOAuthClient_useExpectedEndpoints() =
+        runTest {
+            val client = FakeSupabaseClient()
+            val sut = client.authAdmin(serviceRoleKey = "service-role")
+
+            val getResult = sut.getOAuthClient("oauth-client-1")
+            val regenerateResult = sut.regenerateOAuthClientSecret("oauth-client-1")
+            val deleteResult = sut.deleteOAuthClient("oauth-client-1")
+
+            assertIs<SupabaseResult.Success<*>>(getResult)
+            assertIs<SupabaseResult.Success<*>>(regenerateResult)
+            assertIs<SupabaseResult.Success<*>>(deleteResult)
+            assertEquals("/auth/v1/admin/oauth/clients/oauth-client-1", client.lastDeleteEndpoint)
+            assertEquals("/auth/v1/admin/oauth/clients/oauth-client-1/regenerate_secret", client.lastPostEndpoint)
+        }
+
+    @Test
+    fun test_listCustomProviders_withTypeFilter_decodesProviders() =
+        runTest {
+            val client = FakeSupabaseClient()
+            val sut = client.authAdmin(serviceRoleKey = "service-role")
+
+            val result = sut.listCustomProviders(type = CustomProviderType.OIDC)
+
+            val success = assertIs<SupabaseResult.Success<*>>(result)
+            assertEquals("/auth/v1/admin/custom-providers", client.lastGetEndpoint)
+            assertEquals(listOf("type" to "oidc"), client.lastGetQueryParams)
+            val value = success.value as io.github.androidpoet.supabase.auth.admin.models.CustomProviderListResponse
+            assertEquals("custom:acme", value.providers.first().identifier)
+        }
+
+    @Test
+    fun test_createCustomProvider_sendsProviderPayload() =
+        runTest {
+            val client = FakeSupabaseClient()
+            val sut = client.authAdmin(serviceRoleKey = "service-role")
+
+            val result =
+                sut.createCustomProvider(
+                    CustomProviderCreateRequest(
+                        providerType = CustomProviderType.OIDC,
+                        identifier = "custom:acme",
+                        name = "Acme",
+                        clientId = "client-id",
+                        clientSecret = "client-secret",
+                        issuer = "https://issuer.example",
+                        scopes = listOf("openid", "email"),
+                        pkceEnabled = true,
+                    ),
+                )
+
+            assertIs<SupabaseResult.Success<*>>(result)
+            assertEquals("/auth/v1/admin/custom-providers", client.lastPostEndpoint)
+            val body = json.parseToJsonElement(client.lastPostBody ?: error("missing body")).jsonObject
+            assertEquals("oidc", body["provider_type"]?.jsonPrimitive?.content)
+            assertEquals("custom:acme", body["identifier"]?.jsonPrimitive?.content)
+            assertEquals(true, body["pkce_enabled"]?.jsonPrimitive?.boolean)
+        }
+
+    @Test
+    fun test_getUpdateAndDeleteCustomProvider_useExpectedEndpoints() =
+        runTest {
+            val client = FakeSupabaseClient()
+            val sut = client.authAdmin(serviceRoleKey = "service-role")
+
+            val getResult = sut.getCustomProvider("custom:acme")
+            val updateResult =
+                sut.updateCustomProvider(
+                    identifier = "custom:acme",
+                    request = CustomProviderUpdateRequest(name = "Acme Updated", enabled = false),
+                )
+            val deleteResult = sut.deleteCustomProvider("custom:acme")
+
+            assertIs<SupabaseResult.Success<*>>(getResult)
+            assertIs<SupabaseResult.Success<*>>(updateResult)
+            assertIs<SupabaseResult.Success<*>>(deleteResult)
+            assertEquals("/auth/v1/admin/custom-providers/custom:acme", client.lastDeleteEndpoint)
+            val body = json.parseToJsonElement(client.lastPutBody ?: error("missing body")).jsonObject
+            assertEquals("Acme Updated", body["name"]?.jsonPrimitive?.content)
+            assertEquals(false, body["enabled"]?.jsonPrimitive?.boolean)
+        }
 }
 
 private class FakeSupabaseClient : SupabaseClient {
@@ -378,52 +418,58 @@ private class FakeSupabaseClient : SupabaseClient {
         lastGetQueryParams = queryParams
         lastGetHeaders = headers
         return when {
-            endpoint == "/auth/v1/admin/oauth/clients" -> SupabaseResult.Success(
-                """{"clients":[${oauthClientJson()}],"aud":"authenticated"}""",
-            )
+            endpoint == "/auth/v1/admin/oauth/clients" ->
+                SupabaseResult.Success(
+                    """{"clients":[${oauthClientJson()}],"aud":"authenticated"}""",
+                )
             endpoint.startsWith("/auth/v1/admin/oauth/clients/") -> SupabaseResult.Success(oauthClientJson())
-            endpoint == "/auth/v1/admin/custom-providers" -> SupabaseResult.Success(
-                """{"providers":[${customProviderJson()}]}""",
-            )
+            endpoint == "/auth/v1/admin/custom-providers" ->
+                SupabaseResult.Success(
+                    """{"providers":[${customProviderJson()}]}""",
+                )
             endpoint.startsWith("/auth/v1/admin/custom-providers/") -> SupabaseResult.Success(customProviderJson())
-            endpoint == "/auth/v1/admin/users" -> SupabaseResult.Success(
-                """{"users":[{"id":"u1","email":"user@example.com"}],"aud":"authenticated"}""",
-            )
-            endpoint.endsWith("/factors") -> SupabaseResult.Success(
-                """
-                {
-                  "factors": [
+            endpoint == "/auth/v1/admin/users" ->
+                SupabaseResult.Success(
+                    """{"users":[{"id":"u1","email":"user@example.com"}],"aud":"authenticated"}""",
+                )
+            endpoint.endsWith("/factors") ->
+                SupabaseResult.Success(
+                    """
                     {
-                      "id": "factor1",
-                      "friendly_name": "Auth App",
-                      "factor_type": "totp",
-                      "status": "verified"
-                    },
-                    {
-                      "id": "factor2",
-                      "friendly_name": "Security Key",
-                      "factor_type": "webauthn",
-                      "status": "unverified"
+                      "factors": [
+                        {
+                          "id": "factor1",
+                          "friendly_name": "Auth App",
+                          "factor_type": "totp",
+                          "status": "verified"
+                        },
+                        {
+                          "id": "factor2",
+                          "friendly_name": "Security Key",
+                          "factor_type": "webauthn",
+                          "status": "unverified"
+                        }
+                      ]
                     }
-                  ]
-                }
-                """.trimIndent(),
-            )
-            endpoint.endsWith("/passkeys") -> SupabaseResult.Success(
-                """
-                [
-                  {
-                    "id": "passkey1",
-                    "friendly_name": "Laptop",
-                    "created_at": "2026-01-01T00:00:00Z",
-                    "last_used_at": "2026-01-02T00:00:00Z"
-                  }
-                ]
-                """.trimIndent(),
-            )
-            endpoint.startsWith("/auth/v1/admin/users/") -> SupabaseResult.Success(
-                """{"user":{"id":"u1","email":"user@example.com"}}""",
-            )
+                    """.trimIndent(),
+                )
+            endpoint.endsWith("/passkeys") ->
+                SupabaseResult.Success(
+                    """
+                    [
+                      {
+                        "id": "passkey1",
+                        "friendly_name": "Laptop",
+                        "created_at": "2026-01-01T00:00:00Z",
+                        "last_used_at": "2026-01-02T00:00:00Z"
+                      }
+                    ]
+                    """.trimIndent(),
+                )
+            endpoint.startsWith("/auth/v1/admin/users/") ->
+                SupabaseResult.Success(
+                    """{"user":{"id":"u1","email":"user@example.com"}}""",
+                )
             else -> SupabaseResult.Failure(SupabaseError("unexpected GET $endpoint"))
         }
     }
@@ -439,30 +485,34 @@ private class FakeSupabaseClient : SupabaseClient {
         return when {
             endpoint.startsWith("/auth/v1/logout") -> SupabaseResult.Success("{}")
             endpoint == "/auth/v1/admin/oauth/clients" -> SupabaseResult.Success(oauthClientJson())
-            endpoint.endsWith("/regenerate_secret") -> SupabaseResult.Success(
-                oauthClientJson(clientSecret = "new-secret"),
-            )
+            endpoint.endsWith("/regenerate_secret") ->
+                SupabaseResult.Success(
+                    oauthClientJson(clientSecret = "new-secret"),
+                )
             endpoint == "/auth/v1/admin/custom-providers" -> SupabaseResult.Success(customProviderJson())
-            endpoint == "/auth/v1/admin/users" -> SupabaseResult.Success(
-                """{"user":{"id":"u1","email":"user@example.com"}}""",
-            )
-            endpoint.startsWith("/auth/v1/invite") -> SupabaseResult.Success(
-                """{"user":{"id":"u1","email":"invite@example.com"}}""",
-            )
-            endpoint.startsWith("/auth/v1/admin/generate_link") -> SupabaseResult.Success(
-                """
-                {
-                  "properties": {
-                    "action_link": "https://example.com/action",
-                    "email_otp": "123456",
-                    "hashed_token": "hash",
-                    "redirect_to": "app://callback",
-                    "verification_type": "magiclink"
-                  },
-                  "user": {"id":"u1","email":"user@example.com"}
-                }
-                """.trimIndent(),
-            )
+            endpoint == "/auth/v1/admin/users" ->
+                SupabaseResult.Success(
+                    """{"user":{"id":"u1","email":"user@example.com"}}""",
+                )
+            endpoint.startsWith("/auth/v1/invite") ->
+                SupabaseResult.Success(
+                    """{"user":{"id":"u1","email":"invite@example.com"}}""",
+                )
+            endpoint.startsWith("/auth/v1/admin/generate_link") ->
+                SupabaseResult.Success(
+                    """
+                    {
+                      "properties": {
+                        "action_link": "https://example.com/action",
+                        "email_otp": "123456",
+                        "hashed_token": "hash",
+                        "redirect_to": "app://callback",
+                        "verification_type": "magiclink"
+                      },
+                      "user": {"id":"u1","email":"user@example.com"}
+                    }
+                    """.trimIndent(),
+                )
             else -> SupabaseResult.Failure(SupabaseError("unexpected POST $endpoint"))
         }
     }
@@ -537,27 +587,27 @@ private class FakeSupabaseClient : SupabaseClient {
               "response_types": ["code"],
               "scope": "openid email"$secret
             }
-        """.trimIndent()
+            """.trimIndent()
     }
 
     private fun customProviderJson(name: String = "Acme"): String =
         """
-            {
-              "id": "provider-id",
-              "provider_type": "oidc",
-              "identifier": "custom:acme",
-              "name": "$name",
-              "client_id": "client-id",
-              "scopes": ["openid", "email"],
-              "pkce_enabled": true,
-              "enabled": true,
-              "issuer": "https://issuer.example",
-              "discovery_document": {
-                "issuer": "https://issuer.example",
-                "authorization_endpoint": "https://issuer.example/auth",
-                "token_endpoint": "https://issuer.example/token",
-                "jwks_uri": "https://issuer.example/jwks"
-              }
-            }
+        {
+          "id": "provider-id",
+          "provider_type": "oidc",
+          "identifier": "custom:acme",
+          "name": "$name",
+          "client_id": "client-id",
+          "scopes": ["openid", "email"],
+          "pkce_enabled": true,
+          "enabled": true,
+          "issuer": "https://issuer.example",
+          "discovery_document": {
+            "issuer": "https://issuer.example",
+            "authorization_endpoint": "https://issuer.example/auth",
+            "token_endpoint": "https://issuer.example/token",
+            "jwks_uri": "https://issuer.example/jwks"
+          }
+        }
         """.trimIndent()
 }

--- a/supabase-auth/src/commonMain/kotlin/io/github/androidpoet/supabase/auth/AuthClient.kt
+++ b/supabase-auth/src/commonMain/kotlin/io/github/androidpoet/supabase/auth/AuthClient.kt
@@ -1,12 +1,12 @@
 package io.github.androidpoet.supabase.auth
 import io.github.androidpoet.supabase.auth.models.AuthenticatorAssuranceLevel
+import io.github.androidpoet.supabase.auth.models.LinkIdentityResponse
 import io.github.androidpoet.supabase.auth.models.MfaChallengeResponse
 import io.github.androidpoet.supabase.auth.models.MfaEnrollResponse
 import io.github.androidpoet.supabase.auth.models.MfaFactorType
 import io.github.androidpoet.supabase.auth.models.MfaListFactorsResponse
 import io.github.androidpoet.supabase.auth.models.MfaUnenrollResponse
 import io.github.androidpoet.supabase.auth.models.MfaVerifyResponse
-import io.github.androidpoet.supabase.auth.models.LinkIdentityResponse
 import io.github.androidpoet.supabase.auth.models.OAuthAuthorizationDetails
 import io.github.androidpoet.supabase.auth.models.OAuthGrant
 import io.github.androidpoet.supabase.auth.models.OAuthProvider
@@ -28,29 +28,35 @@ import io.github.androidpoet.supabase.auth.models.UserUpdateRequest
 import io.github.androidpoet.supabase.auth.models.Web3Chain
 import io.github.androidpoet.supabase.core.result.SupabaseResult
 import kotlinx.serialization.json.JsonObject
+
 public interface AuthClient {
     public suspend fun signUpWithEmail(
         email: String,
         password: String,
         data: JsonObject? = null,
     ): SupabaseResult<Session>
+
     public suspend fun signUpWithPhone(
         phone: String,
         password: String,
         data: JsonObject? = null,
     ): SupabaseResult<Session>
+
     public suspend fun signInWithEmail(
         email: String,
         password: String,
     ): SupabaseResult<Session>
+
     public suspend fun signInAnonymously(
         data: JsonObject? = null,
         captchaToken: String? = null,
     ): SupabaseResult<Session>
+
     public suspend fun signInWithPhone(
         phone: String,
         password: String,
     ): SupabaseResult<Session>
+
     public suspend fun signInWithIdToken(
         provider: OAuthProvider,
         idToken: String,
@@ -58,6 +64,7 @@ public interface AuthClient {
         nonce: String? = null,
         captchaToken: String? = null,
     ): SupabaseResult<Session>
+
     public suspend fun signInWithOAuth(
         provider: OAuthProvider,
         redirectTo: String? = null,
@@ -66,12 +73,14 @@ public interface AuthClient {
         skipBrowserRedirect: Boolean = false,
         pkceParams: PkceParams? = null,
     ): SupabaseResult<OAuthResponse>
+
     public suspend fun signInWithWeb3(
         chain: Web3Chain,
         message: String,
         signature: String,
         captchaToken: String? = null,
     ): SupabaseResult<Session>
+
     public suspend fun signInWithOtp(
         email: String? = null,
         phone: String? = null,
@@ -79,6 +88,7 @@ public interface AuthClient {
         captchaToken: String? = null,
         emailRedirectTo: String? = null,
     ): SupabaseResult<Unit>
+
     public suspend fun verifyOtp(
         email: String? = null,
         phone: String? = null,
@@ -86,11 +96,13 @@ public interface AuthClient {
         type: OtpType,
         captchaToken: String? = null,
     ): SupabaseResult<Session>
+
     public suspend fun verifyOtpWithTokenHash(
         tokenHash: String,
         type: OtpType,
         captchaToken: String? = null,
     ): SupabaseResult<Session>
+
     public suspend fun verifyOtpWithResult(
         email: String? = null,
         phone: String? = null,
@@ -98,40 +110,52 @@ public interface AuthClient {
         type: OtpType,
         captchaToken: String? = null,
     ): SupabaseResult<OtpVerifyResult>
+
     public suspend fun verifyOtpWithTokenHashWithResult(
         tokenHash: String,
         type: OtpType,
         captchaToken: String? = null,
     ): SupabaseResult<OtpVerifyResult>
+
     public suspend fun resendEmailOtp(
         type: OtpType,
         email: String,
         captchaToken: String? = null,
         redirectTo: String? = null,
     ): SupabaseResult<Unit>
+
     public suspend fun resendPhoneOtp(
         type: OtpType,
         phone: String,
         captchaToken: String? = null,
     ): SupabaseResult<Unit>
+
     public suspend fun resetPasswordForEmail(
         email: String,
         redirectTo: String? = null,
         captchaToken: String? = null,
     ): SupabaseResult<Unit>
+
     public suspend fun reauthenticate(accessToken: String): SupabaseResult<Unit>
+
     public suspend fun refreshToken(refreshToken: String): SupabaseResult<Session>
+
     public suspend fun getUser(accessToken: String): SupabaseResult<User>
+
     public suspend fun getUserIdentities(accessToken: String): SupabaseResult<List<UserIdentity>>
+
     public suspend fun updateUser(
         accessToken: String,
         updates: UserUpdateRequest,
     ): SupabaseResult<User>
+
     public suspend fun signOut(accessToken: String): SupabaseResult<Unit>
+
     public suspend fun signOut(
         accessToken: String,
         scope: SignOutScope,
     ): SupabaseResult<Unit>
+
     public suspend fun linkIdentity(
         accessToken: String,
         provider: OAuthProvider,
@@ -139,6 +163,7 @@ public interface AuthClient {
         scopes: List<String> = emptyList(),
         queryParams: Map<String, String> = emptyMap(),
     ): SupabaseResult<LinkIdentityResponse>
+
     public suspend fun linkIdentityWithIdToken(
         accessToken: String,
         provider: OAuthProvider,
@@ -146,16 +171,19 @@ public interface AuthClient {
         providerAccessToken: String? = null,
         nonce: String? = null,
     ): SupabaseResult<Session>
+
     public suspend fun unlinkIdentity(
         accessToken: String,
         identityId: String,
     ): SupabaseResult<Unit>
+
     public suspend fun retrieveSsoUrl(
         accessToken: String? = null,
         domain: String? = null,
         providerId: String? = null,
         redirectTo: String? = null,
     ): SupabaseResult<SsoResponse>
+
     public fun getOAuthSignInUrl(
         provider: OAuthProvider,
         redirectTo: String? = null,
@@ -164,11 +192,14 @@ public interface AuthClient {
         skipBrowserRedirect: Boolean = false,
         pkceParams: PkceParams? = null,
     ): String
+
     public fun generatePkceParams(sha256: ((ByteArray) -> ByteArray)? = null): PkceParams
+
     public suspend fun exchangeCodeForSession(
         authCode: String,
         codeVerifier: String,
     ): SupabaseResult<Session>
+
     public suspend fun mfaEnroll(
         factorType: MfaFactorType,
         friendlyName: String? = null,
@@ -176,23 +207,28 @@ public interface AuthClient {
         phone: String? = null,
         accessToken: String,
     ): SupabaseResult<MfaEnrollResponse>
+
     public suspend fun mfaChallenge(
         factorId: String,
         accessToken: String,
     ): SupabaseResult<MfaChallengeResponse>
+
     public suspend fun mfaVerify(
         factorId: String,
         challengeId: String,
         code: String,
         accessToken: String,
     ): SupabaseResult<MfaVerifyResponse>
+
     public suspend fun mfaUnenroll(
         factorId: String,
         accessToken: String,
     ): SupabaseResult<MfaUnenrollResponse>
+
     public suspend fun mfaListFactors(
         accessToken: String,
     ): SupabaseResult<MfaListFactorsResponse>
+
     public suspend fun mfaGetAuthenticatorAssuranceLevel(
         accessToken: String,
     ): SupabaseResult<AuthenticatorAssuranceLevel>

--- a/supabase-auth/src/commonMain/kotlin/io/github/androidpoet/supabase/auth/AuthClientExt.kt
+++ b/supabase-auth/src/commonMain/kotlin/io/github/androidpoet/supabase/auth/AuthClientExt.kt
@@ -1,16 +1,16 @@
 package io.github.androidpoet.supabase.auth
 
-import io.github.androidpoet.supabase.auth.models.OtpType
-import io.github.androidpoet.supabase.auth.models.OAuthProvider
-import io.github.androidpoet.supabase.auth.models.OtpVerifyResult
+import io.github.androidpoet.supabase.auth.models.LinkIdentityResponse
 import io.github.androidpoet.supabase.auth.models.MfaVerifyResponse
+import io.github.androidpoet.supabase.auth.models.OAuthProvider
+import io.github.androidpoet.supabase.auth.models.OtpType
+import io.github.androidpoet.supabase.auth.models.OtpVerifyResult
 import io.github.androidpoet.supabase.auth.models.Session
 import io.github.androidpoet.supabase.auth.models.SignOutScope
+import io.github.androidpoet.supabase.auth.models.SsoResponse
 import io.github.androidpoet.supabase.auth.models.User
 import io.github.androidpoet.supabase.auth.models.UserIdentity
-import io.github.androidpoet.supabase.auth.models.LinkIdentityResponse
 import io.github.androidpoet.supabase.auth.models.UserUpdateRequest
-import io.github.androidpoet.supabase.auth.models.SsoResponse
 import io.github.androidpoet.supabase.auth.session.SessionManager
 import io.github.androidpoet.supabase.core.result.SupabaseError
 import io.github.androidpoet.supabase.core.result.SupabaseResult
@@ -198,8 +198,9 @@ public suspend fun AuthClient.getUserForCurrentSession(
     sessionManager: SessionManager,
     updateStoredSession: Boolean = false,
 ): SupabaseResult<User> {
-    val token = sessionManager.accessToken
-        ?: return SupabaseResult.Failure(SupabaseError(message = "No active session"))
+    val token =
+        sessionManager.accessToken
+            ?: return SupabaseResult.Failure(SupabaseError(message = "No active session"))
     return when (val userResult = getUser(token)) {
         is SupabaseResult.Failure -> userResult
         is SupabaseResult.Success -> {
@@ -217,8 +218,9 @@ public suspend fun AuthClient.getUserForCurrentSession(
 public suspend fun AuthClient.reauthenticateCurrentSession(
     sessionManager: SessionManager,
 ): SupabaseResult<Unit> {
-    val token = sessionManager.accessToken
-        ?: return SupabaseResult.Failure(SupabaseError(message = "No active session"))
+    val token =
+        sessionManager.accessToken
+            ?: return SupabaseResult.Failure(SupabaseError(message = "No active session"))
     return reauthenticate(token)
 }
 
@@ -229,12 +231,13 @@ public suspend fun AuthClient.mfaChallengeAndVerify(
 ): SupabaseResult<MfaVerifyResponse> =
     when (val challenge = mfaChallenge(factorId = factorId, accessToken = accessToken)) {
         is SupabaseResult.Failure -> SupabaseResult.Failure(challenge.error)
-        is SupabaseResult.Success -> mfaVerify(
-            factorId = factorId,
-            challengeId = challenge.value.id,
-            code = code,
-            accessToken = accessToken,
-        )
+        is SupabaseResult.Success ->
+            mfaVerify(
+                factorId = factorId,
+                challengeId = challenge.value.id,
+                code = code,
+                accessToken = accessToken,
+            )
     }
 
 public suspend fun AuthClient.signOutCurrentSession(
@@ -270,8 +273,9 @@ public suspend fun AuthClient.updateUserForCurrentSession(
     updates: UserUpdateRequest,
     updateStoredSession: Boolean = true,
 ): SupabaseResult<User> {
-    val token = sessionManager.accessToken
-        ?: return SupabaseResult.Failure(SupabaseError(message = "No active session"))
+    val token =
+        sessionManager.accessToken
+            ?: return SupabaseResult.Failure(SupabaseError(message = "No active session"))
     return when (val result = updateUser(token, updates)) {
         is SupabaseResult.Failure -> result
         is SupabaseResult.Success -> {
@@ -298,24 +302,26 @@ public suspend fun AuthClient.importAuthToken(
     tokenType: String = "bearer",
     retrieveUser: Boolean = true,
 ): SupabaseResult<Session> {
-    val user = if (retrieveUser) {
-        when (val result = getUser(accessToken)) {
-            is SupabaseResult.Failure -> return result
-            is SupabaseResult.Success -> result.value
+    val user =
+        if (retrieveUser) {
+            when (val result = getUser(accessToken)) {
+                is SupabaseResult.Failure -> return result
+                is SupabaseResult.Success -> result.value
+            }
+        } else {
+            sessionManager.currentSession?.user
+                ?: return SupabaseResult.Failure(
+                    SupabaseError(message = "No user available. Pass retrieveUser=true or provide an existing session"),
+                )
         }
-    } else {
-        sessionManager.currentSession?.user
-            ?: return SupabaseResult.Failure(
-                SupabaseError(message = "No user available. Pass retrieveUser=true or provide an existing session"),
-            )
-    }
-    val session = Session(
-        accessToken = accessToken,
-        refreshToken = refreshToken,
-        expiresIn = expiresIn,
-        tokenType = tokenType,
-        user = user,
-    )
+    val session =
+        Session(
+            accessToken = accessToken,
+            refreshToken = refreshToken,
+            expiresIn = expiresIn,
+            tokenType = tokenType,
+            user = user,
+        )
     sessionManager.saveSession(session)
     return SupabaseResult.Success(session)
 }
@@ -429,13 +435,14 @@ public suspend fun AuthClient.verifyOtpWithResultAndSaveSession(
     captchaToken: String? = null,
 ): SupabaseResult<OtpVerifyResult> =
     when (
-        val result = verifyOtpWithResult(
-            email = email,
-            phone = phone,
-            token = token,
-            type = type,
-            captchaToken = captchaToken,
-        )
+        val result =
+            verifyOtpWithResult(
+                email = email,
+                phone = phone,
+                token = token,
+                type = type,
+                captchaToken = captchaToken,
+            )
     ) {
         is SupabaseResult.Failure -> result
         is SupabaseResult.Success -> {
@@ -454,11 +461,12 @@ public suspend fun AuthClient.verifyOtpWithTokenHashWithResultAndSaveSession(
     captchaToken: String? = null,
 ): SupabaseResult<OtpVerifyResult> =
     when (
-        val result = verifyOtpWithTokenHashWithResult(
-            tokenHash = tokenHash,
-            type = type,
-            captchaToken = captchaToken,
-        )
+        val result =
+            verifyOtpWithTokenHashWithResult(
+                tokenHash = tokenHash,
+                type = type,
+                captchaToken = captchaToken,
+            )
     ) {
         is SupabaseResult.Failure -> result
         is SupabaseResult.Success -> {
@@ -500,9 +508,10 @@ public suspend fun AuthClient.unlinkIdentityAndUpdateSession(
             if (updateStoredSession) {
                 val current = sessionManager.currentSession
                 if (current != null) {
-                    val updatedUser = current.user.copy(
-                        identities = current.user.identities?.filterNot { it.id == identityId },
-                    )
+                    val updatedUser =
+                        current.user.copy(
+                            identities = current.user.identities?.filterNot { it.id == identityId },
+                        )
                     sessionManager.saveSession(current.copy(user = updatedUser))
                 }
             }
@@ -513,8 +522,9 @@ public suspend fun AuthClient.unlinkIdentityAndUpdateSession(
 public suspend fun AuthClient.getUserIdentitiesForCurrentSession(
     sessionManager: SessionManager,
 ): SupabaseResult<List<UserIdentity>> {
-    val token = sessionManager.accessToken
-        ?: return SupabaseResult.Failure(SupabaseError(message = "No active session"))
+    val token =
+        sessionManager.accessToken
+            ?: return SupabaseResult.Failure(SupabaseError(message = "No active session"))
     return getUserIdentities(accessToken = token)
 }
 
@@ -525,8 +535,9 @@ public suspend fun AuthClient.linkIdentityForCurrentSession(
     scopes: List<String> = emptyList(),
     queryParams: Map<String, String> = emptyMap(),
 ): SupabaseResult<LinkIdentityResponse> {
-    val token = sessionManager.accessToken
-        ?: return SupabaseResult.Failure(SupabaseError(message = "No active session"))
+    val token =
+        sessionManager.accessToken
+            ?: return SupabaseResult.Failure(SupabaseError(message = "No active session"))
     return linkIdentity(
         accessToken = token,
         provider = provider,
@@ -544,16 +555,18 @@ public suspend fun AuthClient.linkIdentityWithIdTokenForCurrentSession(
     nonce: String? = null,
     updateStoredSession: Boolean = true,
 ): SupabaseResult<Session> {
-    val token = sessionManager.accessToken
-        ?: return SupabaseResult.Failure(SupabaseError(message = "No active session"))
+    val token =
+        sessionManager.accessToken
+            ?: return SupabaseResult.Failure(SupabaseError(message = "No active session"))
     return when (
-        val result = linkIdentityWithIdToken(
-            accessToken = token,
-            provider = provider,
-            idToken = idToken,
-            providerAccessToken = providerAccessToken,
-            nonce = nonce,
-        )
+        val result =
+            linkIdentityWithIdToken(
+                accessToken = token,
+                provider = provider,
+                idToken = idToken,
+                providerAccessToken = providerAccessToken,
+                nonce = nonce,
+            )
     ) {
         is SupabaseResult.Failure -> result
         is SupabaseResult.Success -> {
@@ -570,8 +583,9 @@ public suspend fun AuthClient.unlinkIdentityForCurrentSession(
     identityId: String,
     updateStoredSession: Boolean = true,
 ): SupabaseResult<Unit> {
-    val token = sessionManager.accessToken
-        ?: return SupabaseResult.Failure(SupabaseError(message = "No active session"))
+    val token =
+        sessionManager.accessToken
+            ?: return SupabaseResult.Failure(SupabaseError(message = "No active session"))
     return unlinkIdentityAndUpdateSession(
         accessToken = token,
         identityId = identityId,
@@ -589,24 +603,28 @@ public data class ParsedSessionTokens(
 
 public fun parseSessionTokensFromFragment(fragment: String): SupabaseResult<ParsedSessionTokens> {
     val normalized = fragment.removePrefix("#")
-    val pairs = normalized
-        .split("&")
-        .mapNotNull { part ->
-            if (part.isBlank()) return@mapNotNull null
-            val i = part.indexOf('=')
-            if (i < 0) return@mapNotNull decodeQueryComponent(part) to ""
-            decodeQueryComponent(part.substring(0, i)) to decodeQueryComponent(part.substring(i + 1))
-        }
-        .toMap()
+    val pairs =
+        normalized
+            .split("&")
+            .mapNotNull { part ->
+                if (part.isBlank()) return@mapNotNull null
+                val i = part.indexOf('=')
+                if (i < 0) return@mapNotNull decodeQueryComponent(part) to ""
+                decodeQueryComponent(part.substring(0, i)) to decodeQueryComponent(part.substring(i + 1))
+            }.toMap()
 
-    val accessToken = pairs["access_token"]
-        ?: return SupabaseResult.Failure(SupabaseError(message = "No access token found in fragment"))
-    val refreshToken = pairs["refresh_token"]
-        ?: return SupabaseResult.Failure(SupabaseError(message = "No refresh token found in fragment"))
-    val expiresIn = pairs["expires_in"]?.toLongOrNull()
-        ?: return SupabaseResult.Failure(SupabaseError(message = "No expires_in found in fragment"))
-    val tokenType = pairs["token_type"]
-        ?: return SupabaseResult.Failure(SupabaseError(message = "No token_type found in fragment"))
+    val accessToken =
+        pairs["access_token"]
+            ?: return SupabaseResult.Failure(SupabaseError(message = "No access token found in fragment"))
+    val refreshToken =
+        pairs["refresh_token"]
+            ?: return SupabaseResult.Failure(SupabaseError(message = "No refresh token found in fragment"))
+    val expiresIn =
+        pairs["expires_in"]?.toLongOrNull()
+            ?: return SupabaseResult.Failure(SupabaseError(message = "No expires_in found in fragment"))
+    val tokenType =
+        pairs["token_type"]
+            ?: return SupabaseResult.Failure(SupabaseError(message = "No token_type found in fragment"))
 
     return SupabaseResult.Success(
         ParsedSessionTokens(
@@ -660,13 +678,14 @@ private suspend fun AuthClient.importParsedSessionTokens(
             when (val userResult = getUser(parsed.value.accessToken)) {
                 is SupabaseResult.Failure -> userResult
                 is SupabaseResult.Success -> {
-                    val session = Session(
-                        accessToken = parsed.value.accessToken,
-                        refreshToken = parsed.value.refreshToken,
-                        expiresIn = parsed.value.expiresIn,
-                        tokenType = parsed.value.tokenType,
-                        user = userResult.value,
-                    )
+                    val session =
+                        Session(
+                            accessToken = parsed.value.accessToken,
+                            refreshToken = parsed.value.refreshToken,
+                            expiresIn = parsed.value.expiresIn,
+                            tokenType = parsed.value.tokenType,
+                            user = userResult.value,
+                        )
                     sessionManager.saveSession(session)
                     SupabaseResult.Success(session)
                 }
@@ -680,7 +699,7 @@ private fun decodeQueryComponent(input: String): String {
     var i = 0
     while (i < input.length) {
         val c = input[i]
-        if (c == '+' ) {
+        if (c == '+') {
             out.append(' ')
             i++
             continue
@@ -705,12 +724,14 @@ public fun parseJwtClaims(jwt: String): SupabaseResult<JsonObject> {
     if (parts.size < 2) {
         return SupabaseResult.Failure(SupabaseError(message = "Invalid JWT format"))
     }
-    val payload = decodeBase64Url(parts[1])
-        ?: return SupabaseResult.Failure(SupabaseError(message = "Invalid JWT payload encoding"))
+    val payload =
+        decodeBase64Url(parts[1])
+            ?: return SupabaseResult.Failure(SupabaseError(message = "Invalid JWT payload encoding"))
     return try {
         val element = Json.parseToJsonElement(payload)
-        val claims = element as? JsonObject
-            ?: return SupabaseResult.Failure(SupabaseError(message = "JWT payload is not a JSON object"))
+        val claims =
+            element as? JsonObject
+                ?: return SupabaseResult.Failure(SupabaseError(message = "JWT payload is not a JSON object"))
         SupabaseResult.Success(claims)
     } catch (e: Throwable) {
         if (e is CancellationException) throw e
@@ -719,22 +740,24 @@ public fun parseJwtClaims(jwt: String): SupabaseResult<JsonObject> {
 }
 
 public fun SessionManager.parseCurrentSessionJwtClaims(): SupabaseResult<JsonObject> {
-    val token = accessToken
-        ?: return SupabaseResult.Failure(SupabaseError(message = "No active session"))
+    val token =
+        accessToken
+            ?: return SupabaseResult.Failure(SupabaseError(message = "No active session"))
     return parseJwtClaims(token)
 }
 
 private fun decodeBase64Url(input: String): String? {
-    val normalized = input
-        .replace('-', '+')
-        .replace('_', '/')
-        .let {
-            when (it.length % 4) {
-                2 -> "$it=="
-                3 -> "$it="
-                else -> it
+    val normalized =
+        input
+            .replace('-', '+')
+            .replace('_', '/')
+            .let {
+                when (it.length % 4) {
+                    2 -> "$it=="
+                    3 -> "$it="
+                    else -> it
+                }
             }
-        }
     val table = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/"
     val output = ArrayList<Byte>((normalized.length * 3) / 4)
     var i = 0

--- a/supabase-auth/src/commonMain/kotlin/io/github/androidpoet/supabase/auth/AuthClientImpl.kt
+++ b/supabase-auth/src/commonMain/kotlin/io/github/androidpoet/supabase/auth/AuthClientImpl.kt
@@ -1,18 +1,18 @@
 package io.github.androidpoet.supabase.auth
-import io.github.androidpoet.supabase.auth.models.AuthenticatorAssuranceLevel
+import dev.whyoleg.cryptography.random.CryptographyRandom
 import io.github.androidpoet.supabase.auth.models.AnonymousSignInRequest
+import io.github.androidpoet.supabase.auth.models.AuthenticatorAssuranceLevel
 import io.github.androidpoet.supabase.auth.models.ExchangeCodeRequest
 import io.github.androidpoet.supabase.auth.models.IdTokenRequest
+import io.github.androidpoet.supabase.auth.models.LinkIdentityResponse
 import io.github.androidpoet.supabase.auth.models.MfaChallengeResponse
 import io.github.androidpoet.supabase.auth.models.MfaEnrollRequest
 import io.github.androidpoet.supabase.auth.models.MfaEnrollResponse
-import io.github.androidpoet.supabase.auth.models.MfaFactor
 import io.github.androidpoet.supabase.auth.models.MfaFactorType
 import io.github.androidpoet.supabase.auth.models.MfaListFactorsResponse
 import io.github.androidpoet.supabase.auth.models.MfaUnenrollResponse
 import io.github.androidpoet.supabase.auth.models.MfaVerifyRequest
 import io.github.androidpoet.supabase.auth.models.MfaVerifyResponse
-import io.github.androidpoet.supabase.auth.models.LinkIdentityResponse
 import io.github.androidpoet.supabase.auth.models.OAuthAuthorizationDetails
 import io.github.androidpoet.supabase.auth.models.OAuthConsentRequest
 import io.github.androidpoet.supabase.auth.models.OAuthGrant
@@ -21,8 +21,8 @@ import io.github.androidpoet.supabase.auth.models.OAuthRedirect
 import io.github.androidpoet.supabase.auth.models.OAuthResponse
 import io.github.androidpoet.supabase.auth.models.OtpRequest
 import io.github.androidpoet.supabase.auth.models.OtpType
-import io.github.androidpoet.supabase.auth.models.OtpVerifyResult
 import io.github.androidpoet.supabase.auth.models.OtpVerifyRequest
+import io.github.androidpoet.supabase.auth.models.OtpVerifyResult
 import io.github.androidpoet.supabase.auth.models.Passkey
 import io.github.androidpoet.supabase.auth.models.PasskeyAuthenticationOptionsRequest
 import io.github.androidpoet.supabase.auth.models.PasskeyAuthenticationOptionsResponse
@@ -54,7 +54,7 @@ import io.github.androidpoet.supabase.core.util.urlEncode
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.decodeFromJsonElement
-import dev.whyoleg.cryptography.random.CryptographyRandom
+
 internal class AuthClientImpl(
     private val client: SupabaseClient,
 ) : AuthClient {
@@ -67,6 +67,7 @@ internal class AuthClientImpl(
         val body = defaultJson.encodeToString(SignUpRequest(email = email, password = password, data = data))
         return client.post("/auth/v1/signup", body = body).deserialize()
     }
+
     override suspend fun signUpWithPhone(
         phone: String,
         password: String,
@@ -76,6 +77,7 @@ internal class AuthClientImpl(
         val body = defaultJson.encodeToString(SignUpRequest(phone = phone, password = password, data = data))
         return client.post("/auth/v1/signup", body = body).deserialize()
     }
+
     override suspend fun signInWithEmail(
         email: String,
         password: String,
@@ -83,18 +85,21 @@ internal class AuthClientImpl(
         val body = defaultJson.encodeToString(SignInRequest(email = email, password = password))
         return client.post("/auth/v1/token?grant_type=password", body = body).deserialize()
     }
+
     override suspend fun signInAnonymously(
         data: JsonObject?,
         captchaToken: String?,
     ): SupabaseResult<Session> {
-        val body = defaultJson.encodeToString(
-            AnonymousSignInRequest(
-                data = data,
-                captchaToken = captchaToken,
-            ),
-        )
+        val body =
+            defaultJson.encodeToString(
+                AnonymousSignInRequest(
+                    data = data,
+                    captchaToken = captchaToken,
+                ),
+            )
         return client.post("/auth/v1/signup", body = body).deserialize()
     }
+
     override suspend fun signInWithPhone(
         phone: String,
         password: String,
@@ -102,6 +107,7 @@ internal class AuthClientImpl(
         val body = defaultJson.encodeToString(SignInRequest(phone = phone, password = password))
         return client.post("/auth/v1/token?grant_type=password", body = body).deserialize()
     }
+
     override suspend fun signInWithIdToken(
         provider: OAuthProvider,
         idToken: String,
@@ -109,33 +115,37 @@ internal class AuthClientImpl(
         nonce: String?,
         captchaToken: String?,
     ): SupabaseResult<Session> {
-        val body = defaultJson.encodeToString(
-            IdTokenRequest(
-                idToken = idToken,
-                provider = provider.value,
-                accessToken = accessToken,
-                nonce = nonce,
-                captchaToken = captchaToken,
-            ),
-        )
+        val body =
+            defaultJson.encodeToString(
+                IdTokenRequest(
+                    idToken = idToken,
+                    provider = provider.value,
+                    accessToken = accessToken,
+                    nonce = nonce,
+                    captchaToken = captchaToken,
+                ),
+            )
         return client.post("/auth/v1/token?grant_type=id_token", body = body).deserialize()
     }
+
     override suspend fun signInWithWeb3(
         chain: Web3Chain,
         message: String,
         signature: String,
         captchaToken: String?,
     ): SupabaseResult<Session> {
-        val body = defaultJson.encodeToString(
-            Web3SignInRequest(
-                chain = chain,
-                message = message,
-                signature = signature,
-                captchaToken = captchaToken,
-            ),
-        )
+        val body =
+            defaultJson.encodeToString(
+                Web3SignInRequest(
+                    chain = chain,
+                    message = message,
+                    signature = signature,
+                    captchaToken = captchaToken,
+                ),
+            )
         return client.post("/auth/v1/token?grant_type=web3", body = body).deserialize()
     }
+
     override suspend fun signInWithOtp(
         email: String?,
         phone: String?,
@@ -143,17 +153,19 @@ internal class AuthClientImpl(
         captchaToken: String?,
         emailRedirectTo: String?,
     ): SupabaseResult<Unit> {
-        val body = defaultJson.encodeToString(
-            OtpRequest(
-                email = email,
-                phone = phone,
-                createUser = createUser,
-                captchaToken = captchaToken,
-                emailRedirectTo = emailRedirectTo,
-            ),
-        )
+        val body =
+            defaultJson.encodeToString(
+                OtpRequest(
+                    email = email,
+                    phone = phone,
+                    createUser = createUser,
+                    captchaToken = captchaToken,
+                    emailRedirectTo = emailRedirectTo,
+                ),
+            )
         return client.post("/auth/v1/otp", body = body).map { }
     }
+
     override suspend fun verifyOtp(
         email: String?,
         phone: String?,
@@ -161,31 +173,35 @@ internal class AuthClientImpl(
         type: OtpType,
         captchaToken: String?,
     ): SupabaseResult<Session> {
-        val body = defaultJson.encodeToString(
-            OtpVerifyRequest(
-                email = email,
-                phone = phone,
-                token = token,
-                type = type,
-                captchaToken = captchaToken,
-            ),
-        )
+        val body =
+            defaultJson.encodeToString(
+                OtpVerifyRequest(
+                    email = email,
+                    phone = phone,
+                    token = token,
+                    type = type,
+                    captchaToken = captchaToken,
+                ),
+            )
         return client.post("/auth/v1/verify", body = body).deserialize()
     }
+
     override suspend fun verifyOtpWithTokenHash(
         tokenHash: String,
         type: OtpType,
         captchaToken: String?,
     ): SupabaseResult<Session> {
-        val body = defaultJson.encodeToString(
-            OtpVerifyRequest(
-                tokenHash = tokenHash,
-                type = type,
-                captchaToken = captchaToken,
-            ),
-        )
+        val body =
+            defaultJson.encodeToString(
+                OtpVerifyRequest(
+                    tokenHash = tokenHash,
+                    type = type,
+                    captchaToken = captchaToken,
+                ),
+            )
         return client.post("/auth/v1/verify", body = body).deserialize()
     }
+
     override suspend fun verifyOtpWithResult(
         email: String?,
         phone: String?,
@@ -193,122 +209,144 @@ internal class AuthClientImpl(
         type: OtpType,
         captchaToken: String?,
     ): SupabaseResult<OtpVerifyResult> {
-        val body = defaultJson.encodeToString(
-            OtpVerifyRequest(
-                email = email,
-                phone = phone,
-                token = token,
-                type = type,
-                captchaToken = captchaToken,
-            ),
-        )
+        val body =
+            defaultJson.encodeToString(
+                OtpVerifyRequest(
+                    email = email,
+                    phone = phone,
+                    token = token,
+                    type = type,
+                    captchaToken = captchaToken,
+                ),
+            )
         return verifyOtpResultFromRawResponse(client.post("/auth/v1/verify", body = body))
     }
+
     override suspend fun verifyOtpWithTokenHashWithResult(
         tokenHash: String,
         type: OtpType,
         captchaToken: String?,
     ): SupabaseResult<OtpVerifyResult> {
-        val body = defaultJson.encodeToString(
-            OtpVerifyRequest(
-                tokenHash = tokenHash,
-                type = type,
-                captchaToken = captchaToken,
-            ),
-        )
+        val body =
+            defaultJson.encodeToString(
+                OtpVerifyRequest(
+                    tokenHash = tokenHash,
+                    type = type,
+                    captchaToken = captchaToken,
+                ),
+            )
         return verifyOtpResultFromRawResponse(client.post("/auth/v1/verify", body = body))
     }
+
     override suspend fun resendEmailOtp(
         type: OtpType,
         email: String,
         captchaToken: String?,
         redirectTo: String?,
     ): SupabaseResult<Unit> {
-        val body = defaultJson.encodeToString(
-            ResendOtpRequest(
-                type = type,
-                email = email,
-                captchaToken = captchaToken,
-                redirectTo = redirectTo,
-            ),
-        )
+        val body =
+            defaultJson.encodeToString(
+                ResendOtpRequest(
+                    type = type,
+                    email = email,
+                    captchaToken = captchaToken,
+                    redirectTo = redirectTo,
+                ),
+            )
         return client.post("/auth/v1/resend", body = body).map { }
     }
+
     override suspend fun resendPhoneOtp(
         type: OtpType,
         phone: String,
         captchaToken: String?,
     ): SupabaseResult<Unit> {
-        val body = defaultJson.encodeToString(
-            ResendOtpRequest(
-                type = type,
-                phone = phone,
-                captchaToken = captchaToken,
-            ),
-        )
+        val body =
+            defaultJson.encodeToString(
+                ResendOtpRequest(
+                    type = type,
+                    phone = phone,
+                    captchaToken = captchaToken,
+                ),
+            )
         return client.post("/auth/v1/resend", body = body).map { }
     }
+
     override suspend fun resetPasswordForEmail(
         email: String,
         redirectTo: String?,
         captchaToken: String?,
     ): SupabaseResult<Unit> {
-        val body = defaultJson.encodeToString(
-            OtpRequest(
-                email = email,
-                createUser = false,
-                captchaToken = captchaToken,
-            ),
-        )
-        val endpoint = buildString {
-            append("/auth/v1/recover")
-            if (redirectTo != null) {
-                append("?redirect_to=")
-                append(urlEncode(redirectTo))
+        val body =
+            defaultJson.encodeToString(
+                OtpRequest(
+                    email = email,
+                    createUser = false,
+                    captchaToken = captchaToken,
+                ),
+            )
+        val endpoint =
+            buildString {
+                append("/auth/v1/recover")
+                if (redirectTo != null) {
+                    append("?redirect_to=")
+                    append(urlEncode(redirectTo))
+                }
             }
-        }
         return client.post(endpoint = endpoint, body = body).map { }
     }
+
     override suspend fun reauthenticate(accessToken: String): SupabaseResult<Unit> =
-        client.get(
-            endpoint = "/auth/v1/reauthenticate",
-            headers = bearerHeaders(accessToken),
-        ).map { }
+        client
+            .get(
+                endpoint = "/auth/v1/reauthenticate",
+                headers = bearerHeaders(accessToken),
+            ).map { }
+
     override suspend fun refreshToken(refreshToken: String): SupabaseResult<Session> {
         val body = defaultJson.encodeToString(RefreshTokenRequest(refreshToken = refreshToken))
         return client.post("/auth/v1/token?grant_type=refresh_token", body = body).deserialize()
     }
+
     override suspend fun getUser(accessToken: String): SupabaseResult<User> =
-        client.get(
-            endpoint = "/auth/v1/user",
-            headers = bearerHeaders(accessToken),
-        ).deserialize()
+        client
+            .get(
+                endpoint = "/auth/v1/user",
+                headers = bearerHeaders(accessToken),
+            ).deserialize()
+
     override suspend fun getUserIdentities(accessToken: String): SupabaseResult<List<UserIdentity>> =
         when (val result = getUser(accessToken = accessToken)) {
             is SupabaseResult.Failure -> result
             is SupabaseResult.Success -> SupabaseResult.Success(result.value.identities ?: emptyList())
         }
+
     override suspend fun updateUser(
         accessToken: String,
         updates: UserUpdateRequest,
     ): SupabaseResult<User> {
         val body = defaultJson.encodeToString(updates)
-        return client.patch(
-            endpoint = "/auth/v1/user",
-            body = body,
-            headers = bearerHeaders(accessToken),
-        ).deserialize()
+        return client
+            .patch(
+                endpoint = "/auth/v1/user",
+                body = body,
+                headers = bearerHeaders(accessToken),
+            ).deserialize()
     }
+
     override suspend fun signOut(accessToken: String): SupabaseResult<Unit> =
         signOut(accessToken = accessToken, scope = SignOutScope.LOCAL)
+
     override suspend fun signOut(
         accessToken: String,
         scope: SignOutScope,
     ): SupabaseResult<Unit> =
-        client.post(
-            endpoint = "/auth/v1/logout?scope=${scope.name.lowercase()}",
-            headers = bearerHeaders(accessToken),
-        ).map { }
+        client
+            .post(
+                endpoint = "/auth/v1/logout?scope=${scope.name.lowercase()}",
+                headers = bearerHeaders(accessToken),
+            ).map { }
+
     override suspend fun linkIdentity(
         accessToken: String,
         provider: OAuthProvider,
@@ -316,26 +354,28 @@ internal class AuthClientImpl(
         scopes: List<String>,
         queryParams: Map<String, String>,
     ): SupabaseResult<LinkIdentityResponse> {
-        val endpoint = buildString {
-            append("/auth/v1/user/identities/authorize?provider=")
-            append(provider.value)
-            if (redirectTo != null) {
-                append("&redirect_to=")
-                append(urlEncode(redirectTo))
+        val endpoint =
+            buildString {
+                append("/auth/v1/user/identities/authorize?provider=")
+                append(provider.value)
+                if (redirectTo != null) {
+                    append("&redirect_to=")
+                    append(urlEncode(redirectTo))
+                }
+                if (scopes.isNotEmpty()) {
+                    append("&scopes=")
+                    append(urlEncode(scopes.joinToString(" ")))
+                }
+                for ((key, value) in queryParams) {
+                    append("&")
+                    append(urlEncode(key))
+                    append("=")
+                    append(urlEncode(value))
+                }
             }
-            if (scopes.isNotEmpty()) {
-                append("&scopes=")
-                append(urlEncode(scopes.joinToString(" ")))
-            }
-            for ((key, value) in queryParams) {
-                append("&")
-                append(urlEncode(key))
-                append("=")
-                append(urlEncode(value))
-            }
-        }
         return client.get(endpoint = endpoint, headers = bearerHeaders(accessToken)).deserialize()
     }
+
     override suspend fun linkIdentityWithIdToken(
         accessToken: String,
         provider: OAuthProvider,
@@ -343,29 +383,34 @@ internal class AuthClientImpl(
         providerAccessToken: String?,
         nonce: String?,
     ): SupabaseResult<Session> {
-        val body = defaultJson.encodeToString(
-            IdTokenRequest(
-                idToken = idToken,
-                provider = provider.value,
-                accessToken = providerAccessToken,
-                nonce = nonce,
-                linkIdentity = true,
-            ),
-        )
-        return client.post(
-            endpoint = "/auth/v1/token?grant_type=id_token",
-            body = body,
-            headers = bearerHeaders(accessToken),
-        ).deserialize()
+        val body =
+            defaultJson.encodeToString(
+                IdTokenRequest(
+                    idToken = idToken,
+                    provider = provider.value,
+                    accessToken = providerAccessToken,
+                    nonce = nonce,
+                    linkIdentity = true,
+                ),
+            )
+        return client
+            .post(
+                endpoint = "/auth/v1/token?grant_type=id_token",
+                body = body,
+                headers = bearerHeaders(accessToken),
+            ).deserialize()
     }
+
     override suspend fun unlinkIdentity(
         accessToken: String,
         identityId: String,
     ): SupabaseResult<Unit> =
-        client.delete(
-            endpoint = "/auth/v1/user/identities/$identityId",
-            headers = bearerHeaders(accessToken),
-        ).map { }
+        client
+            .delete(
+                endpoint = "/auth/v1/user/identities/$identityId",
+                headers = bearerHeaders(accessToken),
+            ).map { }
+
     override suspend fun retrieveSsoUrl(
         accessToken: String?,
         domain: String?,
@@ -376,19 +421,22 @@ internal class AuthClientImpl(
         val hasProviderId = !providerId.isNullOrBlank()
         require(hasDomain || hasProviderId) { "domain or providerId must be provided" }
         require(!(hasDomain && hasProviderId)) { "either domain or providerId must be set, not both" }
-        val body = defaultJson.encodeToString(
-            SsoRequest(
-                domain = domain,
-                providerId = providerId,
-                redirectTo = redirectTo,
-            ),
-        )
-        return client.post(
-            endpoint = "/auth/v1/sso",
-            body = body,
-            headers = accessToken?.let(::bearerHeaders).orEmpty(),
-        ).deserialize()
+        val body =
+            defaultJson.encodeToString(
+                SsoRequest(
+                    domain = domain,
+                    providerId = providerId,
+                    redirectTo = redirectTo,
+                ),
+            )
+        return client
+            .post(
+                endpoint = "/auth/v1/sso",
+                body = body,
+                headers = accessToken?.let(::bearerHeaders).orEmpty(),
+            ).deserialize()
     }
+
     override fun getOAuthSignInUrl(
         provider: OAuthProvider,
         redirectTo: String?,
@@ -396,34 +444,36 @@ internal class AuthClientImpl(
         queryParams: Map<String, String>,
         skipBrowserRedirect: Boolean,
         pkceParams: PkceParams?,
-    ): String = buildString {
-        append(client.projectUrl)
-        append("/auth/v1/authorize?provider=")
-        append(provider.value)
-        if (redirectTo != null) {
-            append("&redirect_to=")
-            append(urlEncode(redirectTo))
+    ): String =
+        buildString {
+            append(client.projectUrl)
+            append("/auth/v1/authorize?provider=")
+            append(provider.value)
+            if (redirectTo != null) {
+                append("&redirect_to=")
+                append(urlEncode(redirectTo))
+            }
+            if (scopes.isNotEmpty()) {
+                append("&scopes=")
+                append(urlEncode(scopes.joinToString(" ")))
+            }
+            if (pkceParams != null) {
+                append("&code_challenge=")
+                append(urlEncode(pkceParams.codeChallenge))
+                append("&code_challenge_method=")
+                append(pkceParams.codeChallengeMethod)
+            }
+            if (skipBrowserRedirect) {
+                append("&skip_http_redirect=true")
+            }
+            for ((key, value) in queryParams) {
+                append("&")
+                append(urlEncode(key))
+                append("=")
+                append(urlEncode(value))
+            }
         }
-        if (scopes.isNotEmpty()) {
-            append("&scopes=")
-            append(urlEncode(scopes.joinToString(" ")))
-        }
-        if (pkceParams != null) {
-            append("&code_challenge=")
-            append(urlEncode(pkceParams.codeChallenge))
-            append("&code_challenge_method=")
-            append(pkceParams.codeChallengeMethod)
-        }
-        if (skipBrowserRedirect) {
-            append("&skip_http_redirect=true")
-        }
-        for ((key, value) in queryParams) {
-            append("&")
-            append(urlEncode(key))
-            append("=")
-            append(urlEncode(value))
-        }
-    }
+
     override suspend fun signInWithOAuth(
         provider: OAuthProvider,
         redirectTo: String?,
@@ -435,24 +485,27 @@ internal class AuthClientImpl(
         SupabaseResult.Success(
             OAuthResponse(
                 provider = provider.value,
-                url = getOAuthSignInUrl(
-                    provider = provider,
-                    redirectTo = redirectTo,
-                    scopes = scopes,
-                    queryParams = queryParams,
-                    skipBrowserRedirect = skipBrowserRedirect,
-                    pkceParams = pkceParams,
-                ),
+                url =
+                    getOAuthSignInUrl(
+                        provider = provider,
+                        redirectTo = redirectTo,
+                        scopes = scopes,
+                        queryParams = queryParams,
+                        skipBrowserRedirect = skipBrowserRedirect,
+                        pkceParams = pkceParams,
+                    ),
             ),
         )
+
     override fun generatePkceParams(sha256: ((ByteArray) -> ByteArray)?): PkceParams {
         // PKCE verifiers are security tokens and MUST be drawn from a
         // cryptographically secure RNG (RFC 7636 §7.1), not kotlin.random.Random.
-        val verifier = buildString(PKCE_VERIFIER_LENGTH) {
-            repeat(PKCE_VERIFIER_LENGTH) {
-                append(PKCE_ALPHABET[CryptographyRandom.nextInt(PKCE_ALPHABET.length)])
+        val verifier =
+            buildString(PKCE_VERIFIER_LENGTH) {
+                repeat(PKCE_VERIFIER_LENGTH) {
+                    append(PKCE_ALPHABET[CryptographyRandom.nextInt(PKCE_ALPHABET.length)])
+                }
             }
-        }
         return if (sha256 != null) {
             val hash = sha256(verifier.encodeToByteArray())
             val challenge = base64UrlEncode(hash)
@@ -469,15 +522,18 @@ internal class AuthClientImpl(
             )
         }
     }
+
     override suspend fun exchangeCodeForSession(
         authCode: String,
         codeVerifier: String,
     ): SupabaseResult<Session> {
-        val body = defaultJson.encodeToString(
-            ExchangeCodeRequest(authCode = authCode, codeVerifier = codeVerifier),
-        )
+        val body =
+            defaultJson.encodeToString(
+                ExchangeCodeRequest(authCode = authCode, codeVerifier = codeVerifier),
+            )
         return client.post("/auth/v1/token?grant_type=pkce", body = body).deserialize()
     }
+
     override suspend fun mfaEnroll(
         factorType: MfaFactorType,
         friendlyName: String?,
@@ -485,62 +541,74 @@ internal class AuthClientImpl(
         phone: String?,
         accessToken: String,
     ): SupabaseResult<MfaEnrollResponse> {
-        val body = defaultJson.encodeToString(
-            MfaEnrollRequest(
-                factorType = factorType,
-                friendlyName = friendlyName,
-                issuer = issuer,
-                phone = phone,
-            ),
-        )
-        return client.post(
-            endpoint = "/auth/v1/factors",
-            body = body,
-            headers = bearerHeaders(accessToken),
-        ).deserialize()
+        val body =
+            defaultJson.encodeToString(
+                MfaEnrollRequest(
+                    factorType = factorType,
+                    friendlyName = friendlyName,
+                    issuer = issuer,
+                    phone = phone,
+                ),
+            )
+        return client
+            .post(
+                endpoint = "/auth/v1/factors",
+                body = body,
+                headers = bearerHeaders(accessToken),
+            ).deserialize()
     }
+
     override suspend fun mfaChallenge(
         factorId: String,
         accessToken: String,
     ): SupabaseResult<MfaChallengeResponse> =
-        client.post(
-            endpoint = "/auth/v1/factors/$factorId/challenge",
-            headers = bearerHeaders(accessToken),
-        ).deserialize()
+        client
+            .post(
+                endpoint = "/auth/v1/factors/$factorId/challenge",
+                headers = bearerHeaders(accessToken),
+            ).deserialize()
+
     override suspend fun mfaVerify(
         factorId: String,
         challengeId: String,
         code: String,
         accessToken: String,
     ): SupabaseResult<MfaVerifyResponse> {
-        val body = defaultJson.encodeToString(
-            MfaVerifyRequest(
-                factorId = factorId,
-                challengeId = challengeId,
-                code = code,
-            ),
-        )
-        return client.post(
-            endpoint = "/auth/v1/factors/$factorId/verify",
-            body = body,
-            headers = bearerHeaders(accessToken),
-        ).deserialize()
+        val body =
+            defaultJson.encodeToString(
+                MfaVerifyRequest(
+                    factorId = factorId,
+                    challengeId = challengeId,
+                    code = code,
+                ),
+            )
+        return client
+            .post(
+                endpoint = "/auth/v1/factors/$factorId/verify",
+                body = body,
+                headers = bearerHeaders(accessToken),
+            ).deserialize()
     }
+
     override suspend fun mfaUnenroll(
         factorId: String,
         accessToken: String,
     ): SupabaseResult<MfaUnenrollResponse> =
-        client.delete(
-            endpoint = "/auth/v1/factors/$factorId",
-            headers = bearerHeaders(accessToken),
-        ).deserialize()
+        client
+            .delete(
+                endpoint = "/auth/v1/factors/$factorId",
+                headers = bearerHeaders(accessToken),
+            ).deserialize()
+
     override suspend fun mfaListFactors(
         accessToken: String,
     ): SupabaseResult<MfaListFactorsResponse> {
-        val userResult: SupabaseResult<User> = client.get(
-            endpoint = "/auth/v1/user",
-            headers = bearerHeaders(accessToken),
-        ).deserialize()
+        val userResult: SupabaseResult<User> =
+            client
+                .get(
+                    endpoint = "/auth/v1/user",
+                    headers = bearerHeaders(accessToken),
+                ).deserialize()
         return when (userResult) {
             is SupabaseResult.Success -> {
                 val factors = userResult.value.factors.orEmpty()
@@ -556,22 +624,26 @@ internal class AuthClientImpl(
             is SupabaseResult.Failure -> SupabaseResult.Failure(userResult.error)
         }
     }
+
     override suspend fun mfaGetAuthenticatorAssuranceLevel(
         accessToken: String,
     ): SupabaseResult<AuthenticatorAssuranceLevel> {
-        val userResult: SupabaseResult<User> = client.get(
-            endpoint = "/auth/v1/user",
-            headers = bearerHeaders(accessToken),
-        ).deserialize()
+        val userResult: SupabaseResult<User> =
+            client
+                .get(
+                    endpoint = "/auth/v1/user",
+                    headers = bearerHeaders(accessToken),
+                ).deserialize()
         return when (userResult) {
             is SupabaseResult.Success -> {
                 val factors = userResult.value.factors.orEmpty()
                 val hasVerifiedFactor = factors.any { it.status == "verified" }
-                val level = if (hasVerifiedFactor) {
-                    AuthenticatorAssuranceLevel.AAL2
-                } else {
-                    AuthenticatorAssuranceLevel.AAL1
-                }
+                val level =
+                    if (hasVerifiedFactor) {
+                        AuthenticatorAssuranceLevel.AAL2
+                    } else {
+                        AuthenticatorAssuranceLevel.AAL1
+                    }
                 SupabaseResult.Success(level)
             }
             is SupabaseResult.Failure -> SupabaseResult.Failure(userResult.error)
@@ -581,57 +653,64 @@ internal class AuthClientImpl(
     override suspend fun passkeyStartRegistration(
         accessToken: String,
     ): SupabaseResult<PasskeyRegistrationOptionsResponse> =
-        client.post(
-            endpoint = "/auth/v1/passkeys/registration/options",
-            body = "{}",
-            headers = bearerHeaders(accessToken),
-        ).deserialize()
+        client
+            .post(
+                endpoint = "/auth/v1/passkeys/registration/options",
+                body = "{}",
+                headers = bearerHeaders(accessToken),
+            ).deserialize()
 
     override suspend fun passkeyVerifyRegistration(
         accessToken: String,
         challengeId: String,
         credential: JsonObject,
     ): SupabaseResult<PasskeyMetadata> {
-        val body = defaultJson.encodeToString(
-            PasskeyVerifyRequest(challengeId = challengeId, credential = credential),
-        )
-        return client.post(
-            endpoint = "/auth/v1/passkeys/registration/verify",
-            body = body,
-            headers = bearerHeaders(accessToken),
-        ).deserialize()
+        val body =
+            defaultJson.encodeToString(
+                PasskeyVerifyRequest(challengeId = challengeId, credential = credential),
+            )
+        return client
+            .post(
+                endpoint = "/auth/v1/passkeys/registration/verify",
+                body = body,
+                headers = bearerHeaders(accessToken),
+            ).deserialize()
     }
 
     override suspend fun passkeyStartAuthentication(
         captchaToken: String?,
     ): SupabaseResult<PasskeyAuthenticationOptionsResponse> {
         val body = defaultJson.encodeToString(PasskeyAuthenticationOptionsRequest(captchaToken = captchaToken))
-        return client.post(
-            endpoint = "/auth/v1/passkeys/authentication/options",
-            body = body,
-        ).deserialize()
+        return client
+            .post(
+                endpoint = "/auth/v1/passkeys/authentication/options",
+                body = body,
+            ).deserialize()
     }
 
     override suspend fun passkeyVerifyAuthentication(
         challengeId: String,
         credential: JsonObject,
     ): SupabaseResult<Session> {
-        val body = defaultJson.encodeToString(
-            PasskeyVerifyRequest(challengeId = challengeId, credential = credential),
-        )
-        return client.post(
-            endpoint = "/auth/v1/passkeys/authentication/verify",
-            body = body,
-        ).deserialize()
+        val body =
+            defaultJson.encodeToString(
+                PasskeyVerifyRequest(challengeId = challengeId, credential = credential),
+            )
+        return client
+            .post(
+                endpoint = "/auth/v1/passkeys/authentication/verify",
+                body = body,
+            ).deserialize()
     }
 
     override suspend fun passkeyList(
         accessToken: String,
     ): SupabaseResult<List<Passkey>> =
-        client.get(
-            endpoint = "/auth/v1/passkeys",
-            headers = bearerHeaders(accessToken),
-        ).deserialize()
+        client
+            .get(
+                endpoint = "/auth/v1/passkeys",
+                headers = bearerHeaders(accessToken),
+            ).deserialize()
 
     override suspend fun passkeyUpdate(
         accessToken: String,
@@ -639,30 +718,33 @@ internal class AuthClientImpl(
         friendlyName: String,
     ): SupabaseResult<Passkey> {
         val body = defaultJson.encodeToString(PasskeyUpdateRequest(friendlyName = friendlyName))
-        return client.patch(
-            endpoint = "/auth/v1/passkeys/$passkeyId",
-            body = body,
-            headers = bearerHeaders(accessToken),
-        ).deserialize()
+        return client
+            .patch(
+                endpoint = "/auth/v1/passkeys/$passkeyId",
+                body = body,
+                headers = bearerHeaders(accessToken),
+            ).deserialize()
     }
 
     override suspend fun passkeyDelete(
         accessToken: String,
         passkeyId: String,
     ): SupabaseResult<Unit> =
-        client.delete(
-            endpoint = "/auth/v1/passkeys/$passkeyId",
-            headers = bearerHeaders(accessToken),
-        ).map { }
+        client
+            .delete(
+                endpoint = "/auth/v1/passkeys/$passkeyId",
+                headers = bearerHeaders(accessToken),
+            ).map { }
 
     override suspend fun oauthGetAuthorizationDetails(
         accessToken: String,
         authorizationId: String,
     ): SupabaseResult<OAuthAuthorizationDetails> =
-        client.get(
-            endpoint = "/auth/v1/oauth/authorizations/$authorizationId",
-            headers = bearerHeaders(accessToken),
-        ).deserialize()
+        client
+            .get(
+                endpoint = "/auth/v1/oauth/authorizations/$authorizationId",
+                headers = bearerHeaders(accessToken),
+            ).deserialize()
 
     override suspend fun oauthApproveAuthorization(
         accessToken: String,
@@ -679,19 +761,21 @@ internal class AuthClientImpl(
     override suspend fun oauthListGrants(
         accessToken: String,
     ): SupabaseResult<List<OAuthGrant>> =
-        client.get(
-            endpoint = "/auth/v1/user/oauth/grants",
-            headers = bearerHeaders(accessToken),
-        ).deserialize()
+        client
+            .get(
+                endpoint = "/auth/v1/user/oauth/grants",
+                headers = bearerHeaders(accessToken),
+            ).deserialize()
 
     override suspend fun oauthRevokeGrant(
         accessToken: String,
         clientId: String,
     ): SupabaseResult<Unit> =
-        client.delete(
-            endpoint = "/auth/v1/user/oauth/grants?client_id=${urlEncode(clientId)}",
-            headers = bearerHeaders(accessToken),
-        ).map { }
+        client
+            .delete(
+                endpoint = "/auth/v1/user/oauth/grants?client_id=${urlEncode(clientId)}",
+                headers = bearerHeaders(accessToken),
+            ).map { }
 
     private suspend fun oauthConsent(
         accessToken: String,
@@ -699,12 +783,14 @@ internal class AuthClientImpl(
         action: String,
     ): SupabaseResult<OAuthRedirect> {
         val body = defaultJson.encodeToString(OAuthConsentRequest(action = action))
-        return client.post(
-            endpoint = "/auth/v1/oauth/authorizations/$authorizationId/consent",
-            body = body,
-            headers = bearerHeaders(accessToken),
-        ).deserialize()
+        return client
+            .post(
+                endpoint = "/auth/v1/oauth/authorizations/$authorizationId/consent",
+                body = body,
+                headers = bearerHeaders(accessToken),
+            ).deserialize()
     }
+
     private fun bearerHeaders(token: String): Map<String, String> =
         mapOf("Authorization" to "Bearer $token")
 
@@ -712,11 +798,13 @@ internal class AuthClientImpl(
         when (response) {
             is SupabaseResult.Failure -> SupabaseResult.Failure(response.error)
             is SupabaseResult.Success -> {
-                val element = runCatching { defaultJson.parseToJsonElement(response.value) }.getOrElse {
-                    return SupabaseResult.Failure(SupabaseError(message = "Invalid verify response: ${it.message}"))
-                }
-                val obj = element as? JsonObject
-                    ?: return SupabaseResult.Failure(SupabaseError(message = "Invalid verify response shape"))
+                val element =
+                    runCatching { defaultJson.parseToJsonElement(response.value) }.getOrElse {
+                        return SupabaseResult.Failure(SupabaseError(message = "Invalid verify response: ${it.message}"))
+                    }
+                val obj =
+                    element as? JsonObject
+                        ?: return SupabaseResult.Failure(SupabaseError(message = "Invalid verify response shape"))
                 if ("access_token" in obj) {
                     runCatching {
                         defaultJson.decodeFromJsonElement<Session>(obj)
@@ -731,6 +819,7 @@ internal class AuthClientImpl(
                 }
             }
         }
+
     private fun base64UrlEncode(bytes: ByteArray): String {
         val table = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_"
         return buildString {
@@ -755,6 +844,7 @@ internal class AuthClientImpl(
             }
         }
     }
+
     private companion object {
         const val PKCE_ALPHABET = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-._~"
         const val PKCE_VERIFIER_LENGTH = 43

--- a/supabase-auth/src/commonMain/kotlin/io/github/androidpoet/supabase/auth/models/AuthModels.kt
+++ b/supabase-auth/src/commonMain/kotlin/io/github/androidpoet/supabase/auth/models/AuthModels.kt
@@ -2,6 +2,7 @@ package io.github.androidpoet.supabase.auth.models
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.JsonObject
+
 @Serializable
 public data class Session(
     @SerialName("access_token") val accessToken: String,
@@ -10,6 +11,7 @@ public data class Session(
     @SerialName("token_type") val tokenType: String,
     val user: User,
 )
+
 @Serializable
 public data class User(
     val id: String,
@@ -31,6 +33,7 @@ public data class UserIdentity(
     @SerialName("user_id") val userId: String? = null,
     @SerialName("identity_data") val identityData: JsonObject? = null,
 )
+
 @Serializable
 public data class SignUpRequest(
     val email: String? = null,
@@ -38,12 +41,14 @@ public data class SignUpRequest(
     val password: String,
     val data: JsonObject? = null,
 )
+
 @Serializable
 public data class SignInRequest(
     val email: String? = null,
     val phone: String? = null,
     val password: String,
 )
+
 @Serializable
 public data class IdTokenRequest(
     @SerialName("id_token") val idToken: String,
@@ -59,6 +64,7 @@ public data class AnonymousSignInRequest(
     val data: JsonObject? = null,
     @SerialName("captcha_token") val captchaToken: String? = null,
 )
+
 @Serializable
 public data class OtpRequest(
     val email: String? = null,
@@ -67,6 +73,7 @@ public data class OtpRequest(
     @SerialName("captcha_token") val captchaToken: String? = null,
     @SerialName("email_redirect_to") val emailRedirectTo: String? = null,
 )
+
 @Serializable
 public data class OtpVerifyRequest(
     val email: String? = null,
@@ -78,9 +85,13 @@ public data class OtpVerifyRequest(
 )
 
 public sealed interface OtpVerifyResult {
-    public data class Authenticated(public val session: Session) : OtpVerifyResult
+    public data class Authenticated(
+        public val session: Session,
+    ) : OtpVerifyResult
+
     public data object VerifiedNoSession : OtpVerifyResult
 }
+
 @Serializable
 public data class ResendOtpRequest(
     val type: OtpType,
@@ -89,19 +100,33 @@ public data class ResendOtpRequest(
     @SerialName("captcha_token") val captchaToken: String? = null,
     @SerialName("redirect_to") val redirectTo: String? = null,
 )
+
 @Serializable
 public enum class OtpType {
-    @SerialName("sms") SMS,
-    @SerialName("email") EMAIL,
-    @SerialName("recovery") RECOVERY,
-    @SerialName("invite") INVITE,
-    @SerialName("email_change") EMAIL_CHANGE,
-    @SerialName("phone_change") PHONE_CHANGE,
+    @SerialName("sms")
+    SMS,
+
+    @SerialName("email")
+    EMAIL,
+
+    @SerialName("recovery")
+    RECOVERY,
+
+    @SerialName("invite")
+    INVITE,
+
+    @SerialName("email_change")
+    EMAIL_CHANGE,
+
+    @SerialName("phone_change")
+    PHONE_CHANGE,
 }
+
 @Serializable
 public data class RefreshTokenRequest(
     @SerialName("refresh_token") val refreshToken: String,
 )
+
 @Serializable
 public data class UserUpdateRequest(
     val email: String? = null,
@@ -111,11 +136,17 @@ public data class UserUpdateRequest(
     val data: JsonObject? = null,
     val nonce: String? = null,
 )
+
 @Serializable
 public enum class SignOutScope {
-    @SerialName("global") GLOBAL,
-    @SerialName("local") LOCAL,
-    @SerialName("others") OTHERS,
+    @SerialName("global")
+    GLOBAL,
+
+    @SerialName("local")
+    LOCAL,
+
+    @SerialName("others")
+    OTHERS,
 }
 
 @Serializable
@@ -135,48 +166,94 @@ public data class SsoRequest(
 public data class SsoResponse(
     @SerialName("url") public val url: String,
 )
+
 @Serializable
-public enum class OAuthProvider(@SerialName("value") public val value: String) {
-    @SerialName("google") GOOGLE("google"),
-    @SerialName("apple") APPLE("apple"),
-    @SerialName("github") GITHUB("github"),
-    @SerialName("gitlab") GITLAB("gitlab"),
-    @SerialName("bitbucket") BITBUCKET("bitbucket"),
-    @SerialName("discord") DISCORD("discord"),
-    @SerialName("facebook") FACEBOOK("facebook"),
-    @SerialName("twitter") TWITTER("twitter"),
-    @SerialName("slack") SLACK("slack"),
-    @SerialName("spotify") SPOTIFY("spotify"),
-    @SerialName("twitch") TWITCH("twitch"),
-    @SerialName("azure") AZURE("azure"),
-    @SerialName("keycloak") KEYCLOAK("keycloak"),
-    @SerialName("linkedin_oidc") LINKEDIN("linkedin_oidc"),
-    @SerialName("notion") NOTION("notion"),
-    @SerialName("zoom") ZOOM("zoom"),
-    @SerialName("figma") FIGMA("figma"),
+public enum class OAuthProvider(
+    @SerialName("value") public val value: String,
+) {
+    @SerialName("google")
+    GOOGLE("google"),
+
+    @SerialName("apple")
+    APPLE("apple"),
+
+    @SerialName("github")
+    GITHUB("github"),
+
+    @SerialName("gitlab")
+    GITLAB("gitlab"),
+
+    @SerialName("bitbucket")
+    BITBUCKET("bitbucket"),
+
+    @SerialName("discord")
+    DISCORD("discord"),
+
+    @SerialName("facebook")
+    FACEBOOK("facebook"),
+
+    @SerialName("twitter")
+    TWITTER("twitter"),
+
+    @SerialName("slack")
+    SLACK("slack"),
+
+    @SerialName("spotify")
+    SPOTIFY("spotify"),
+
+    @SerialName("twitch")
+    TWITCH("twitch"),
+
+    @SerialName("azure")
+    AZURE("azure"),
+
+    @SerialName("keycloak")
+    KEYCLOAK("keycloak"),
+
+    @SerialName("linkedin_oidc")
+    LINKEDIN("linkedin_oidc"),
+
+    @SerialName("notion")
+    NOTION("notion"),
+
+    @SerialName("zoom")
+    ZOOM("zoom"),
+
+    @SerialName("figma")
+    FIGMA("figma"),
 }
+
 @Serializable
 public data class OAuthResponse(
     @SerialName("url") public val url: String,
     @SerialName("provider") public val provider: String,
 )
+
 @Serializable
 public data class PkceParams(
     public val codeVerifier: String,
     public val codeChallenge: String,
     public val codeChallengeMethod: String = "S256",
 )
+
 @Serializable
 public data class ExchangeCodeRequest(
     @SerialName("auth_code") public val authCode: String,
     @SerialName("code_verifier") public val codeVerifier: String,
 )
+
 @Serializable
 public enum class MfaFactorType {
-    @SerialName("totp") TOTP,
-    @SerialName("phone") PHONE,
-    @SerialName("webauthn") WEBAUTHN,
+    @SerialName("totp")
+    TOTP,
+
+    @SerialName("phone")
+    PHONE,
+
+    @SerialName("webauthn")
+    WEBAUTHN,
 }
+
 @Serializable
 public data class MfaEnrollRequest(
     @SerialName("factor_type") public val factorType: MfaFactorType,
@@ -184,6 +261,7 @@ public data class MfaEnrollRequest(
     @SerialName("issuer") public val issuer: String? = null,
     @SerialName("phone") public val phone: String? = null,
 )
+
 @Serializable
 public data class MfaEnrollResponse(
     @SerialName("id") public val id: String,
@@ -192,28 +270,33 @@ public data class MfaEnrollResponse(
     @SerialName("friendly_name") public val friendlyName: String? = null,
     @SerialName("phone") public val phone: String? = null,
 )
+
 @Serializable
 public data class MfaTotpDetails(
     @SerialName("qr_code") public val qrCode: String,
     @SerialName("secret") public val secret: String,
     @SerialName("uri") public val uri: String,
 )
+
 @Serializable
 public data class MfaChallengeRequest(
     @SerialName("factor_id") public val factorId: String,
 )
+
 @Serializable
 public data class MfaChallengeResponse(
     @SerialName("id") public val id: String,
     @SerialName("factor_id") public val factorId: String,
     @SerialName("expires_at") public val expiresAt: Long? = null,
 )
+
 @Serializable
 public data class MfaVerifyRequest(
     @SerialName("factor_id") public val factorId: String,
     @SerialName("challenge_id") public val challengeId: String,
     @SerialName("code") public val code: String,
 )
+
 @Serializable
 public data class MfaVerifyResponse(
     @SerialName("access_token") public val accessToken: String,
@@ -222,15 +305,21 @@ public data class MfaVerifyResponse(
     @SerialName("expires_in") public val expiresIn: Long,
     @SerialName("user") public val user: User,
 )
+
 @Serializable
 public data class MfaUnenrollResponse(
     @SerialName("id") public val id: String,
 )
+
 @Serializable
 public enum class AuthenticatorAssuranceLevel {
-    @SerialName("aal1") AAL1,
-    @SerialName("aal2") AAL2,
+    @SerialName("aal1")
+    AAL1,
+
+    @SerialName("aal2")
+    AAL2,
 }
+
 @Serializable
 public data class MfaListFactorsResponse(
     @SerialName("all") public val all: List<MfaFactor>,
@@ -238,6 +327,7 @@ public data class MfaListFactorsResponse(
     @SerialName("phone") public val phone: List<MfaFactor>,
     @SerialName("webauthn") public val webauthn: List<MfaFactor> = emptyList(),
 )
+
 @Serializable
 public data class MfaFactor(
     @SerialName("id") public val id: String,
@@ -320,8 +410,11 @@ public data class OAuthConsentRequest(
 
 @Serializable
 public enum class Web3Chain {
-    @SerialName("ethereum") ETHEREUM,
-    @SerialName("solana") SOLANA,
+    @SerialName("ethereum")
+    ETHEREUM,
+
+    @SerialName("solana")
+    SOLANA,
 }
 
 @Serializable

--- a/supabase-auth/src/commonMain/kotlin/io/github/androidpoet/supabase/auth/session/InMemorySessionStorage.kt
+++ b/supabase-auth/src/commonMain/kotlin/io/github/androidpoet/supabase/auth/session/InMemorySessionStorage.kt
@@ -1,11 +1,15 @@
 package io.github.androidpoet.supabase.auth.session
 import io.github.androidpoet.supabase.auth.models.Session
+
 public class InMemorySessionStorage : SessionStorage {
     private var stored: Session? = null
+
     override suspend fun save(session: Session) {
         stored = session
     }
+
     override suspend fun load(): Session? = stored
+
     override suspend fun clear() {
         stored = null
     }

--- a/supabase-auth/src/commonMain/kotlin/io/github/androidpoet/supabase/auth/session/KeyValueSessionStorage.kt
+++ b/supabase-auth/src/commonMain/kotlin/io/github/androidpoet/supabase/auth/session/KeyValueSessionStorage.kt
@@ -12,7 +12,9 @@ import kotlinx.serialization.json.Json
  */
 public interface KeyValueStore {
     public suspend fun get(key: String): String?
+
     public suspend fun set(key: String, value: String)
+
     public suspend fun remove(key: String)
 }
 

--- a/supabase-auth/src/commonMain/kotlin/io/github/androidpoet/supabase/auth/session/SessionConfig.kt
+++ b/supabase-auth/src/commonMain/kotlin/io/github/androidpoet/supabase/auth/session/SessionConfig.kt
@@ -1,4 +1,5 @@
 package io.github.androidpoet.supabase.auth.session
+
 public data class SessionConfig(
     public val autoRefresh: Boolean = true,
     public val refreshBufferSeconds: Long = 60,

--- a/supabase-auth/src/commonMain/kotlin/io/github/androidpoet/supabase/auth/session/SessionManager.kt
+++ b/supabase-auth/src/commonMain/kotlin/io/github/androidpoet/supabase/auth/session/SessionManager.kt
@@ -2,17 +2,27 @@ package io.github.androidpoet.supabase.auth.session
 import io.github.androidpoet.supabase.auth.models.Session
 import io.github.androidpoet.supabase.core.result.SupabaseResult
 import kotlinx.coroutines.flow.StateFlow
+
 public interface SessionManager {
     public val sessionState: StateFlow<SessionState>
     public val currentSession: Session?
     public val accessToken: String?
+
     public suspend fun saveSession(session: Session)
+
     public suspend fun clearSession()
+
     public suspend fun refreshSession(): SupabaseResult<Session>
+
     public suspend fun restoreSession(): SupabaseResult<Session>
+
     public suspend fun initialize(): SupabaseResult<Session>
+
     public fun startAutoRefresh()
+
     public fun stopAutoRefresh()
+
     public fun dispose()
+
     public fun close()
 }

--- a/supabase-auth/src/commonMain/kotlin/io/github/androidpoet/supabase/auth/session/SessionManagerExt.kt
+++ b/supabase-auth/src/commonMain/kotlin/io/github/androidpoet/supabase/auth/session/SessionManagerExt.kt
@@ -20,17 +20,18 @@ public fun SessionManager.onAuthStateChange(
     scope: CoroutineScope,
     emitInitialSession: Boolean = true,
     callback: suspend (event: AuthStateChangeEvent, session: Session?) -> Unit,
-): Job = scope.launch {
-    var previousState = sessionState.value
-    if (emitInitialSession) {
-        callback(AuthStateChangeEvent.INITIAL_SESSION, previousState.sessionOrNull())
+): Job =
+    scope.launch {
+        var previousState = sessionState.value
+        if (emitInitialSession) {
+            callback(AuthStateChangeEvent.INITIAL_SESSION, previousState.sessionOrNull())
+        }
+        sessionState.drop(1).collect { state ->
+            val event = state.toAuthStateChangeEvent(previousState) ?: return@collect
+            previousState = state
+            callback(event, state.sessionOrNull())
+        }
     }
-    sessionState.drop(1).collect { state ->
-        val event = state.toAuthStateChangeEvent(previousState) ?: return@collect
-        previousState = state
-        callback(event, state.sessionOrNull())
-    }
-}
 
 private fun SessionState.sessionOrNull(): Session? =
     when (this) {

--- a/supabase-auth/src/commonMain/kotlin/io/github/androidpoet/supabase/auth/session/SessionManagerImpl.kt
+++ b/supabase-auth/src/commonMain/kotlin/io/github/androidpoet/supabase/auth/session/SessionManagerImpl.kt
@@ -19,6 +19,7 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import kotlin.concurrent.Volatile
+
 internal class SessionManagerImpl(
     private val authClient: AuthClient,
     private val supabaseClient: SupabaseClient,
@@ -48,23 +49,28 @@ internal class SessionManagerImpl(
 
     @Volatile
     private var inFlightRefresh: Deferred<SupabaseResult<Session>>? = null
+
     override suspend fun saveSession(session: Session) {
         storage.save(session)
         _sessionState.value = SessionState.Authenticated(session)
         supabaseClient.setAccessToken(session.accessToken)
         scheduleRefresh(session)
     }
+
     override suspend fun clearSession() {
         cancelRefresh()
         storage.clear()
         _sessionState.value = SessionState.NotAuthenticated
         supabaseClient.clearAccessToken()
     }
+
     override suspend fun refreshSession(): SupabaseResult<Session> {
-        val current = currentSession
-            ?: return SupabaseResult.Failure(SupabaseError(message = "No active session to refresh"))
+        val current =
+            currentSession
+                ?: return SupabaseResult.Failure(SupabaseError(message = "No active session to refresh"))
         return dedupedRefresh(current)
     }
+
     override suspend fun restoreSession(): SupabaseResult<Session> {
         _sessionState.value = SessionState.Loading
         val stored = storage.load()
@@ -76,9 +82,10 @@ internal class SessionManagerImpl(
     }
 
     private suspend fun dedupedRefresh(session: Session): SupabaseResult<Session> {
-        val deferred = refreshMutex.withLock {
-            inFlightRefresh ?: scope.async { handleRefresh(session) }.also { inFlightRefresh = it }
-        }
+        val deferred =
+            refreshMutex.withLock {
+                inFlightRefresh ?: scope.async { handleRefresh(session) }.also { inFlightRefresh = it }
+            }
         return try {
             deferred.await()
         } finally {
@@ -87,6 +94,7 @@ internal class SessionManagerImpl(
             }
         }
     }
+
     override suspend fun initialize(): SupabaseResult<Session> =
         restoreSession()
 
@@ -108,6 +116,7 @@ internal class SessionManagerImpl(
         cancelRefresh()
         scope.cancel()
     }
+
     private suspend fun handleRefresh(session: Session): SupabaseResult<Session> =
         when (val result = authClient.refreshToken(session.refreshToken)) {
             is SupabaseResult.Success -> {
@@ -118,16 +127,19 @@ internal class SessionManagerImpl(
                 _sessionState.value = SessionState.Expired(session)
                 result
             }
-    }
+        }
+
     private fun scheduleRefresh(session: Session) {
         if (!autoRefreshEnabled) return
         cancelRefresh()
         val delayMs = maxOf((session.expiresIn - refreshBufferSeconds) * 1000L, 0L)
-        refreshJob = scope.launch {
-            delay(delayMs)
-            refreshSession()
-        }
+        refreshJob =
+            scope.launch {
+                delay(delayMs)
+                refreshSession()
+            }
     }
+
     private fun cancelRefresh() {
         refreshJob?.cancel()
         refreshJob = null

--- a/supabase-auth/src/commonMain/kotlin/io/github/androidpoet/supabase/auth/session/SessionState.kt
+++ b/supabase-auth/src/commonMain/kotlin/io/github/androidpoet/supabase/auth/session/SessionState.kt
@@ -1,8 +1,16 @@
 package io.github.androidpoet.supabase.auth.session
 import io.github.androidpoet.supabase.auth.models.Session
+
 public sealed interface SessionState {
     public data object NotAuthenticated : SessionState
+
     public data object Loading : SessionState
-    public data class Authenticated(public val session: Session) : SessionState
-    public data class Expired(public val lastSession: Session) : SessionState
+
+    public data class Authenticated(
+        public val session: Session,
+    ) : SessionState
+
+    public data class Expired(
+        public val lastSession: Session,
+    ) : SessionState
 }

--- a/supabase-auth/src/commonMain/kotlin/io/github/androidpoet/supabase/auth/session/SessionStorage.kt
+++ b/supabase-auth/src/commonMain/kotlin/io/github/androidpoet/supabase/auth/session/SessionStorage.kt
@@ -1,7 +1,10 @@
 package io.github.androidpoet.supabase.auth.session
 import io.github.androidpoet.supabase.auth.models.Session
+
 public interface SessionStorage {
     public suspend fun save(session: Session)
+
     public suspend fun load(): Session?
+
     public suspend fun clear()
 }

--- a/supabase-auth/src/commonTest/kotlin/io/github/androidpoet/supabase/auth/AuthClientExtTest.kt
+++ b/supabase-auth/src/commonTest/kotlin/io/github/androidpoet/supabase/auth/AuthClientExtTest.kt
@@ -8,29 +8,31 @@ import io.github.androidpoet.supabase.auth.models.MfaFactorType
 import io.github.androidpoet.supabase.auth.models.MfaListFactorsResponse
 import io.github.androidpoet.supabase.auth.models.MfaUnenrollResponse
 import io.github.androidpoet.supabase.auth.models.MfaVerifyResponse
+import io.github.androidpoet.supabase.auth.models.OAuthAuthorizationDetails
+import io.github.androidpoet.supabase.auth.models.OAuthGrant
 import io.github.androidpoet.supabase.auth.models.OAuthProvider
+import io.github.androidpoet.supabase.auth.models.OAuthRedirect
+import io.github.androidpoet.supabase.auth.models.OAuthResponse
 import io.github.androidpoet.supabase.auth.models.OtpType
 import io.github.androidpoet.supabase.auth.models.OtpVerifyResult
 import io.github.androidpoet.supabase.auth.models.Passkey
 import io.github.androidpoet.supabase.auth.models.PasskeyAuthenticationOptionsResponse
 import io.github.androidpoet.supabase.auth.models.PasskeyMetadata
 import io.github.androidpoet.supabase.auth.models.PasskeyRegistrationOptionsResponse
-import io.github.androidpoet.supabase.auth.models.OAuthAuthorizationDetails
-import io.github.androidpoet.supabase.auth.models.OAuthGrant
-import io.github.androidpoet.supabase.auth.models.OAuthRedirect
-import io.github.androidpoet.supabase.auth.models.OAuthResponse
 import io.github.androidpoet.supabase.auth.models.PkceParams
 import io.github.androidpoet.supabase.auth.models.Session
 import io.github.androidpoet.supabase.auth.models.SignOutScope
 import io.github.androidpoet.supabase.auth.models.SsoResponse
-import io.github.androidpoet.supabase.auth.models.UserIdentity
 import io.github.androidpoet.supabase.auth.models.User
+import io.github.androidpoet.supabase.auth.models.UserIdentity
 import io.github.androidpoet.supabase.auth.models.UserUpdateRequest
 import io.github.androidpoet.supabase.auth.models.Web3Chain
 import io.github.androidpoet.supabase.auth.session.SessionManager
 import io.github.androidpoet.supabase.auth.session.SessionState
 import io.github.androidpoet.supabase.core.result.SupabaseError
 import io.github.androidpoet.supabase.core.result.SupabaseResult
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.test.runTest
 import kotlinx.serialization.json.JsonObject
 import kotlin.test.Test
@@ -38,219 +40,245 @@ import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
-import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.StateFlow
 
 class AuthClientExtTest {
     @Test
-    fun test_signUp_alias_routesToEmailSignup() = runTest {
-        val auth = FakeAuthClient()
+    fun test_signUp_alias_routesToEmailSignup() =
+        runTest {
+            val auth = FakeAuthClient()
 
-        auth.signUp(email = "a@b.com", password = "secret")
+            auth.signUp(email = "a@b.com", password = "secret")
 
-        assertEquals("a@b.com", auth.lastEmailSignUp)
-    }
-
-    @Test
-    fun test_signIn_alias_routesToEmailSignIn() = runTest {
-        val auth = FakeAuthClient()
-
-        auth.signIn(email = "a@b.com", password = "secret")
-
-        assertEquals("a@b.com", auth.lastEmailSignIn)
-    }
+            assertEquals("a@b.com", auth.lastEmailSignUp)
+        }
 
     @Test
-    fun test_signUpPhone_alias_routesToPhoneSignup() = runTest {
-        val auth = FakeAuthClient()
+    fun test_signIn_alias_routesToEmailSignIn() =
+        runTest {
+            val auth = FakeAuthClient()
 
-        auth.signUpPhone(phone = "+10000000000", password = "secret")
+            auth.signIn(email = "a@b.com", password = "secret")
 
-        assertEquals("+10000000000", auth.lastPhoneSignUp)
-    }
-
-    @Test
-    fun test_forgotPassword_alias_routesToResetPassword() = runTest {
-        val auth = FakeAuthClient()
-
-        val result = auth.forgotPassword(email = "a@b.com")
-
-        assertTrue(result is SupabaseResult.Success)
-        assertEquals("a@b.com", auth.lastResetPasswordEmail)
-    }
+            assertEquals("a@b.com", auth.lastEmailSignIn)
+        }
 
     @Test
-    fun test_resendSignUpEmailOtp_routesWithEmailType() = runTest {
-        val auth = FakeAuthClient()
+    fun test_signUpPhone_alias_routesToPhoneSignup() =
+        runTest {
+            val auth = FakeAuthClient()
 
-        auth.resendSignUpEmailOtp(email = "a@b.com")
+            auth.signUpPhone(phone = "+10000000000", password = "secret")
 
-        assertEquals(OtpType.EMAIL, auth.lastResendEmailType)
-        assertEquals("a@b.com", auth.lastResendEmail)
-    }
-
-    @Test
-    fun test_verifyEmailSignUpOtp_usesEmailOtpType() = runTest {
-        val auth = FakeAuthClient()
-
-        auth.verifyEmailSignUpOtp(email = "a@b.com", token = "123456")
-
-        assertEquals(OtpType.EMAIL, auth.lastVerifyOtpType)
-    }
+            assertEquals("+10000000000", auth.lastPhoneSignUp)
+        }
 
     @Test
-    fun test_signOutGlobal_usesGlobalScope() = runTest {
-        val auth = FakeAuthClient()
+    fun test_forgotPassword_alias_routesToResetPassword() =
+        runTest {
+            val auth = FakeAuthClient()
 
-        auth.signOutGlobal("token-1")
+            val result = auth.forgotPassword(email = "a@b.com")
 
-        assertEquals(SignOutScope.GLOBAL, auth.lastSignOutScope)
-    }
-
-    @Test
-    fun test_verifyEmailSignUpOtpWithResult_usesEmailOtpType() = runTest {
-        val auth = FakeAuthClient()
-
-        auth.verifyEmailSignUpOtpWithResult(email = "a@b.com", token = "123456")
-
-        assertEquals(OtpType.EMAIL, auth.lastVerifyOtpWithResultType)
-    }
+            assertTrue(result is SupabaseResult.Success)
+            assertEquals("a@b.com", auth.lastResetPasswordEmail)
+        }
 
     @Test
-    fun test_verifyPhoneSignInOtpWithResult_usesSmsOtpType() = runTest {
-        val auth = FakeAuthClient()
+    fun test_resendSignUpEmailOtp_routesWithEmailType() =
+        runTest {
+            val auth = FakeAuthClient()
 
-        auth.verifyPhoneSignInOtpWithResult(phone = "+10000000000", token = "123456")
+            auth.resendSignUpEmailOtp(email = "a@b.com")
 
-        assertEquals(OtpType.SMS, auth.lastVerifyOtpWithResultType)
-    }
-
-    @Test
-    fun test_verifyEmailOtpWithTokenHashWithResult_routesToTokenHashApi() = runTest {
-        val auth = FakeAuthClient()
-
-        auth.verifyEmailOtpWithTokenHashWithResult(
-            tokenHash = "hash-1",
-            type = OtpType.RECOVERY,
-        )
-
-        assertEquals("hash-1", auth.lastVerifyOtpTokenHashWithResult)
-    }
+            assertEquals(OtpType.EMAIL, auth.lastResendEmailType)
+            assertEquals("a@b.com", auth.lastResendEmail)
+        }
 
     @Test
-    fun test_verifyOtpWithResultAndSaveSession_savesWhenAuthenticated() = runTest {
-        val auth = FakeAuthClient().apply {
-            verifyWithResultValue = OtpVerifyResult.Authenticated(
-                dummySession.copy(accessToken = "otp-result-acc", refreshToken = "otp-result-ref"),
+    fun test_verifyEmailSignUpOtp_usesEmailOtpType() =
+        runTest {
+            val auth = FakeAuthClient()
+
+            auth.verifyEmailSignUpOtp(email = "a@b.com", token = "123456")
+
+            assertEquals(OtpType.EMAIL, auth.lastVerifyOtpType)
+        }
+
+    @Test
+    fun test_signOutGlobal_usesGlobalScope() =
+        runTest {
+            val auth = FakeAuthClient()
+
+            auth.signOutGlobal("token-1")
+
+            assertEquals(SignOutScope.GLOBAL, auth.lastSignOutScope)
+        }
+
+    @Test
+    fun test_verifyEmailSignUpOtpWithResult_usesEmailOtpType() =
+        runTest {
+            val auth = FakeAuthClient()
+
+            auth.verifyEmailSignUpOtpWithResult(email = "a@b.com", token = "123456")
+
+            assertEquals(OtpType.EMAIL, auth.lastVerifyOtpWithResultType)
+        }
+
+    @Test
+    fun test_verifyPhoneSignInOtpWithResult_usesSmsOtpType() =
+        runTest {
+            val auth = FakeAuthClient()
+
+            auth.verifyPhoneSignInOtpWithResult(phone = "+10000000000", token = "123456")
+
+            assertEquals(OtpType.SMS, auth.lastVerifyOtpWithResultType)
+        }
+
+    @Test
+    fun test_verifyEmailOtpWithTokenHashWithResult_routesToTokenHashApi() =
+        runTest {
+            val auth = FakeAuthClient()
+
+            auth.verifyEmailOtpWithTokenHashWithResult(
+                tokenHash = "hash-1",
+                type = OtpType.RECOVERY,
             )
+
+            assertEquals("hash-1", auth.lastVerifyOtpTokenHashWithResult)
         }
-        val sessionManager = FakeSessionManager()
-
-        val result = auth.verifyOtpWithResultAndSaveSession(
-            sessionManager = sessionManager,
-            email = "a@b.com",
-            token = "123456",
-            type = OtpType.EMAIL,
-        )
-
-        assertTrue(result is SupabaseResult.Success)
-        assertEquals("otp-result-acc", sessionManager.currentSession?.accessToken)
-    }
 
     @Test
-    fun test_verifyOtpWithResultAndSaveSession_doesNotSaveWhenNoSession() = runTest {
-        val auth = FakeAuthClient().apply {
-            verifyWithResultValue = OtpVerifyResult.VerifiedNoSession
+    fun test_verifyOtpWithResultAndSaveSession_savesWhenAuthenticated() =
+        runTest {
+            val auth =
+                FakeAuthClient().apply {
+                    verifyWithResultValue =
+                        OtpVerifyResult.Authenticated(
+                            dummySession.copy(accessToken = "otp-result-acc", refreshToken = "otp-result-ref"),
+                        )
+                }
+            val sessionManager = FakeSessionManager()
+
+            val result =
+                auth.verifyOtpWithResultAndSaveSession(
+                    sessionManager = sessionManager,
+                    email = "a@b.com",
+                    token = "123456",
+                    type = OtpType.EMAIL,
+                )
+
+            assertTrue(result is SupabaseResult.Success)
+            assertEquals("otp-result-acc", sessionManager.currentSession?.accessToken)
         }
-        val sessionManager = FakeSessionManager()
-
-        val result = auth.verifyOtpWithResultAndSaveSession(
-            sessionManager = sessionManager,
-            email = "a@b.com",
-            token = "123456",
-            type = OtpType.EMAIL,
-        )
-
-        assertTrue(result is SupabaseResult.Success)
-        assertTrue(sessionManager.currentSession == null)
-    }
 
     @Test
-    fun test_getUserForCurrentSession_updatesStoredSessionWhenRequested() = runTest {
-        val auth = FakeAuthClient()
-        val sessionManager = FakeSessionManager(
-            session = auth.dummySession.copy(
-                accessToken = "token-123",
-                user = auth.dummySession.user.copy(email = "old@b.com"),
-            ),
-        )
+    fun test_verifyOtpWithResultAndSaveSession_doesNotSaveWhenNoSession() =
+        runTest {
+            val auth =
+                FakeAuthClient().apply {
+                    verifyWithResultValue = OtpVerifyResult.VerifiedNoSession
+                }
+            val sessionManager = FakeSessionManager()
 
-        val result = auth.getUserForCurrentSession(
-            sessionManager = sessionManager,
-            updateStoredSession = true,
-        )
+            val result =
+                auth.verifyOtpWithResultAndSaveSession(
+                    sessionManager = sessionManager,
+                    email = "a@b.com",
+                    token = "123456",
+                    type = OtpType.EMAIL,
+                )
 
-        assertTrue(result is SupabaseResult.Success)
-        assertEquals("token-123", auth.lastGetUserAccessToken)
-        assertEquals("updated@b.com", sessionManager.currentSession?.user?.email)
-    }
-
-    @Test
-    fun test_reauthenticateCurrentSession_usesCurrentAccessToken() = runTest {
-        val auth = FakeAuthClient()
-        val sessionManager = FakeSessionManager(session = auth.dummySession.copy(accessToken = "token-reauth"))
-
-        val result = auth.reauthenticateCurrentSession(sessionManager)
-
-        assertTrue(result is SupabaseResult.Success)
-        assertEquals("token-reauth", auth.lastReauthenticateAccessToken)
-    }
+            assertTrue(result is SupabaseResult.Success)
+            assertTrue(sessionManager.currentSession == null)
+        }
 
     @Test
-    fun test_signOutCurrentSession_clearsStoredSessionOnSuccess() = runTest {
-        val auth = FakeAuthClient()
-        val sessionManager = FakeSessionManager(session = auth.dummySession.copy(accessToken = "token-signout"))
+    fun test_getUserForCurrentSession_updatesStoredSessionWhenRequested() =
+        runTest {
+            val auth = FakeAuthClient()
+            val sessionManager =
+                FakeSessionManager(
+                    session =
+                        auth.dummySession.copy(
+                            accessToken = "token-123",
+                            user = auth.dummySession.user.copy(email = "old@b.com"),
+                        ),
+                )
 
-        val result = auth.signOutCurrentSession(
-            sessionManager = sessionManager,
-            scope = SignOutScope.OTHERS,
-            clearStoredSessionOnSuccess = true,
-        )
+            val result =
+                auth.getUserForCurrentSession(
+                    sessionManager = sessionManager,
+                    updateStoredSession = true,
+                )
 
-        assertTrue(result is SupabaseResult.Success)
-        assertEquals("token-signout", auth.lastSignOutAccessToken)
-        assertEquals(SignOutScope.OTHERS, auth.lastSignOutScope)
-        assertFalse(sessionManager.wasAuthenticated)
-    }
-
-    @Test
-    fun test_signOutCurrentSession_withoutSession_succeedsByDefault() = runTest {
-        val auth = FakeAuthClient()
-        val sessionManager = FakeSessionManager()
-
-        val result = auth.signOutCurrentSession(sessionManager = sessionManager)
-
-        assertTrue(result is SupabaseResult.Success)
-    }
+            assertTrue(result is SupabaseResult.Success)
+            assertEquals("token-123", auth.lastGetUserAccessToken)
+            assertEquals("updated@b.com", sessionManager.currentSession?.user?.email)
+        }
 
     @Test
-    fun test_signOutCurrentSession_withoutSession_canFailWhenStrict() = runTest {
-        val auth = FakeAuthClient()
-        val sessionManager = FakeSessionManager()
+    fun test_reauthenticateCurrentSession_usesCurrentAccessToken() =
+        runTest {
+            val auth = FakeAuthClient()
+            val sessionManager = FakeSessionManager(session = auth.dummySession.copy(accessToken = "token-reauth"))
 
-        val result = auth.signOutCurrentSession(
-            sessionManager = sessionManager,
-            succeedIfNoSession = false,
-        )
+            val result = auth.reauthenticateCurrentSession(sessionManager)
 
-        assertTrue(result is SupabaseResult.Failure)
-    }
+            assertTrue(result is SupabaseResult.Success)
+            assertEquals("token-reauth", auth.lastReauthenticateAccessToken)
+        }
+
+    @Test
+    fun test_signOutCurrentSession_clearsStoredSessionOnSuccess() =
+        runTest {
+            val auth = FakeAuthClient()
+            val sessionManager = FakeSessionManager(session = auth.dummySession.copy(accessToken = "token-signout"))
+
+            val result =
+                auth.signOutCurrentSession(
+                    sessionManager = sessionManager,
+                    scope = SignOutScope.OTHERS,
+                    clearStoredSessionOnSuccess = true,
+                )
+
+            assertTrue(result is SupabaseResult.Success)
+            assertEquals("token-signout", auth.lastSignOutAccessToken)
+            assertEquals(SignOutScope.OTHERS, auth.lastSignOutScope)
+            assertFalse(sessionManager.wasAuthenticated)
+        }
+
+    @Test
+    fun test_signOutCurrentSession_withoutSession_succeedsByDefault() =
+        runTest {
+            val auth = FakeAuthClient()
+            val sessionManager = FakeSessionManager()
+
+            val result = auth.signOutCurrentSession(sessionManager = sessionManager)
+
+            assertTrue(result is SupabaseResult.Success)
+        }
+
+    @Test
+    fun test_signOutCurrentSession_withoutSession_canFailWhenStrict() =
+        runTest {
+            val auth = FakeAuthClient()
+            val sessionManager = FakeSessionManager()
+
+            val result =
+                auth.signOutCurrentSession(
+                    sessionManager = sessionManager,
+                    succeedIfNoSession = false,
+                )
+
+            assertTrue(result is SupabaseResult.Failure)
+        }
 
     @Test
     fun test_parseSessionTokensFromFragment_parsesRequiredFields() {
-        val parsed = parseSessionTokensFromFragment(
-            "access_token=acc-1&refresh_token=ref-1&expires_in=3600&token_type=bearer",
-        )
+        val parsed =
+            parseSessionTokensFromFragment(
+                "access_token=acc-1&refresh_token=ref-1&expires_in=3600&token_type=bearer",
+            )
 
         assertTrue(parsed is SupabaseResult.Success)
         assertEquals("acc-1", parsed.value.accessToken)
@@ -260,41 +288,45 @@ class AuthClientExtTest {
     }
 
     @Test
-    fun test_importSessionFromUrl_retrievesUserAndSavesSession() = runTest {
-        val auth = FakeAuthClient()
-        val sessionManager = FakeSessionManager()
+    fun test_importSessionFromUrl_retrievesUserAndSavesSession() =
+        runTest {
+            val auth = FakeAuthClient()
+            val sessionManager = FakeSessionManager()
 
-        val result = auth.importSessionFromUrl(
-            url = "myapp://cb#access_token=acc-2&refresh_token=ref-2&expires_in=7200&token_type=bearer",
-            sessionManager = sessionManager,
-        )
+            val result =
+                auth.importSessionFromUrl(
+                    url = "myapp://cb#access_token=acc-2&refresh_token=ref-2&expires_in=7200&token_type=bearer",
+                    sessionManager = sessionManager,
+                )
 
-        assertTrue(result is SupabaseResult.Success)
-        assertEquals("acc-2", auth.lastGetUserAccessToken)
-        val stored = sessionManager.currentSession
-        assertNotNull(stored)
-        assertEquals("acc-2", stored.accessToken)
-        assertEquals("ref-2", stored.refreshToken)
-        assertEquals(7200L, stored.expiresIn)
-        assertEquals("updated@b.com", stored.user.email)
-    }
+            assertTrue(result is SupabaseResult.Success)
+            assertEquals("acc-2", auth.lastGetUserAccessToken)
+            val stored = sessionManager.currentSession
+            assertNotNull(stored)
+            assertEquals("acc-2", stored.accessToken)
+            assertEquals("ref-2", stored.refreshToken)
+            assertEquals(7200L, stored.expiresIn)
+            assertEquals("updated@b.com", stored.user.email)
+        }
 
     @Test
-    fun test_exchangeCodeForSessionAndSave_savesExchangedSession() = runTest {
-        val auth = FakeAuthClient()
-        val sessionManager = FakeSessionManager()
+    fun test_exchangeCodeForSessionAndSave_savesExchangedSession() =
+        runTest {
+            val auth = FakeAuthClient()
+            val sessionManager = FakeSessionManager()
 
-        val result = auth.exchangeCodeForSessionAndSave(
-            authCode = "code-1",
-            codeVerifier = "verifier-1",
-            sessionManager = sessionManager,
-        )
+            val result =
+                auth.exchangeCodeForSessionAndSave(
+                    authCode = "code-1",
+                    codeVerifier = "verifier-1",
+                    sessionManager = sessionManager,
+                )
 
-        assertTrue(result is SupabaseResult.Success)
-        assertEquals("code-1", auth.lastExchangeAuthCode)
-        assertEquals("verifier-1", auth.lastExchangeCodeVerifier)
-        assertEquals("exch-acc", sessionManager.currentSession?.accessToken)
-    }
+            assertTrue(result is SupabaseResult.Success)
+            assertEquals("code-1", auth.lastExchangeAuthCode)
+            assertEquals("verifier-1", auth.lastExchangeCodeVerifier)
+            assertEquals("exch-acc", sessionManager.currentSession?.accessToken)
+        }
 
     @Test
     fun test_parseJwtClaims_parsesPayloadObject() {
@@ -310,361 +342,418 @@ class AuthClientExtTest {
     }
 
     @Test
-    fun test_parseCurrentSessionJwtClaims_usesSessionAccessToken() = runTest {
-        val header = "eyJhbGciOiJub25lIiwidHlwIjoiSldUIn0"
-        val payload = "eyJleHAiOjE3MDAwMDAwMDAsInN1YiI6InUxIn0"
-        val jwt = "$header.$payload."
-        val sessionManager = FakeSessionManager(
-            session = FakeAuthClient().dummySession.copy(accessToken = jwt),
-        )
+    fun test_parseCurrentSessionJwtClaims_usesSessionAccessToken() =
+        runTest {
+            val header = "eyJhbGciOiJub25lIiwidHlwIjoiSldUIn0"
+            val payload = "eyJleHAiOjE3MDAwMDAwMDAsInN1YiI6InUxIn0"
+            val jwt = "$header.$payload."
+            val sessionManager =
+                FakeSessionManager(
+                    session = FakeAuthClient().dummySession.copy(accessToken = jwt),
+                )
 
-        val result = sessionManager.parseCurrentSessionJwtClaims()
+            val result = sessionManager.parseCurrentSessionJwtClaims()
 
-        assertTrue(result is SupabaseResult.Success)
-        assertEquals("u1", result.value["sub"]?.toString()?.trim('"'))
-    }
-
-    @Test
-    fun test_unlinkIdentityAndUpdateSession_removesIdentityFromStoredSession() = runTest {
-        val auth = FakeAuthClient()
-        val sessionManager = FakeSessionManager(
-            session = auth.dummySession.copy(
-                accessToken = "token-unlink",
-                user = auth.dummySession.user.copy(
-                    identities = listOf(
-                        UserIdentity(id = "i-1", provider = "google"),
-                        UserIdentity(id = "i-2", provider = "github"),
-                    ),
-                ),
-            ),
-        )
-
-        val result = auth.unlinkIdentityAndUpdateSession(
-            accessToken = "token-unlink",
-            identityId = "i-1",
-            sessionManager = sessionManager,
-            updateStoredSession = true,
-        )
-
-        assertTrue(result is SupabaseResult.Success)
-        val identities = sessionManager.currentSession?.user?.identities
-        assertNotNull(identities)
-        assertEquals(1, identities.size)
-        assertEquals("i-2", identities.first().id)
-    }
-
-    @Test
-    fun test_getUserIdentitiesForCurrentSession_usesSessionAccessToken() = runTest {
-        val auth = FakeAuthClient()
-        auth.currentUserIdentities = listOf(
-            UserIdentity(id = "provider-user-1", identityId = "identity-1", provider = "github"),
-        )
-        val sessionManager = FakeSessionManager(session = auth.dummySession.copy(accessToken = "token-identities"))
-
-        val result = auth.getUserIdentitiesForCurrentSession(sessionManager)
-
-        assertTrue(result is SupabaseResult.Success)
-        assertEquals("token-identities", auth.lastGetIdentitiesAccessToken)
-        assertEquals("identity-1", result.value.first().identityId)
-    }
-
-    @Test
-    fun test_linkIdentityForCurrentSession_usesSessionAccessToken() = runTest {
-        val auth = FakeAuthClient()
-        val sessionManager = FakeSessionManager(session = auth.dummySession.copy(accessToken = "token-link"))
-
-        val result = auth.linkIdentityForCurrentSession(
-            sessionManager = sessionManager,
-            provider = OAuthProvider.GITHUB,
-        )
-
-        assertTrue(result is SupabaseResult.Success)
-        assertEquals("token-link", auth.lastLinkIdentityAccessToken)
-        assertEquals(OAuthProvider.GITHUB, auth.lastLinkIdentityProvider)
-    }
-
-    @Test
-    fun test_linkIdentityWithIdTokenForCurrentSession_savesSessionOnSuccess() = runTest {
-        val auth = FakeAuthClient()
-        val sessionManager = FakeSessionManager(session = auth.dummySession.copy(accessToken = "token-link-id"))
-
-        val result = auth.linkIdentityWithIdTokenForCurrentSession(
-            sessionManager = sessionManager,
-            provider = OAuthProvider.GOOGLE,
-            idToken = "id-token-123",
-            providerAccessToken = "provider-token-xyz",
-            nonce = "nonce-1",
-            updateStoredSession = true,
-        )
-
-        assertTrue(result is SupabaseResult.Success)
-        assertEquals("token-link-id", auth.lastLinkIdTokenAccessToken)
-        assertEquals("id-token-123", auth.lastLinkIdTokenValue)
-        assertEquals("linked-acc", sessionManager.currentSession?.accessToken)
-    }
-
-    @Test
-    fun test_unlinkIdentityForCurrentSession_usesSessionAccessToken() = runTest {
-        val auth = FakeAuthClient()
-        val sessionManager = FakeSessionManager(
-            session = auth.dummySession.copy(
-                accessToken = "token-unlink-current",
-                user = auth.dummySession.user.copy(
-                    identities = listOf(UserIdentity(id = "i-1"), UserIdentity(id = "i-2")),
-                ),
-            ),
-        )
-
-        val result = auth.unlinkIdentityForCurrentSession(
-            sessionManager = sessionManager,
-            identityId = "i-1",
-            updateStoredSession = true,
-        )
-
-        assertTrue(result is SupabaseResult.Success)
-        assertEquals("token-unlink-current", auth.lastUnlinkAccessToken)
-        assertEquals("i-1", auth.lastUnlinkIdentityId)
-        assertEquals(listOf("i-2"), sessionManager.currentSession?.user?.identities?.map { it.id })
-    }
-
-    @Test
-    fun test_updateUserForCurrentSession_updatesStoredSession() = runTest {
-        val auth = FakeAuthClient()
-        val sessionManager = FakeSessionManager(session = auth.dummySession.copy(accessToken = "token-update-current"))
-
-        val result = auth.updateUserForCurrentSession(
-            sessionManager = sessionManager,
-            updates = UserUpdateRequest(email = "new@b.com"),
-            updateStoredSession = true,
-        )
-
-        assertTrue(result is SupabaseResult.Success)
-        assertEquals("token-update-current", auth.lastUpdateUserAccessToken)
-        assertEquals("new@b.com", sessionManager.currentSession?.user?.email)
-    }
-
-    @Test
-    fun test_refreshCurrentSession_delegatesToSessionManager() = runTest {
-        val auth = FakeAuthClient()
-        val sessionManager = FakeSessionManager(session = auth.dummySession).apply {
-            refreshResult = SupabaseResult.Success(auth.dummySession.copy(accessToken = "refreshed-token"))
+            assertTrue(result is SupabaseResult.Success)
+            assertEquals("u1", result.value["sub"]?.toString()?.trim('"'))
         }
 
-        val result = auth.refreshCurrentSession(sessionManager)
+    @Test
+    fun test_unlinkIdentityAndUpdateSession_removesIdentityFromStoredSession() =
+        runTest {
+            val auth = FakeAuthClient()
+            val sessionManager =
+                FakeSessionManager(
+                    session =
+                        auth.dummySession.copy(
+                            accessToken = "token-unlink",
+                            user =
+                                auth.dummySession.user.copy(
+                                    identities =
+                                        listOf(
+                                            UserIdentity(id = "i-1", provider = "google"),
+                                            UserIdentity(id = "i-2", provider = "github"),
+                                        ),
+                                ),
+                        ),
+                )
 
-        assertTrue(result is SupabaseResult.Success)
-        assertEquals("refreshed-token", result.value.accessToken)
-        assertTrue(sessionManager.refreshCalled)
-    }
+            val result =
+                auth.unlinkIdentityAndUpdateSession(
+                    accessToken = "token-unlink",
+                    identityId = "i-1",
+                    sessionManager = sessionManager,
+                    updateStoredSession = true,
+                )
+
+            assertTrue(result is SupabaseResult.Success)
+            val identities = sessionManager.currentSession?.user?.identities
+            assertNotNull(identities)
+            assertEquals(1, identities.size)
+            assertEquals("i-2", identities.first().id)
+        }
 
     @Test
-    fun test_importAuthToken_retrievesUserAndSavesSession() = runTest {
-        val auth = FakeAuthClient()
-        val sessionManager = FakeSessionManager()
+    fun test_getUserIdentitiesForCurrentSession_usesSessionAccessToken() =
+        runTest {
+            val auth = FakeAuthClient()
+            auth.currentUserIdentities =
+                listOf(
+                    UserIdentity(id = "provider-user-1", identityId = "identity-1", provider = "github"),
+                )
+            val sessionManager = FakeSessionManager(session = auth.dummySession.copy(accessToken = "token-identities"))
 
-        val result = auth.importAuthToken(
-            sessionManager = sessionManager,
-            accessToken = "import-acc",
-            refreshToken = "import-ref",
-            expiresIn = 1234L,
-            tokenType = "bearer",
-            retrieveUser = true,
-        )
+            val result = auth.getUserIdentitiesForCurrentSession(sessionManager)
 
-        assertTrue(result is SupabaseResult.Success)
-        assertEquals("import-acc", auth.lastGetUserAccessToken)
-        assertEquals("import-acc", sessionManager.currentSession?.accessToken)
-        assertEquals("import-ref", sessionManager.currentSession?.refreshToken)
-        assertEquals(1234L, sessionManager.currentSession?.expiresIn)
-    }
+            assertTrue(result is SupabaseResult.Success)
+            assertEquals("token-identities", auth.lastGetIdentitiesAccessToken)
+            assertEquals("identity-1", result.value.first().identityId)
+        }
 
     @Test
-    fun test_retrieveSsoUrlForCurrentSession_usesSessionAccessToken() = runTest {
-        val auth = FakeAuthClient()
-        val sessionManager = FakeSessionManager(session = auth.dummySession.copy(accessToken = "sso-token"))
+    fun test_linkIdentityForCurrentSession_usesSessionAccessToken() =
+        runTest {
+            val auth = FakeAuthClient()
+            val sessionManager = FakeSessionManager(session = auth.dummySession.copy(accessToken = "token-link"))
 
-        val result = auth.retrieveSsoUrlForCurrentSession(
-            sessionManager = sessionManager,
-            domain = "example.com",
-        )
+            val result =
+                auth.linkIdentityForCurrentSession(
+                    sessionManager = sessionManager,
+                    provider = OAuthProvider.GITHUB,
+                )
 
-        assertTrue(result is SupabaseResult.Success)
-        assertEquals("sso-token", auth.lastRetrieveSsoAccessToken)
-    }
-
-    @Test
-    fun test_signInWithEmailAndSaveSession_savesReturnedSession() = runTest {
-        val auth = FakeAuthClient()
-        val sessionManager = FakeSessionManager()
-
-        val result = auth.signInWithEmailAndSaveSession(
-            sessionManager = sessionManager,
-            email = "a@b.com",
-            password = "secret",
-        )
-
-        assertTrue(result is SupabaseResult.Success)
-        assertEquals("a@b.com", auth.lastEmailSignIn)
-        assertEquals("sign-in-acc", sessionManager.currentSession?.accessToken)
-    }
+            assertTrue(result is SupabaseResult.Success)
+            assertEquals("token-link", auth.lastLinkIdentityAccessToken)
+            assertEquals(OAuthProvider.GITHUB, auth.lastLinkIdentityProvider)
+        }
 
     @Test
-    fun test_signUpWithEmailAndSaveSession_savesReturnedSession() = runTest {
-        val auth = FakeAuthClient()
-        val sessionManager = FakeSessionManager()
+    fun test_linkIdentityWithIdTokenForCurrentSession_savesSessionOnSuccess() =
+        runTest {
+            val auth = FakeAuthClient()
+            val sessionManager = FakeSessionManager(session = auth.dummySession.copy(accessToken = "token-link-id"))
 
-        val result = auth.signUpWithEmailAndSaveSession(
-            sessionManager = sessionManager,
-            email = "a@b.com",
-            password = "secret",
-        )
+            val result =
+                auth.linkIdentityWithIdTokenForCurrentSession(
+                    sessionManager = sessionManager,
+                    provider = OAuthProvider.GOOGLE,
+                    idToken = "id-token-123",
+                    providerAccessToken = "provider-token-xyz",
+                    nonce = "nonce-1",
+                    updateStoredSession = true,
+                )
 
-        assertTrue(result is SupabaseResult.Success)
-        assertEquals("a@b.com", auth.lastEmailSignUp)
-        assertEquals("sign-up-acc", sessionManager.currentSession?.accessToken)
-    }
-
-    @Test
-    fun test_signInAnonymouslyAndSaveSession_savesReturnedSession() = runTest {
-        val auth = FakeAuthClient()
-        val sessionManager = FakeSessionManager()
-
-        val result = auth.signInAnonymouslyAndSaveSession(
-            sessionManager = sessionManager,
-            captchaToken = "captcha-1",
-        )
-
-        assertTrue(result is SupabaseResult.Success)
-        assertEquals("anon-acc", sessionManager.currentSession?.accessToken)
-    }
+            assertTrue(result is SupabaseResult.Success)
+            assertEquals("token-link-id", auth.lastLinkIdTokenAccessToken)
+            assertEquals("id-token-123", auth.lastLinkIdTokenValue)
+            assertEquals("linked-acc", sessionManager.currentSession?.accessToken)
+        }
 
     @Test
-    fun test_refreshTokenAndSaveSession_savesReturnedSession() = runTest {
-        val auth = FakeAuthClient()
-        val sessionManager = FakeSessionManager()
+    fun test_unlinkIdentityForCurrentSession_usesSessionAccessToken() =
+        runTest {
+            val auth = FakeAuthClient()
+            val sessionManager =
+                FakeSessionManager(
+                    session =
+                        auth.dummySession.copy(
+                            accessToken = "token-unlink-current",
+                            user =
+                                auth.dummySession.user.copy(
+                                    identities = listOf(UserIdentity(id = "i-1"), UserIdentity(id = "i-2")),
+                                ),
+                        ),
+                )
 
-        val result = auth.refreshTokenAndSaveSession(
-            sessionManager = sessionManager,
-            refreshToken = "refresh-1",
-        )
+            val result =
+                auth.unlinkIdentityForCurrentSession(
+                    sessionManager = sessionManager,
+                    identityId = "i-1",
+                    updateStoredSession = true,
+                )
 
-        assertTrue(result is SupabaseResult.Success)
-        assertEquals("refresh-1", auth.lastRefreshTokenInput)
-        assertEquals("refresh-acc", sessionManager.currentSession?.accessToken)
-    }
-
-    @Test
-    fun test_verifyOtpAndSaveSession_savesReturnedSession() = runTest {
-        val auth = FakeAuthClient()
-        val sessionManager = FakeSessionManager()
-
-        val result = auth.verifyOtpAndSaveSession(
-            sessionManager = sessionManager,
-            email = "a@b.com",
-            token = "123456",
-            type = OtpType.EMAIL,
-        )
-
-        assertTrue(result is SupabaseResult.Success)
-        assertEquals(OtpType.EMAIL, auth.lastVerifyOtpType)
-        assertEquals("verify-acc", sessionManager.currentSession?.accessToken)
-    }
-
-    @Test
-    fun test_signInWithPhoneAndSaveSession_savesReturnedSession() = runTest {
-        val auth = FakeAuthClient()
-        val sessionManager = FakeSessionManager()
-
-        val result = auth.signInWithPhoneAndSaveSession(
-            sessionManager = sessionManager,
-            phone = "+10000000000",
-            password = "secret",
-        )
-
-        assertTrue(result is SupabaseResult.Success)
-        assertEquals("phone-sign-in-acc", sessionManager.currentSession?.accessToken)
-    }
-
-    @Test
-    fun test_signUpWithPhoneAndSaveSession_savesReturnedSession() = runTest {
-        val auth = FakeAuthClient()
-        val sessionManager = FakeSessionManager()
-
-        val result = auth.signUpWithPhoneAndSaveSession(
-            sessionManager = sessionManager,
-            phone = "+10000000000",
-            password = "secret",
-        )
-
-        assertTrue(result is SupabaseResult.Success)
-        assertEquals("phone-sign-up-acc", sessionManager.currentSession?.accessToken)
-    }
-
-    @Test
-    fun test_signInWithIdTokenAndSaveSession_savesReturnedSession() = runTest {
-        val auth = FakeAuthClient()
-        val sessionManager = FakeSessionManager()
-
-        val result = auth.signInWithIdTokenAndSaveSession(
-            sessionManager = sessionManager,
-            provider = OAuthProvider.GOOGLE,
-            idToken = "id-token-1",
-        )
-
-        assertTrue(result is SupabaseResult.Success)
-        assertEquals("id-token-sign-in-acc", sessionManager.currentSession?.accessToken)
-    }
-
-    @Test
-    fun test_verifyOtpWithTokenHashAndSaveSession_savesReturnedSession() = runTest {
-        val auth = FakeAuthClient()
-        val sessionManager = FakeSessionManager()
-
-        val result = auth.verifyOtpWithTokenHashAndSaveSession(
-            sessionManager = sessionManager,
-            tokenHash = "hash-123",
-            type = OtpType.EMAIL,
-        )
-
-        assertTrue(result is SupabaseResult.Success)
-        assertEquals("verify-hash-acc", sessionManager.currentSession?.accessToken)
-    }
-
-    @Test
-    fun test_verifyOtpWithTokenHashWithResultAndSaveSession_savesWhenAuthenticated() = runTest {
-        val auth = FakeAuthClient().apply {
-            verifyWithResultValue = OtpVerifyResult.Authenticated(
-                dummySession.copy(accessToken = "verify-hash-result-acc", refreshToken = "verify-hash-result-ref"),
+            assertTrue(result is SupabaseResult.Success)
+            assertEquals("token-unlink-current", auth.lastUnlinkAccessToken)
+            assertEquals("i-1", auth.lastUnlinkIdentityId)
+            assertEquals(
+                listOf("i-2"),
+                sessionManager.currentSession
+                    ?.user
+                    ?.identities
+                    ?.map { it.id },
             )
         }
-        val sessionManager = FakeSessionManager()
-
-        val result = auth.verifyOtpWithTokenHashWithResultAndSaveSession(
-            sessionManager = sessionManager,
-            tokenHash = "hash-123",
-            type = OtpType.EMAIL,
-        )
-
-        assertTrue(result is SupabaseResult.Success)
-        assertEquals("verify-hash-result-acc", sessionManager.currentSession?.accessToken)
-    }
 
     @Test
-    fun test_mfaChallengeAndVerify_usesChallengeIdFromChallengeResponse() = runTest {
-        val auth = FakeAuthClient()
+    fun test_updateUserForCurrentSession_updatesStoredSession() =
+        runTest {
+            val auth = FakeAuthClient()
+            val sessionManager = FakeSessionManager(session = auth.dummySession.copy(accessToken = "token-update-current"))
 
-        val result = auth.mfaChallengeAndVerify(
-            factorId = "factor-1",
-            code = "123456",
-            accessToken = "token-mfa",
-        )
+            val result =
+                auth.updateUserForCurrentSession(
+                    sessionManager = sessionManager,
+                    updates = UserUpdateRequest(email = "new@b.com"),
+                    updateStoredSession = true,
+                )
 
-        assertTrue(result is SupabaseResult.Success)
-        assertEquals("factor-1", auth.lastMfaChallengeFactorId)
-        assertEquals("challenge-1", auth.lastMfaVerifyChallengeId)
-        assertEquals("123456", auth.lastMfaVerifyCode)
-        assertEquals("token-mfa", auth.lastMfaVerifyAccessToken)
-    }
+            assertTrue(result is SupabaseResult.Success)
+            assertEquals("token-update-current", auth.lastUpdateUserAccessToken)
+            assertEquals("new@b.com", sessionManager.currentSession?.user?.email)
+        }
+
+    @Test
+    fun test_refreshCurrentSession_delegatesToSessionManager() =
+        runTest {
+            val auth = FakeAuthClient()
+            val sessionManager =
+                FakeSessionManager(session = auth.dummySession).apply {
+                    refreshResult = SupabaseResult.Success(auth.dummySession.copy(accessToken = "refreshed-token"))
+                }
+
+            val result = auth.refreshCurrentSession(sessionManager)
+
+            assertTrue(result is SupabaseResult.Success)
+            assertEquals("refreshed-token", result.value.accessToken)
+            assertTrue(sessionManager.refreshCalled)
+        }
+
+    @Test
+    fun test_importAuthToken_retrievesUserAndSavesSession() =
+        runTest {
+            val auth = FakeAuthClient()
+            val sessionManager = FakeSessionManager()
+
+            val result =
+                auth.importAuthToken(
+                    sessionManager = sessionManager,
+                    accessToken = "import-acc",
+                    refreshToken = "import-ref",
+                    expiresIn = 1234L,
+                    tokenType = "bearer",
+                    retrieveUser = true,
+                )
+
+            assertTrue(result is SupabaseResult.Success)
+            assertEquals("import-acc", auth.lastGetUserAccessToken)
+            assertEquals("import-acc", sessionManager.currentSession?.accessToken)
+            assertEquals("import-ref", sessionManager.currentSession?.refreshToken)
+            assertEquals(1234L, sessionManager.currentSession?.expiresIn)
+        }
+
+    @Test
+    fun test_retrieveSsoUrlForCurrentSession_usesSessionAccessToken() =
+        runTest {
+            val auth = FakeAuthClient()
+            val sessionManager = FakeSessionManager(session = auth.dummySession.copy(accessToken = "sso-token"))
+
+            val result =
+                auth.retrieveSsoUrlForCurrentSession(
+                    sessionManager = sessionManager,
+                    domain = "example.com",
+                )
+
+            assertTrue(result is SupabaseResult.Success)
+            assertEquals("sso-token", auth.lastRetrieveSsoAccessToken)
+        }
+
+    @Test
+    fun test_signInWithEmailAndSaveSession_savesReturnedSession() =
+        runTest {
+            val auth = FakeAuthClient()
+            val sessionManager = FakeSessionManager()
+
+            val result =
+                auth.signInWithEmailAndSaveSession(
+                    sessionManager = sessionManager,
+                    email = "a@b.com",
+                    password = "secret",
+                )
+
+            assertTrue(result is SupabaseResult.Success)
+            assertEquals("a@b.com", auth.lastEmailSignIn)
+            assertEquals("sign-in-acc", sessionManager.currentSession?.accessToken)
+        }
+
+    @Test
+    fun test_signUpWithEmailAndSaveSession_savesReturnedSession() =
+        runTest {
+            val auth = FakeAuthClient()
+            val sessionManager = FakeSessionManager()
+
+            val result =
+                auth.signUpWithEmailAndSaveSession(
+                    sessionManager = sessionManager,
+                    email = "a@b.com",
+                    password = "secret",
+                )
+
+            assertTrue(result is SupabaseResult.Success)
+            assertEquals("a@b.com", auth.lastEmailSignUp)
+            assertEquals("sign-up-acc", sessionManager.currentSession?.accessToken)
+        }
+
+    @Test
+    fun test_signInAnonymouslyAndSaveSession_savesReturnedSession() =
+        runTest {
+            val auth = FakeAuthClient()
+            val sessionManager = FakeSessionManager()
+
+            val result =
+                auth.signInAnonymouslyAndSaveSession(
+                    sessionManager = sessionManager,
+                    captchaToken = "captcha-1",
+                )
+
+            assertTrue(result is SupabaseResult.Success)
+            assertEquals("anon-acc", sessionManager.currentSession?.accessToken)
+        }
+
+    @Test
+    fun test_refreshTokenAndSaveSession_savesReturnedSession() =
+        runTest {
+            val auth = FakeAuthClient()
+            val sessionManager = FakeSessionManager()
+
+            val result =
+                auth.refreshTokenAndSaveSession(
+                    sessionManager = sessionManager,
+                    refreshToken = "refresh-1",
+                )
+
+            assertTrue(result is SupabaseResult.Success)
+            assertEquals("refresh-1", auth.lastRefreshTokenInput)
+            assertEquals("refresh-acc", sessionManager.currentSession?.accessToken)
+        }
+
+    @Test
+    fun test_verifyOtpAndSaveSession_savesReturnedSession() =
+        runTest {
+            val auth = FakeAuthClient()
+            val sessionManager = FakeSessionManager()
+
+            val result =
+                auth.verifyOtpAndSaveSession(
+                    sessionManager = sessionManager,
+                    email = "a@b.com",
+                    token = "123456",
+                    type = OtpType.EMAIL,
+                )
+
+            assertTrue(result is SupabaseResult.Success)
+            assertEquals(OtpType.EMAIL, auth.lastVerifyOtpType)
+            assertEquals("verify-acc", sessionManager.currentSession?.accessToken)
+        }
+
+    @Test
+    fun test_signInWithPhoneAndSaveSession_savesReturnedSession() =
+        runTest {
+            val auth = FakeAuthClient()
+            val sessionManager = FakeSessionManager()
+
+            val result =
+                auth.signInWithPhoneAndSaveSession(
+                    sessionManager = sessionManager,
+                    phone = "+10000000000",
+                    password = "secret",
+                )
+
+            assertTrue(result is SupabaseResult.Success)
+            assertEquals("phone-sign-in-acc", sessionManager.currentSession?.accessToken)
+        }
+
+    @Test
+    fun test_signUpWithPhoneAndSaveSession_savesReturnedSession() =
+        runTest {
+            val auth = FakeAuthClient()
+            val sessionManager = FakeSessionManager()
+
+            val result =
+                auth.signUpWithPhoneAndSaveSession(
+                    sessionManager = sessionManager,
+                    phone = "+10000000000",
+                    password = "secret",
+                )
+
+            assertTrue(result is SupabaseResult.Success)
+            assertEquals("phone-sign-up-acc", sessionManager.currentSession?.accessToken)
+        }
+
+    @Test
+    fun test_signInWithIdTokenAndSaveSession_savesReturnedSession() =
+        runTest {
+            val auth = FakeAuthClient()
+            val sessionManager = FakeSessionManager()
+
+            val result =
+                auth.signInWithIdTokenAndSaveSession(
+                    sessionManager = sessionManager,
+                    provider = OAuthProvider.GOOGLE,
+                    idToken = "id-token-1",
+                )
+
+            assertTrue(result is SupabaseResult.Success)
+            assertEquals("id-token-sign-in-acc", sessionManager.currentSession?.accessToken)
+        }
+
+    @Test
+    fun test_verifyOtpWithTokenHashAndSaveSession_savesReturnedSession() =
+        runTest {
+            val auth = FakeAuthClient()
+            val sessionManager = FakeSessionManager()
+
+            val result =
+                auth.verifyOtpWithTokenHashAndSaveSession(
+                    sessionManager = sessionManager,
+                    tokenHash = "hash-123",
+                    type = OtpType.EMAIL,
+                )
+
+            assertTrue(result is SupabaseResult.Success)
+            assertEquals("verify-hash-acc", sessionManager.currentSession?.accessToken)
+        }
+
+    @Test
+    fun test_verifyOtpWithTokenHashWithResultAndSaveSession_savesWhenAuthenticated() =
+        runTest {
+            val auth =
+                FakeAuthClient().apply {
+                    verifyWithResultValue =
+                        OtpVerifyResult.Authenticated(
+                            dummySession.copy(accessToken = "verify-hash-result-acc", refreshToken = "verify-hash-result-ref"),
+                        )
+                }
+            val sessionManager = FakeSessionManager()
+
+            val result =
+                auth.verifyOtpWithTokenHashWithResultAndSaveSession(
+                    sessionManager = sessionManager,
+                    tokenHash = "hash-123",
+                    type = OtpType.EMAIL,
+                )
+
+            assertTrue(result is SupabaseResult.Success)
+            assertEquals("verify-hash-result-acc", sessionManager.currentSession?.accessToken)
+        }
+
+    @Test
+    fun test_mfaChallengeAndVerify_usesChallengeIdFromChallengeResponse() =
+        runTest {
+            val auth = FakeAuthClient()
+
+            val result =
+                auth.mfaChallengeAndVerify(
+                    factorId = "factor-1",
+                    code = "123456",
+                    accessToken = "token-mfa",
+                )
+
+            assertTrue(result is SupabaseResult.Success)
+            assertEquals("factor-1", auth.lastMfaChallengeFactorId)
+            assertEquals("challenge-1", auth.lastMfaVerifyChallengeId)
+            assertEquals("123456", auth.lastMfaVerifyCode)
+            assertEquals("token-mfa", auth.lastMfaVerifyAccessToken)
+        }
 }
 
 private class FakeAuthClient : AuthClient {
@@ -700,16 +789,18 @@ private class FakeAuthClient : AuthClient {
     var lastMfaVerifyAccessToken: String? = null
     var currentUserIdentities: List<UserIdentity> = emptyList()
 
-    val dummySession = Session(
-        accessToken = "a",
-        tokenType = "bearer",
-        expiresIn = 3600,
-        refreshToken = "r",
-        user = User(
-            id = "u1",
-            email = "a@b.com",
-        ),
-    )
+    val dummySession =
+        Session(
+            accessToken = "a",
+            tokenType = "bearer",
+            expiresIn = 3600,
+            refreshToken = "r",
+            user =
+                User(
+                    id = "u1",
+                    email = "a@b.com",
+                ),
+        )
 
     override suspend fun signUpWithEmail(email: String, password: String, data: JsonObject?): SupabaseResult<Session> {
         lastEmailSignUp = email
@@ -728,23 +819,28 @@ private class FakeAuthClient : AuthClient {
 
     override suspend fun signInAnonymously(data: JsonObject?, captchaToken: String?): SupabaseResult<Session> =
         SupabaseResult.Success(dummySession.copy(accessToken = "anon-acc", refreshToken = "anon-ref"))
+
     override suspend fun signInWithPhone(phone: String, password: String): SupabaseResult<Session> =
         SupabaseResult.Success(dummySession.copy(accessToken = "phone-sign-in-acc", refreshToken = "phone-sign-in-ref"))
+
     override suspend fun signInWithIdToken(
         provider: OAuthProvider,
         idToken: String,
         accessToken: String?,
         nonce: String?,
         captchaToken: String?,
-    ): SupabaseResult<Session> = SupabaseResult.Success(
-        dummySession.copy(accessToken = "id-token-sign-in-acc", refreshToken = "id-token-sign-in-ref"),
-    )
+    ): SupabaseResult<Session> =
+        SupabaseResult.Success(
+            dummySession.copy(accessToken = "id-token-sign-in-acc", refreshToken = "id-token-sign-in-ref"),
+        )
+
     override suspend fun signInWithWeb3(
         chain: Web3Chain,
         message: String,
         signature: String,
         captchaToken: String?,
     ): SupabaseResult<Session> = SupabaseResult.Failure(SupabaseError("not used"))
+
     override suspend fun signInWithOtp(
         email: String?,
         phone: String?,
@@ -752,6 +848,7 @@ private class FakeAuthClient : AuthClient {
         captchaToken: String?,
         emailRedirectTo: String?,
     ): SupabaseResult<Unit> = SupabaseResult.Failure(SupabaseError("not used"))
+
     override suspend fun verifyOtp(
         email: String?,
         phone: String?,
@@ -762,12 +859,14 @@ private class FakeAuthClient : AuthClient {
         SupabaseResult.Success(dummySession.copy(accessToken = "verify-acc", refreshToken = "verify-ref")).also {
             lastVerifyOtpType = type
         }
+
     override suspend fun verifyOtpWithTokenHash(
         tokenHash: String,
         type: OtpType,
         captchaToken: String?,
     ): SupabaseResult<Session> =
         SupabaseResult.Success(dummySession.copy(accessToken = "verify-hash-acc", refreshToken = "verify-hash-ref"))
+
     override suspend fun verifyOtpWithResult(
         email: String?,
         phone: String?,
@@ -778,6 +877,7 @@ private class FakeAuthClient : AuthClient {
         SupabaseResult.Success(verifyWithResultValue).also {
             lastVerifyOtpWithResultType = type
         }
+
     override suspend fun verifyOtpWithTokenHashWithResult(
         tokenHash: String,
         type: OtpType,
@@ -786,17 +886,21 @@ private class FakeAuthClient : AuthClient {
         SupabaseResult.Success(verifyWithResultValue).also {
             lastVerifyOtpTokenHashWithResult = tokenHash
         }
+
     override suspend fun resendEmailOtp(type: OtpType, email: String, captchaToken: String?, redirectTo: String?): SupabaseResult<Unit> =
         SupabaseResult.Success(Unit).also {
             lastResendEmailType = type
             lastResendEmail = email
         }
+
     override suspend fun resendPhoneOtp(type: OtpType, phone: String, captchaToken: String?): SupabaseResult<Unit> =
         SupabaseResult.Failure(SupabaseError("not used"))
+
     override suspend fun resetPasswordForEmail(email: String, redirectTo: String?, captchaToken: String?): SupabaseResult<Unit> {
         lastResetPasswordEmail = email
         return SupabaseResult.Success(Unit)
     }
+
     override suspend fun reauthenticate(accessToken: String): SupabaseResult<Unit> =
         SupabaseResult.Success(Unit).also {
             lastReauthenticateAccessToken = accessToken
@@ -806,50 +910,62 @@ private class FakeAuthClient : AuthClient {
         SupabaseResult.Success(dummySession.copy(accessToken = "refresh-acc", refreshToken = refreshToken)).also {
             lastRefreshTokenInput = refreshToken
         }
+
     override suspend fun getUser(accessToken: String): SupabaseResult<User> =
         SupabaseResult.Success(dummySession.user.copy(email = "updated@b.com")).also {
             lastGetUserAccessToken = accessToken
         }
+
     override suspend fun getUserIdentities(accessToken: String): SupabaseResult<List<UserIdentity>> =
         SupabaseResult.Success(currentUserIdentities).also {
             lastGetIdentitiesAccessToken = accessToken
         }
+
     override suspend fun updateUser(accessToken: String, updates: UserUpdateRequest): SupabaseResult<User> =
         SupabaseResult.Success(dummySession.user.copy(email = updates.email ?: dummySession.user.email)).also {
             lastUpdateUserAccessToken = accessToken
         }
+
     override suspend fun signOut(accessToken: String): SupabaseResult<Unit> = SupabaseResult.Failure(SupabaseError("not used"))
+
     override suspend fun signOut(accessToken: String, scope: SignOutScope): SupabaseResult<Unit> =
         SupabaseResult.Success(Unit).also {
             lastSignOutScope = scope
             lastSignOutAccessToken = accessToken
         }
+
     override suspend fun linkIdentity(accessToken: String, provider: OAuthProvider, redirectTo: String?, scopes: List<String>, queryParams: Map<String, String>): SupabaseResult<LinkIdentityResponse> =
         SupabaseResult.Success(LinkIdentityResponse(url = "https://example.com/link", provider = provider.value)).also {
             lastLinkIdentityAccessToken = accessToken
             lastLinkIdentityProvider = provider
         }
+
     override suspend fun linkIdentityWithIdToken(
         accessToken: String,
         provider: OAuthProvider,
         idToken: String,
         providerAccessToken: String?,
         nonce: String?,
-    ): SupabaseResult<Session> = SupabaseResult.Success(
-        dummySession.copy(accessToken = "linked-acc", refreshToken = "linked-ref"),
-    ).also {
-        lastLinkIdTokenAccessToken = accessToken
-        lastLinkIdTokenValue = idToken
-    }
+    ): SupabaseResult<Session> =
+        SupabaseResult
+            .Success(
+                dummySession.copy(accessToken = "linked-acc", refreshToken = "linked-ref"),
+            ).also {
+                lastLinkIdTokenAccessToken = accessToken
+                lastLinkIdTokenValue = idToken
+            }
+
     override suspend fun unlinkIdentity(accessToken: String, identityId: String): SupabaseResult<Unit> =
         SupabaseResult.Success(Unit).also {
             lastUnlinkAccessToken = accessToken
             lastUnlinkIdentityId = identityId
         }
+
     override suspend fun retrieveSsoUrl(accessToken: String?, domain: String?, providerId: String?, redirectTo: String?): SupabaseResult<SsoResponse> =
         SupabaseResult.Success(SsoResponse(url = "https://example.com/sso")).also {
             lastRetrieveSsoAccessToken = accessToken
         }
+
     override suspend fun signInWithOAuth(
         provider: OAuthProvider,
         redirectTo: String?,
@@ -859,69 +975,92 @@ private class FakeAuthClient : AuthClient {
         pkceParams: PkceParams?,
     ): SupabaseResult<OAuthResponse> =
         SupabaseResult.Success(OAuthResponse(provider = provider.value, url = "https://example.com/oauth"))
+
     override fun getOAuthSignInUrl(provider: OAuthProvider, redirectTo: String?, scopes: List<String>, queryParams: Map<String, String>, skipBrowserRedirect: Boolean, pkceParams: PkceParams?): String =
         "https://example.com/oauth"
+
     override fun generatePkceParams(sha256: ((ByteArray) -> ByteArray)?): PkceParams =
         PkceParams(codeVerifier = "v", codeChallenge = "c", codeChallengeMethod = "S256")
+
     override suspend fun exchangeCodeForSession(authCode: String, codeVerifier: String): SupabaseResult<Session> =
-        SupabaseResult.Success(
-            dummySession.copy(
-                accessToken = "exch-acc",
-                refreshToken = "exch-ref",
-                expiresIn = 1111L,
-            ),
-        ).also {
-            lastExchangeAuthCode = authCode
-            lastExchangeCodeVerifier = codeVerifier
-        }
+        SupabaseResult
+            .Success(
+                dummySession.copy(
+                    accessToken = "exch-acc",
+                    refreshToken = "exch-ref",
+                    expiresIn = 1111L,
+                ),
+            ).also {
+                lastExchangeAuthCode = authCode
+                lastExchangeCodeVerifier = codeVerifier
+            }
+
     override suspend fun mfaEnroll(factorType: MfaFactorType, friendlyName: String?, issuer: String?, phone: String?, accessToken: String): SupabaseResult<MfaEnrollResponse> =
         SupabaseResult.Failure(SupabaseError("not used"))
+
     override suspend fun mfaChallenge(factorId: String, accessToken: String): SupabaseResult<MfaChallengeResponse> =
         SupabaseResult.Success(MfaChallengeResponse(id = "challenge-1", factorId = factorId)).also {
             lastMfaChallengeFactorId = factorId
         }
+
     override suspend fun mfaVerify(factorId: String, challengeId: String, code: String, accessToken: String): SupabaseResult<MfaVerifyResponse> =
-        SupabaseResult.Success(
-            MfaVerifyResponse(
-                accessToken = "mfa-acc",
-                refreshToken = "mfa-ref",
-                tokenType = "bearer",
-                expiresIn = 3600,
-                user = dummySession.user,
-            ),
-        ).also {
-            lastMfaVerifyChallengeId = challengeId
-            lastMfaVerifyCode = code
-            lastMfaVerifyAccessToken = accessToken
-        }
+        SupabaseResult
+            .Success(
+                MfaVerifyResponse(
+                    accessToken = "mfa-acc",
+                    refreshToken = "mfa-ref",
+                    tokenType = "bearer",
+                    expiresIn = 3600,
+                    user = dummySession.user,
+                ),
+            ).also {
+                lastMfaVerifyChallengeId = challengeId
+                lastMfaVerifyCode = code
+                lastMfaVerifyAccessToken = accessToken
+            }
+
     override suspend fun mfaUnenroll(factorId: String, accessToken: String): SupabaseResult<MfaUnenrollResponse> =
         SupabaseResult.Failure(SupabaseError("not used"))
+
     override suspend fun mfaListFactors(accessToken: String): SupabaseResult<MfaListFactorsResponse> =
         SupabaseResult.Failure(SupabaseError("not used"))
+
     override suspend fun mfaGetAuthenticatorAssuranceLevel(accessToken: String): SupabaseResult<AuthenticatorAssuranceLevel> =
         SupabaseResult.Failure(SupabaseError("not used"))
+
     override suspend fun passkeyStartRegistration(accessToken: String): SupabaseResult<PasskeyRegistrationOptionsResponse> =
         SupabaseResult.Failure(SupabaseError("not used"))
+
     override suspend fun passkeyVerifyRegistration(accessToken: String, challengeId: String, credential: JsonObject): SupabaseResult<PasskeyMetadata> =
         SupabaseResult.Failure(SupabaseError("not used"))
+
     override suspend fun passkeyStartAuthentication(captchaToken: String?): SupabaseResult<PasskeyAuthenticationOptionsResponse> =
         SupabaseResult.Failure(SupabaseError("not used"))
+
     override suspend fun passkeyVerifyAuthentication(challengeId: String, credential: JsonObject): SupabaseResult<Session> =
         SupabaseResult.Failure(SupabaseError("not used"))
+
     override suspend fun passkeyList(accessToken: String): SupabaseResult<List<Passkey>> =
         SupabaseResult.Failure(SupabaseError("not used"))
+
     override suspend fun passkeyUpdate(accessToken: String, passkeyId: String, friendlyName: String): SupabaseResult<Passkey> =
         SupabaseResult.Failure(SupabaseError("not used"))
+
     override suspend fun passkeyDelete(accessToken: String, passkeyId: String): SupabaseResult<Unit> =
         SupabaseResult.Failure(SupabaseError("not used"))
+
     override suspend fun oauthGetAuthorizationDetails(accessToken: String, authorizationId: String): SupabaseResult<OAuthAuthorizationDetails> =
         SupabaseResult.Failure(SupabaseError("not used"))
+
     override suspend fun oauthApproveAuthorization(accessToken: String, authorizationId: String): SupabaseResult<OAuthRedirect> =
         SupabaseResult.Failure(SupabaseError("not used"))
+
     override suspend fun oauthDenyAuthorization(accessToken: String, authorizationId: String): SupabaseResult<OAuthRedirect> =
         SupabaseResult.Failure(SupabaseError("not used"))
+
     override suspend fun oauthListGrants(accessToken: String): SupabaseResult<List<OAuthGrant>> =
         SupabaseResult.Failure(SupabaseError("not used"))
+
     override suspend fun oauthRevokeGrant(accessToken: String, clientId: String): SupabaseResult<Unit> =
         SupabaseResult.Failure(SupabaseError("not used"))
 }
@@ -929,9 +1068,10 @@ private class FakeAuthClient : AuthClient {
 private class FakeSessionManager(
     session: Session? = null,
 ) : SessionManager {
-    private val state = MutableStateFlow<SessionState>(
-        if (session == null) SessionState.NotAuthenticated else SessionState.Authenticated(session),
-    )
+    private val state =
+        MutableStateFlow<SessionState>(
+            if (session == null) SessionState.NotAuthenticated else SessionState.Authenticated(session),
+        )
     override val sessionState: StateFlow<SessionState> = state
     override val currentSession: Session?
         get() = (state.value as? SessionState.Authenticated)?.session
@@ -941,20 +1081,29 @@ private class FakeSessionManager(
         get() = state.value is SessionState.Authenticated
     var refreshCalled: Boolean = false
     var refreshResult: SupabaseResult<Session> = SupabaseResult.Failure(SupabaseError("not used"))
+
     override suspend fun saveSession(session: Session) {
         state.value = SessionState.Authenticated(session)
     }
+
     override suspend fun clearSession() {
         state.value = SessionState.NotAuthenticated
     }
+
     override suspend fun refreshSession(): SupabaseResult<Session> {
         refreshCalled = true
         return refreshResult
     }
+
     override suspend fun restoreSession(): SupabaseResult<Session> = SupabaseResult.Failure(SupabaseError("not used"))
+
     override suspend fun initialize(): SupabaseResult<Session> = restoreSession()
+
     override fun startAutoRefresh() = Unit
+
     override fun stopAutoRefresh() = Unit
+
     override fun dispose() = close()
+
     override fun close() = Unit
 }

--- a/supabase-auth/src/commonTest/kotlin/io/github/androidpoet/supabase/auth/AuthClientImplTest.kt
+++ b/supabase-auth/src/commonTest/kotlin/io/github/androidpoet/supabase/auth/AuthClientImplTest.kt
@@ -18,221 +18,239 @@ import kotlin.test.assertTrue
 
 class AuthClientImplTest {
     @Test
-    fun test_signInWithIdToken_usesIdTokenGrantPayload() = runTest {
-        val client = FakeSupabaseClient()
-        val sut = AuthClientImpl(client)
+    fun test_signInWithIdToken_usesIdTokenGrantPayload() =
+        runTest {
+            val client = FakeSupabaseClient()
+            val sut = AuthClientImpl(client)
 
-        sut.signInWithIdToken(
-            provider = OAuthProvider.GOOGLE,
-            idToken = "id-token-1",
-            accessToken = "provider-access",
-            nonce = "nonce-1",
-            captchaToken = "captcha-1",
-        )
+            sut.signInWithIdToken(
+                provider = OAuthProvider.GOOGLE,
+                idToken = "id-token-1",
+                accessToken = "provider-access",
+                nonce = "nonce-1",
+                captchaToken = "captcha-1",
+            )
 
-        assertEquals("/auth/v1/token?grant_type=id_token", client.lastPostEndpoint)
-        assertTrue(client.lastPostBody?.contains("\"id_token\":\"id-token-1\"") == true)
-        assertTrue(client.lastPostBody?.contains("\"provider\":\"google\"") == true)
-        assertTrue(client.lastPostBody?.contains("\"access_token\":\"provider-access\"") == true)
-        assertTrue(client.lastPostBody?.contains("\"nonce\":\"nonce-1\"") == true)
-        assertTrue(client.lastPostBody?.contains("\"captcha_token\":\"captcha-1\"") == true)
-    }
-
-    @Test
-    fun test_signInWithWeb3_usesWeb3GrantPayload() = runTest {
-        val client = FakeSupabaseClient()
-        val sut = AuthClientImpl(client)
-
-        val result = sut.signInWithWeb3(
-            chain = Web3Chain.ETHEREUM,
-            message = "example siwe message",
-            signature = "0xsignature",
-            captchaToken = "captcha-web3",
-        )
-
-        assertTrue(result is SupabaseResult.Success)
-        assertEquals("/auth/v1/token?grant_type=web3", client.lastPostEndpoint)
-        assertTrue(client.lastPostBody?.contains("\"chain\":\"ethereum\"") == true)
-        assertTrue(client.lastPostBody?.contains("\"message\":\"example siwe message\"") == true)
-        assertTrue(client.lastPostBody?.contains("\"signature\":\"0xsignature\"") == true)
-        assertTrue(client.lastPostBody?.contains("\"captcha_token\":\"captcha-web3\"") == true)
-        assertEquals("web3-acc", result.value.accessToken)
-    }
+            assertEquals("/auth/v1/token?grant_type=id_token", client.lastPostEndpoint)
+            assertTrue(client.lastPostBody?.contains("\"id_token\":\"id-token-1\"") == true)
+            assertTrue(client.lastPostBody?.contains("\"provider\":\"google\"") == true)
+            assertTrue(client.lastPostBody?.contains("\"access_token\":\"provider-access\"") == true)
+            assertTrue(client.lastPostBody?.contains("\"nonce\":\"nonce-1\"") == true)
+            assertTrue(client.lastPostBody?.contains("\"captcha_token\":\"captcha-1\"") == true)
+        }
 
     @Test
-    fun test_signInWithOAuth_returnsProviderUrlWithOptions() = runTest {
-        val client = FakeSupabaseClient()
-        val sut = AuthClientImpl(client)
+    fun test_signInWithWeb3_usesWeb3GrantPayload() =
+        runTest {
+            val client = FakeSupabaseClient()
+            val sut = AuthClientImpl(client)
 
-        val result = sut.signInWithOAuth(
-            provider = OAuthProvider.GITHUB,
-            redirectTo = "myapp://callback",
-            scopes = listOf("repo", "user"),
-            queryParams = mapOf("prompt" to "consent"),
-            skipBrowserRedirect = true,
-        )
+            val result =
+                sut.signInWithWeb3(
+                    chain = Web3Chain.ETHEREUM,
+                    message = "example siwe message",
+                    signature = "0xsignature",
+                    captchaToken = "captcha-web3",
+                )
 
-        assertTrue(result is SupabaseResult.Success)
-        assertEquals("github", result.value.provider)
-        assertTrue(result.value.url.startsWith("https://example.supabase.co/auth/v1/authorize?provider=github"))
-        assertTrue(result.value.url.contains("redirect_to=myapp%3A%2F%2Fcallback"))
-        assertTrue(result.value.url.contains("scopes=repo%20user"))
-        assertTrue(result.value.url.contains("skip_http_redirect=true"))
-        assertTrue(result.value.url.contains("prompt=consent"))
-    }
-
-    @Test
-    fun test_signInAnonymously_usesDataAndCaptchaPayload() = runTest {
-        val client = FakeSupabaseClient()
-        val sut = AuthClientImpl(client)
-
-        sut.signInAnonymously(
-            data = buildJsonObject { put("role", "guest") },
-            captchaToken = "captcha-anon",
-        )
-
-        assertEquals("/auth/v1/signup", client.lastPostEndpoint)
-        assertTrue(client.lastPostBody?.contains("\"data\":{\"role\":\"guest\"}") == true)
-        assertTrue(client.lastPostBody?.contains("\"captcha_token\":\"captcha-anon\"") == true)
-    }
+            assertTrue(result is SupabaseResult.Success)
+            assertEquals("/auth/v1/token?grant_type=web3", client.lastPostEndpoint)
+            assertTrue(client.lastPostBody?.contains("\"chain\":\"ethereum\"") == true)
+            assertTrue(client.lastPostBody?.contains("\"message\":\"example siwe message\"") == true)
+            assertTrue(client.lastPostBody?.contains("\"signature\":\"0xsignature\"") == true)
+            assertTrue(client.lastPostBody?.contains("\"captcha_token\":\"captcha-web3\"") == true)
+            assertEquals("web3-acc", result.value.accessToken)
+        }
 
     @Test
-    fun test_verifyOtpWithTokenHash_usesVerifyPayload() = runTest {
-        val client = FakeSupabaseClient()
-        val sut = AuthClientImpl(client)
+    fun test_signInWithOAuth_returnsProviderUrlWithOptions() =
+        runTest {
+            val client = FakeSupabaseClient()
+            val sut = AuthClientImpl(client)
 
-        sut.verifyOtpWithTokenHash(
-            tokenHash = "hash-123",
-            type = io.github.androidpoet.supabase.auth.models.OtpType.EMAIL,
-            captchaToken = "captcha-1",
-        )
+            val result =
+                sut.signInWithOAuth(
+                    provider = OAuthProvider.GITHUB,
+                    redirectTo = "myapp://callback",
+                    scopes = listOf("repo", "user"),
+                    queryParams = mapOf("prompt" to "consent"),
+                    skipBrowserRedirect = true,
+                )
 
-        assertEquals("/auth/v1/verify", client.lastPostEndpoint)
-        assertTrue(client.lastPostBody?.contains("\"token_hash\":\"hash-123\"") == true)
-        assertTrue(client.lastPostBody?.contains("\"captcha_token\":\"captcha-1\"") == true)
-    }
-
-    @Test
-    fun test_signInWithOtp_withOptions_usesOtpPayloadFields() = runTest {
-        val client = FakeSupabaseClient()
-        val sut = AuthClientImpl(client)
-
-        sut.signInWithOtp(
-            email = "a@b.com",
-            createUser = false,
-            captchaToken = "captcha-otp",
-            emailRedirectTo = "myapp://otp",
-        )
-
-        assertEquals("/auth/v1/otp", client.lastPostEndpoint)
-        assertTrue(client.lastPostBody?.contains("\"email\":\"a@b.com\"") == true)
-        assertTrue(client.lastPostBody?.contains("\"create_user\":false") == true)
-        assertTrue(client.lastPostBody?.contains("\"captcha_token\":\"captcha-otp\"") == true)
-        assertTrue(client.lastPostBody?.contains("\"email_redirect_to\":\"myapp://otp\"") == true)
-    }
+            assertTrue(result is SupabaseResult.Success)
+            assertEquals("github", result.value.provider)
+            assertTrue(result.value.url.startsWith("https://example.supabase.co/auth/v1/authorize?provider=github"))
+            assertTrue(result.value.url.contains("redirect_to=myapp%3A%2F%2Fcallback"))
+            assertTrue(result.value.url.contains("scopes=repo%20user"))
+            assertTrue(result.value.url.contains("skip_http_redirect=true"))
+            assertTrue(result.value.url.contains("prompt=consent"))
+        }
 
     @Test
-    fun test_verifyOtpWithResult_returnsVerifiedNoSessionWhenNoAccessToken() = runTest {
-        val client = FakeSupabaseClient()
-        client.verifyResponse = "{}"
-        val sut = AuthClientImpl(client)
+    fun test_signInAnonymously_usesDataAndCaptchaPayload() =
+        runTest {
+            val client = FakeSupabaseClient()
+            val sut = AuthClientImpl(client)
 
-        val result = sut.verifyOtpWithResult(
-            email = "a@b.com",
-            token = "123456",
-            type = io.github.androidpoet.supabase.auth.models.OtpType.EMAIL,
-            captchaToken = "captcha-verify",
-        )
+            sut.signInAnonymously(
+                data = buildJsonObject { put("role", "guest") },
+                captchaToken = "captcha-anon",
+            )
 
-        assertTrue(result is SupabaseResult.Success)
-        assertTrue(client.lastPostBody?.contains("\"captcha_token\":\"captcha-verify\"") == true)
-        assertTrue(result.value == OtpVerifyResult.VerifiedNoSession)
-    }
+            assertEquals("/auth/v1/signup", client.lastPostEndpoint)
+            assertTrue(client.lastPostBody?.contains("\"data\":{\"role\":\"guest\"}") == true)
+            assertTrue(client.lastPostBody?.contains("\"captcha_token\":\"captcha-anon\"") == true)
+        }
 
     @Test
-    fun test_verifyOtp_withCaptchaToken_usesVerifyPayload() = runTest {
-        val client = FakeSupabaseClient()
-        val sut = AuthClientImpl(client)
+    fun test_verifyOtpWithTokenHash_usesVerifyPayload() =
+        runTest {
+            val client = FakeSupabaseClient()
+            val sut = AuthClientImpl(client)
 
-        sut.verifyOtp(
-            email = "a@b.com",
-            token = "123456",
-            type = io.github.androidpoet.supabase.auth.models.OtpType.EMAIL,
-            captchaToken = "captcha-2",
-        )
+            sut.verifyOtpWithTokenHash(
+                tokenHash = "hash-123",
+                type = io.github.androidpoet.supabase.auth.models.OtpType.EMAIL,
+                captchaToken = "captcha-1",
+            )
 
-        assertEquals("/auth/v1/verify", client.lastPostEndpoint)
-        assertTrue(client.lastPostBody?.contains("\"captcha_token\":\"captcha-2\"") == true)
-    }
-
-    @Test
-    fun test_verifyOtpWithTokenHashWithResult_returnsAuthenticatedWhenSessionPayloadPresent() = runTest {
-        val client = FakeSupabaseClient()
-        val sut = AuthClientImpl(client)
-
-        val result = sut.verifyOtpWithTokenHashWithResult(
-            tokenHash = "hash-123",
-            type = io.github.androidpoet.supabase.auth.models.OtpType.EMAIL,
-            captchaToken = null,
-        )
-
-        assertTrue(result is SupabaseResult.Success)
-        val value = result.value
-        assertTrue(value is OtpVerifyResult.Authenticated)
-        assertEquals("acc", value.session.accessToken)
-    }
+            assertEquals("/auth/v1/verify", client.lastPostEndpoint)
+            assertTrue(client.lastPostBody?.contains("\"token_hash\":\"hash-123\"") == true)
+            assertTrue(client.lastPostBody?.contains("\"captcha_token\":\"captcha-1\"") == true)
+        }
 
     @Test
-    fun test_signOut_scopeBuildsEndpoint() = runTest {
-        val client = FakeSupabaseClient()
-        val sut = AuthClientImpl(client)
+    fun test_signInWithOtp_withOptions_usesOtpPayloadFields() =
+        runTest {
+            val client = FakeSupabaseClient()
+            val sut = AuthClientImpl(client)
 
-        val result = sut.signOut("token-1", SignOutScope.GLOBAL)
+            sut.signInWithOtp(
+                email = "a@b.com",
+                createUser = false,
+                captchaToken = "captcha-otp",
+                emailRedirectTo = "myapp://otp",
+            )
 
-        assertEquals("/auth/v1/logout?scope=global", client.lastPostEndpoint)
-        assertTrue(result is SupabaseResult.Success)
-    }
-
-    @Test
-    fun test_linkIdentity_buildsAuthorizeEndpoint() = runTest {
-        val client = FakeSupabaseClient()
-        val sut = AuthClientImpl(client)
-
-        val result = sut.linkIdentity(
-            accessToken = "token-1",
-            provider = OAuthProvider.GITHUB,
-            redirectTo = "myapp://callback",
-            scopes = listOf("read:user"),
-            queryParams = mapOf("prompt" to "consent"),
-        )
-
-        assertTrue(client.lastGetEndpoint?.startsWith("/auth/v1/user/identities/authorize?provider=github") == true)
-        assertTrue(client.lastGetEndpoint?.contains("redirect_to=myapp%3A%2F%2Fcallback") == true)
-        assertTrue(client.lastGetEndpoint?.contains("scopes=read%3Auser") == true)
-        assertTrue(client.lastGetEndpoint?.contains("prompt=consent") == true)
-        assertTrue(result is SupabaseResult.Success)
-    }
+            assertEquals("/auth/v1/otp", client.lastPostEndpoint)
+            assertTrue(client.lastPostBody?.contains("\"email\":\"a@b.com\"") == true)
+            assertTrue(client.lastPostBody?.contains("\"create_user\":false") == true)
+            assertTrue(client.lastPostBody?.contains("\"captcha_token\":\"captcha-otp\"") == true)
+            assertTrue(client.lastPostBody?.contains("\"email_redirect_to\":\"myapp://otp\"") == true)
+        }
 
     @Test
-    fun test_linkIdentityWithIdToken_usesBearerAndLinkIdentityPayload() = runTest {
-        val client = FakeSupabaseClient()
-        val sut = AuthClientImpl(client)
+    fun test_verifyOtpWithResult_returnsVerifiedNoSessionWhenNoAccessToken() =
+        runTest {
+            val client = FakeSupabaseClient()
+            client.verifyResponse = "{}"
+            val sut = AuthClientImpl(client)
 
-        val result = sut.linkIdentityWithIdToken(
-            accessToken = "session-token-1",
-            provider = OAuthProvider.APPLE,
-            idToken = "apple-id-token",
-            providerAccessToken = null,
-            nonce = "nonce-2",
-        )
+            val result =
+                sut.verifyOtpWithResult(
+                    email = "a@b.com",
+                    token = "123456",
+                    type = io.github.androidpoet.supabase.auth.models.OtpType.EMAIL,
+                    captchaToken = "captcha-verify",
+                )
 
-        assertEquals("/auth/v1/token?grant_type=id_token", client.lastPostEndpoint)
-        assertEquals("Bearer session-token-1", client.lastPostHeaders["Authorization"])
-        assertTrue(client.lastPostBody?.contains("\"provider\":\"apple\"") == true)
-        assertTrue(client.lastPostBody?.contains("\"id_token\":\"apple-id-token\"") == true)
-        assertTrue(client.lastPostBody?.contains("\"link_identity\":true") == true)
-        assertTrue(result is SupabaseResult.Success)
-    }
+            assertTrue(result is SupabaseResult.Success)
+            assertTrue(client.lastPostBody?.contains("\"captcha_token\":\"captcha-verify\"") == true)
+            assertTrue(result.value == OtpVerifyResult.VerifiedNoSession)
+        }
+
+    @Test
+    fun test_verifyOtp_withCaptchaToken_usesVerifyPayload() =
+        runTest {
+            val client = FakeSupabaseClient()
+            val sut = AuthClientImpl(client)
+
+            sut.verifyOtp(
+                email = "a@b.com",
+                token = "123456",
+                type = io.github.androidpoet.supabase.auth.models.OtpType.EMAIL,
+                captchaToken = "captcha-2",
+            )
+
+            assertEquals("/auth/v1/verify", client.lastPostEndpoint)
+            assertTrue(client.lastPostBody?.contains("\"captcha_token\":\"captcha-2\"") == true)
+        }
+
+    @Test
+    fun test_verifyOtpWithTokenHashWithResult_returnsAuthenticatedWhenSessionPayloadPresent() =
+        runTest {
+            val client = FakeSupabaseClient()
+            val sut = AuthClientImpl(client)
+
+            val result =
+                sut.verifyOtpWithTokenHashWithResult(
+                    tokenHash = "hash-123",
+                    type = io.github.androidpoet.supabase.auth.models.OtpType.EMAIL,
+                    captchaToken = null,
+                )
+
+            assertTrue(result is SupabaseResult.Success)
+            val value = result.value
+            assertTrue(value is OtpVerifyResult.Authenticated)
+            assertEquals("acc", value.session.accessToken)
+        }
+
+    @Test
+    fun test_signOut_scopeBuildsEndpoint() =
+        runTest {
+            val client = FakeSupabaseClient()
+            val sut = AuthClientImpl(client)
+
+            val result = sut.signOut("token-1", SignOutScope.GLOBAL)
+
+            assertEquals("/auth/v1/logout?scope=global", client.lastPostEndpoint)
+            assertTrue(result is SupabaseResult.Success)
+        }
+
+    @Test
+    fun test_linkIdentity_buildsAuthorizeEndpoint() =
+        runTest {
+            val client = FakeSupabaseClient()
+            val sut = AuthClientImpl(client)
+
+            val result =
+                sut.linkIdentity(
+                    accessToken = "token-1",
+                    provider = OAuthProvider.GITHUB,
+                    redirectTo = "myapp://callback",
+                    scopes = listOf("read:user"),
+                    queryParams = mapOf("prompt" to "consent"),
+                )
+
+            assertTrue(client.lastGetEndpoint?.startsWith("/auth/v1/user/identities/authorize?provider=github") == true)
+            assertTrue(client.lastGetEndpoint?.contains("redirect_to=myapp%3A%2F%2Fcallback") == true)
+            assertTrue(client.lastGetEndpoint?.contains("scopes=read%3Auser") == true)
+            assertTrue(client.lastGetEndpoint?.contains("prompt=consent") == true)
+            assertTrue(result is SupabaseResult.Success)
+        }
+
+    @Test
+    fun test_linkIdentityWithIdToken_usesBearerAndLinkIdentityPayload() =
+        runTest {
+            val client = FakeSupabaseClient()
+            val sut = AuthClientImpl(client)
+
+            val result =
+                sut.linkIdentityWithIdToken(
+                    accessToken = "session-token-1",
+                    provider = OAuthProvider.APPLE,
+                    idToken = "apple-id-token",
+                    providerAccessToken = null,
+                    nonce = "nonce-2",
+                )
+
+            assertEquals("/auth/v1/token?grant_type=id_token", client.lastPostEndpoint)
+            assertEquals("Bearer session-token-1", client.lastPostHeaders["Authorization"])
+            assertTrue(client.lastPostBody?.contains("\"provider\":\"apple\"") == true)
+            assertTrue(client.lastPostBody?.contains("\"id_token\":\"apple-id-token\"") == true)
+            assertTrue(client.lastPostBody?.contains("\"link_identity\":true") == true)
+            assertTrue(result is SupabaseResult.Success)
+        }
 
     @Test
     fun test_retrieveSsoUrl_requiresDomainOrProviderId() {
@@ -263,198 +281,223 @@ class AuthClientImplTest {
     }
 
     @Test
-    fun test_reauthenticate_usesAuthorizedEndpoint() = runTest {
-        val client = FakeSupabaseClient()
-        val sut = AuthClientImpl(client)
+    fun test_reauthenticate_usesAuthorizedEndpoint() =
+        runTest {
+            val client = FakeSupabaseClient()
+            val sut = AuthClientImpl(client)
 
-        val result = sut.reauthenticate("token-reauth")
+            val result = sut.reauthenticate("token-reauth")
 
-        assertEquals("/auth/v1/reauthenticate", client.lastGetEndpoint)
-        assertEquals("Bearer token-reauth", client.lastGetHeaders["Authorization"])
-        assertTrue(result is SupabaseResult.Success)
-    }
-
-    @Test
-    fun test_getUserIdentities_returnsUserIdentities() = runTest {
-        val client = FakeSupabaseClient()
-        client.userResponse =
-            """{"id":"u1","identities":[{"id":"provider-user-1","identity_id":"identity-1","provider":"github","user_id":"u1"}]}"""
-        val sut = AuthClientImpl(client)
-
-        val result = sut.getUserIdentities("token-identities")
-
-        assertTrue(result is SupabaseResult.Success)
-        assertEquals("/auth/v1/user", client.lastGetEndpoint)
-        assertEquals("Bearer token-identities", client.lastGetHeaders["Authorization"])
-        assertEquals(
-            listOf(UserIdentity(id = "provider-user-1", identityId = "identity-1", provider = "github", userId = "u1")),
-            result.value,
-        )
-    }
+            assertEquals("/auth/v1/reauthenticate", client.lastGetEndpoint)
+            assertEquals("Bearer token-reauth", client.lastGetHeaders["Authorization"])
+            assertTrue(result is SupabaseResult.Success)
+        }
 
     @Test
-    fun test_getUserIdentities_returnsEmptyListWhenUserHasNoIdentities() = runTest {
-        val client = FakeSupabaseClient()
-        client.userResponse = """{"id":"u1"}"""
-        val sut = AuthClientImpl(client)
+    fun test_getUserIdentities_returnsUserIdentities() =
+        runTest {
+            val client = FakeSupabaseClient()
+            client.userResponse =
+                """{"id":"u1","identities":[{"id":"provider-user-1","identity_id":"identity-1","provider":"github","user_id":"u1"}]}"""
+            val sut = AuthClientImpl(client)
 
-        val result = sut.getUserIdentities("token-identities")
+            val result = sut.getUserIdentities("token-identities")
 
-        assertTrue(result is SupabaseResult.Success)
-        assertEquals(emptyList(), result.value)
-    }
-
-    @Test
-    fun test_retrieveSsoUrl_withoutAccessToken_usesNoAuthorizationHeader() = runTest {
-        val client = FakeSupabaseClient()
-        val sut = AuthClientImpl(client)
-
-        val result = sut.retrieveSsoUrl(
-            accessToken = null,
-            domain = "example.com",
-        )
-
-        assertEquals("/auth/v1/sso", client.lastPostEndpoint)
-        assertTrue(client.lastPostHeaders["Authorization"] == null)
-        assertTrue(result is SupabaseResult.Success)
-    }
+            assertTrue(result is SupabaseResult.Success)
+            assertEquals("/auth/v1/user", client.lastGetEndpoint)
+            assertEquals("Bearer token-identities", client.lastGetHeaders["Authorization"])
+            assertEquals(
+                listOf(UserIdentity(id = "provider-user-1", identityId = "identity-1", provider = "github", userId = "u1")),
+                result.value,
+            )
+        }
 
     @Test
-    fun test_updateUser_includesNonceAndBearerHeader() = runTest {
-        val client = FakeSupabaseClient()
-        val sut = AuthClientImpl(client)
+    fun test_getUserIdentities_returnsEmptyListWhenUserHasNoIdentities() =
+        runTest {
+            val client = FakeSupabaseClient()
+            client.userResponse = """{"id":"u1"}"""
+            val sut = AuthClientImpl(client)
 
-        val result = sut.updateUser(
-            accessToken = "token-upd",
-            updates = io.github.androidpoet.supabase.auth.models.UserUpdateRequest(
-                password = "new-password",
-                currentPassword = "old-password",
-                nonce = "nonce-xyz",
-            ),
-        )
+            val result = sut.getUserIdentities("token-identities")
 
-        assertEquals("/auth/v1/user", client.lastPatchEndpoint)
-        assertEquals("Bearer token-upd", client.lastPatchHeaders["Authorization"])
-        assertTrue(client.lastPatchBody?.contains("\"current_password\":\"old-password\"") == true)
-        assertTrue(client.lastPatchBody?.contains("\"nonce\":\"nonce-xyz\"") == true)
-        assertTrue(result is SupabaseResult.Success)
-    }
+            assertTrue(result is SupabaseResult.Success)
+            assertEquals(emptyList(), result.value)
+        }
 
     @Test
-    fun test_passkeyStartRegistration_usesBearerAndRegistrationOptionsEndpoint() = runTest {
-        val client = FakeSupabaseClient()
-        val sut = AuthClientImpl(client)
+    fun test_retrieveSsoUrl_withoutAccessToken_usesNoAuthorizationHeader() =
+        runTest {
+            val client = FakeSupabaseClient()
+            val sut = AuthClientImpl(client)
 
-        val result = sut.passkeyStartRegistration(accessToken = "token-passkey")
+            val result =
+                sut.retrieveSsoUrl(
+                    accessToken = null,
+                    domain = "example.com",
+                )
 
-        assertTrue(result is SupabaseResult.Success)
-        assertEquals("/auth/v1/passkeys/registration/options", client.lastPostEndpoint)
-        assertEquals("Bearer token-passkey", client.lastPostHeaders["Authorization"])
-        assertEquals("challenge-reg", result.value.challengeId)
-    }
-
-    @Test
-    fun test_passkeyVerifyRegistration_sendsChallengeAndCredential() = runTest {
-        val client = FakeSupabaseClient()
-        val sut = AuthClientImpl(client)
-
-        val result = sut.passkeyVerifyRegistration(
-            accessToken = "token-passkey",
-            challengeId = "challenge-reg",
-            credential = buildJsonObject { put("id", "credential-id") },
-        )
-
-        assertTrue(result is SupabaseResult.Success)
-        assertEquals("/auth/v1/passkeys/registration/verify", client.lastPostEndpoint)
-        assertEquals("Bearer token-passkey", client.lastPostHeaders["Authorization"])
-        assertTrue(client.lastPostBody?.contains("\"challenge_id\":\"challenge-reg\"") == true)
-        assertTrue(client.lastPostBody?.contains("\"credential\":{\"id\":\"credential-id\"}") == true)
-        assertEquals("passkey1", result.value.id)
-    }
+            assertEquals("/auth/v1/sso", client.lastPostEndpoint)
+            assertTrue(client.lastPostHeaders["Authorization"] == null)
+            assertTrue(result is SupabaseResult.Success)
+        }
 
     @Test
-    fun test_passkeyStartAuthentication_sendsCaptchaPayload() = runTest {
-        val client = FakeSupabaseClient()
-        val sut = AuthClientImpl(client)
+    fun test_updateUser_includesNonceAndBearerHeader() =
+        runTest {
+            val client = FakeSupabaseClient()
+            val sut = AuthClientImpl(client)
 
-        val result = sut.passkeyStartAuthentication(captchaToken = "captcha-passkey")
+            val result =
+                sut.updateUser(
+                    accessToken = "token-upd",
+                    updates =
+                        io.github.androidpoet.supabase.auth.models.UserUpdateRequest(
+                            password = "new-password",
+                            currentPassword = "old-password",
+                            nonce = "nonce-xyz",
+                        ),
+                )
 
-        assertTrue(result is SupabaseResult.Success)
-        assertEquals("/auth/v1/passkeys/authentication/options", client.lastPostEndpoint)
-        assertTrue(client.lastPostBody?.contains("\"captcha_token\":\"captcha-passkey\"") == true)
-        assertEquals("challenge-auth", result.value.challengeId)
-    }
-
-    @Test
-    fun test_passkeyVerifyAuthentication_sendsCredentialAndDecodesSession() = runTest {
-        val client = FakeSupabaseClient()
-        val sut = AuthClientImpl(client)
-
-        val result = sut.passkeyVerifyAuthentication(
-            challengeId = "challenge-auth",
-            credential = buildJsonObject { put("id", "credential-id") },
-        )
-
-        assertTrue(result is SupabaseResult.Success)
-        assertEquals("/auth/v1/passkeys/authentication/verify", client.lastPostEndpoint)
-        assertTrue(client.lastPostBody?.contains("\"challenge_id\":\"challenge-auth\"") == true)
-        assertEquals("passkey-acc", result.value.accessToken)
-    }
+            assertEquals("/auth/v1/user", client.lastPatchEndpoint)
+            assertEquals("Bearer token-upd", client.lastPatchHeaders["Authorization"])
+            assertTrue(client.lastPatchBody?.contains("\"current_password\":\"old-password\"") == true)
+            assertTrue(client.lastPatchBody?.contains("\"nonce\":\"nonce-xyz\"") == true)
+            assertTrue(result is SupabaseResult.Success)
+        }
 
     @Test
-    fun test_passkeyListUpdateAndDelete_useExpectedEndpoints() = runTest {
-        val client = FakeSupabaseClient()
-        val sut = AuthClientImpl(client)
+    fun test_passkeyStartRegistration_usesBearerAndRegistrationOptionsEndpoint() =
+        runTest {
+            val client = FakeSupabaseClient()
+            val sut = AuthClientImpl(client)
 
-        val listResult = sut.passkeyList(accessToken = "token-passkey")
-        val updateResult = sut.passkeyUpdate(
-            accessToken = "token-passkey",
-            passkeyId = "passkey1",
-            friendlyName = "Laptop",
-        )
-        val deleteResult = sut.passkeyDelete(accessToken = "token-passkey", passkeyId = "passkey1")
+            val result = sut.passkeyStartRegistration(accessToken = "token-passkey")
 
-        assertTrue(listResult is SupabaseResult.Success)
-        assertEquals("passkey1", listResult.value.first().id)
-        assertTrue(updateResult is SupabaseResult.Success)
-        assertEquals("/auth/v1/passkeys/passkey1", client.lastDeleteEndpoint)
-        assertEquals("Bearer token-passkey", client.lastDeleteHeaders["Authorization"])
-        assertTrue(deleteResult is SupabaseResult.Success)
-    }
+            assertTrue(result is SupabaseResult.Success)
+            assertEquals("/auth/v1/passkeys/registration/options", client.lastPostEndpoint)
+            assertEquals("Bearer token-passkey", client.lastPostHeaders["Authorization"])
+            assertEquals("challenge-reg", result.value.challengeId)
+        }
 
     @Test
-    fun test_oauthAuthorizationServerMethods_useExpectedEndpointsAndBearerToken() = runTest {
-        val client = FakeSupabaseClient()
-        val sut = AuthClientImpl(client)
+    fun test_passkeyVerifyRegistration_sendsChallengeAndCredential() =
+        runTest {
+            val client = FakeSupabaseClient()
+            val sut = AuthClientImpl(client)
 
-        val details = sut.oauthGetAuthorizationDetails(
-            accessToken = "token-oauth",
-            authorizationId = "authz-1",
-        )
-        val approve = sut.oauthApproveAuthorization(
-            accessToken = "token-oauth",
-            authorizationId = "authz-1",
-        )
-        val deny = sut.oauthDenyAuthorization(
-            accessToken = "token-oauth",
-            authorizationId = "authz-1",
-        )
-        val grants = sut.oauthListGrants(accessToken = "token-oauth")
-        val revoke = sut.oauthRevokeGrant(accessToken = "token-oauth", clientId = "client-1")
+            val result =
+                sut.passkeyVerifyRegistration(
+                    accessToken = "token-passkey",
+                    challengeId = "challenge-reg",
+                    credential = buildJsonObject { put("id", "credential-id") },
+                )
 
-        assertTrue(details is SupabaseResult.Success)
-        assertEquals("authz-1", details.value.authorizationId)
-        assertEquals("Example App", details.value.client?.name)
-        assertTrue(approve is SupabaseResult.Success)
-        assertEquals("https://app.example.com/callback", approve.value.redirectUrl)
-        assertTrue(deny is SupabaseResult.Success)
-        assertEquals("https://app.example.com/callback?error=access_denied", deny.value.redirectUrl)
-        assertTrue(grants is SupabaseResult.Success)
-        assertEquals("client-1", grants.value.first().client.id)
-        assertEquals("/auth/v1/user/oauth/grants?client_id=client-1", client.lastDeleteEndpoint)
-        assertEquals("Bearer token-oauth", client.lastDeleteHeaders["Authorization"])
-        assertTrue(revoke is SupabaseResult.Success)
-    }
+            assertTrue(result is SupabaseResult.Success)
+            assertEquals("/auth/v1/passkeys/registration/verify", client.lastPostEndpoint)
+            assertEquals("Bearer token-passkey", client.lastPostHeaders["Authorization"])
+            assertTrue(client.lastPostBody?.contains("\"challenge_id\":\"challenge-reg\"") == true)
+            assertTrue(client.lastPostBody?.contains("\"credential\":{\"id\":\"credential-id\"}") == true)
+            assertEquals("passkey1", result.value.id)
+        }
+
+    @Test
+    fun test_passkeyStartAuthentication_sendsCaptchaPayload() =
+        runTest {
+            val client = FakeSupabaseClient()
+            val sut = AuthClientImpl(client)
+
+            val result = sut.passkeyStartAuthentication(captchaToken = "captcha-passkey")
+
+            assertTrue(result is SupabaseResult.Success)
+            assertEquals("/auth/v1/passkeys/authentication/options", client.lastPostEndpoint)
+            assertTrue(client.lastPostBody?.contains("\"captcha_token\":\"captcha-passkey\"") == true)
+            assertEquals("challenge-auth", result.value.challengeId)
+        }
+
+    @Test
+    fun test_passkeyVerifyAuthentication_sendsCredentialAndDecodesSession() =
+        runTest {
+            val client = FakeSupabaseClient()
+            val sut = AuthClientImpl(client)
+
+            val result =
+                sut.passkeyVerifyAuthentication(
+                    challengeId = "challenge-auth",
+                    credential = buildJsonObject { put("id", "credential-id") },
+                )
+
+            assertTrue(result is SupabaseResult.Success)
+            assertEquals("/auth/v1/passkeys/authentication/verify", client.lastPostEndpoint)
+            assertTrue(client.lastPostBody?.contains("\"challenge_id\":\"challenge-auth\"") == true)
+            assertEquals("passkey-acc", result.value.accessToken)
+        }
+
+    @Test
+    fun test_passkeyListUpdateAndDelete_useExpectedEndpoints() =
+        runTest {
+            val client = FakeSupabaseClient()
+            val sut = AuthClientImpl(client)
+
+            val listResult = sut.passkeyList(accessToken = "token-passkey")
+            val updateResult =
+                sut.passkeyUpdate(
+                    accessToken = "token-passkey",
+                    passkeyId = "passkey1",
+                    friendlyName = "Laptop",
+                )
+            val deleteResult = sut.passkeyDelete(accessToken = "token-passkey", passkeyId = "passkey1")
+
+            assertTrue(listResult is SupabaseResult.Success)
+            assertEquals("passkey1", listResult.value.first().id)
+            assertTrue(updateResult is SupabaseResult.Success)
+            assertEquals("/auth/v1/passkeys/passkey1", client.lastDeleteEndpoint)
+            assertEquals("Bearer token-passkey", client.lastDeleteHeaders["Authorization"])
+            assertTrue(deleteResult is SupabaseResult.Success)
+        }
+
+    @Test
+    fun test_oauthAuthorizationServerMethods_useExpectedEndpointsAndBearerToken() =
+        runTest {
+            val client = FakeSupabaseClient()
+            val sut = AuthClientImpl(client)
+
+            val details =
+                sut.oauthGetAuthorizationDetails(
+                    accessToken = "token-oauth",
+                    authorizationId = "authz-1",
+                )
+            val approve =
+                sut.oauthApproveAuthorization(
+                    accessToken = "token-oauth",
+                    authorizationId = "authz-1",
+                )
+            val deny =
+                sut.oauthDenyAuthorization(
+                    accessToken = "token-oauth",
+                    authorizationId = "authz-1",
+                )
+            val grants = sut.oauthListGrants(accessToken = "token-oauth")
+            val revoke = sut.oauthRevokeGrant(accessToken = "token-oauth", clientId = "client-1")
+
+            assertTrue(details is SupabaseResult.Success)
+            assertEquals("authz-1", details.value.authorizationId)
+            assertEquals("Example App", details.value.client?.name)
+            assertTrue(approve is SupabaseResult.Success)
+            assertEquals("https://app.example.com/callback", approve.value.redirectUrl)
+            assertTrue(deny is SupabaseResult.Success)
+            assertEquals("https://app.example.com/callback?error=access_denied", deny.value.redirectUrl)
+            assertTrue(grants is SupabaseResult.Success)
+            assertEquals(
+                "client-1",
+                grants.value
+                    .first()
+                    .client.id,
+            )
+            assertEquals("/auth/v1/user/oauth/grants?client_id=client-1", client.lastDeleteEndpoint)
+            assertEquals("Bearer token-oauth", client.lastDeleteHeaders["Authorization"])
+            assertTrue(revoke is SupabaseResult.Success)
+        }
 }
 
 private class FakeSupabaseClient : SupabaseClient {
@@ -485,15 +528,18 @@ private class FakeSupabaseClient : SupabaseClient {
         lastGetHeaders = headers
         return when {
             endpoint == "/auth/v1/user" -> SupabaseResult.Success(userResponse)
-            endpoint == "/auth/v1/passkeys" -> SupabaseResult.Success(
-                """[{"id":"passkey1","friendly_name":"Laptop","created_at":"2026-01-01T00:00:00Z","last_used_at":"2026-01-02T00:00:00Z"}]""",
-            )
-            endpoint == "/auth/v1/oauth/authorizations/authz-1" -> SupabaseResult.Success(
-                """{"authorization_id":"authz-1","redirect_uri":"https://app.example.com/callback","client":{"id":"client-1","name":"Example App","uri":"https://app.example.com","logo_uri":"https://app.example.com/logo.png"},"user":{"id":"u1","email":"user@example.com"},"scope":"openid email"}""",
-            )
-            endpoint == "/auth/v1/user/oauth/grants" -> SupabaseResult.Success(
-                """[{"client":{"id":"client-1","name":"Example App","uri":"https://app.example.com","logo_uri":"https://app.example.com/logo.png"},"scopes":["openid","email"],"granted_at":"2026-01-01T00:00:00Z"}]""",
-            )
+            endpoint == "/auth/v1/passkeys" ->
+                SupabaseResult.Success(
+                    """[{"id":"passkey1","friendly_name":"Laptop","created_at":"2026-01-01T00:00:00Z","last_used_at":"2026-01-02T00:00:00Z"}]""",
+                )
+            endpoint == "/auth/v1/oauth/authorizations/authz-1" ->
+                SupabaseResult.Success(
+                    """{"authorization_id":"authz-1","redirect_uri":"https://app.example.com/callback","client":{"id":"client-1","name":"Example App","uri":"https://app.example.com","logo_uri":"https://app.example.com/logo.png"},"user":{"id":"u1","email":"user@example.com"},"scope":"openid email"}""",
+                )
+            endpoint == "/auth/v1/user/oauth/grants" ->
+                SupabaseResult.Success(
+                    """[{"client":{"id":"client-1","name":"Example App","uri":"https://app.example.com","logo_uri":"https://app.example.com/logo.png"},"scopes":["openid","email"],"granted_at":"2026-01-01T00:00:00Z"}]""",
+                )
             else -> SupabaseResult.Success("""{"url":"https://example.com/link","provider":"github"}""")
         }
     }
@@ -509,34 +555,43 @@ private class FakeSupabaseClient : SupabaseClient {
         return when {
             endpoint.startsWith("/auth/v1/logout") -> SupabaseResult.Success("{}")
             endpoint == "/auth/v1/sso" -> SupabaseResult.Success("""{"url":"https://example.com/sso"}""")
-            endpoint == "/auth/v1/passkeys/registration/options" -> SupabaseResult.Success(
-                """{"challenge_id":"challenge-reg","options":{"challenge":"abc"},"expires_at":1893456000}""",
-            )
-            endpoint == "/auth/v1/passkeys/registration/verify" -> SupabaseResult.Success(
-                """{"id":"passkey1","friendly_name":"Laptop","created_at":"2026-01-01T00:00:00Z"}""",
-            )
-            endpoint == "/auth/v1/passkeys/authentication/options" -> SupabaseResult.Success(
-                """{"challenge_id":"challenge-auth","options":{"challenge":"xyz"},"expires_at":1893456000}""",
-            )
-            endpoint == "/auth/v1/passkeys/authentication/verify" -> SupabaseResult.Success(
-                """{"access_token":"passkey-acc","refresh_token":"passkey-ref","expires_in":3600,"token_type":"bearer","user":{"id":"u1"}}""",
-            )
-            endpoint == "/auth/v1/oauth/authorizations/authz-1/consent" && body?.contains("\"action\":\"approve\"") == true -> SupabaseResult.Success(
-                """{"redirect_url":"https://app.example.com/callback"}""",
-            )
-            endpoint == "/auth/v1/oauth/authorizations/authz-1/consent" && body?.contains("\"action\":\"deny\"") == true -> SupabaseResult.Success(
-                """{"redirect_url":"https://app.example.com/callback?error=access_denied"}""",
-            )
-            endpoint == "/auth/v1/token?grant_type=id_token" -> SupabaseResult.Success(
-                """{"access_token":"acc","refresh_token":"ref","expires_in":3600,"token_type":"bearer","user":{"id":"u1"}}""",
-            )
-            endpoint == "/auth/v1/token?grant_type=web3" -> SupabaseResult.Success(
-                """{"access_token":"web3-acc","refresh_token":"web3-ref","expires_in":3600,"token_type":"bearer","user":{"id":"u1"}}""",
-            )
+            endpoint == "/auth/v1/passkeys/registration/options" ->
+                SupabaseResult.Success(
+                    """{"challenge_id":"challenge-reg","options":{"challenge":"abc"},"expires_at":1893456000}""",
+                )
+            endpoint == "/auth/v1/passkeys/registration/verify" ->
+                SupabaseResult.Success(
+                    """{"id":"passkey1","friendly_name":"Laptop","created_at":"2026-01-01T00:00:00Z"}""",
+                )
+            endpoint == "/auth/v1/passkeys/authentication/options" ->
+                SupabaseResult.Success(
+                    """{"challenge_id":"challenge-auth","options":{"challenge":"xyz"},"expires_at":1893456000}""",
+                )
+            endpoint == "/auth/v1/passkeys/authentication/verify" ->
+                SupabaseResult.Success(
+                    """{"access_token":"passkey-acc","refresh_token":"passkey-ref","expires_in":3600,"token_type":"bearer","user":{"id":"u1"}}""",
+                )
+            endpoint == "/auth/v1/oauth/authorizations/authz-1/consent" && body?.contains("\"action\":\"approve\"") == true ->
+                SupabaseResult.Success(
+                    """{"redirect_url":"https://app.example.com/callback"}""",
+                )
+            endpoint == "/auth/v1/oauth/authorizations/authz-1/consent" && body?.contains("\"action\":\"deny\"") == true ->
+                SupabaseResult.Success(
+                    """{"redirect_url":"https://app.example.com/callback?error=access_denied"}""",
+                )
+            endpoint == "/auth/v1/token?grant_type=id_token" ->
+                SupabaseResult.Success(
+                    """{"access_token":"acc","refresh_token":"ref","expires_in":3600,"token_type":"bearer","user":{"id":"u1"}}""",
+                )
+            endpoint == "/auth/v1/token?grant_type=web3" ->
+                SupabaseResult.Success(
+                    """{"access_token":"web3-acc","refresh_token":"web3-ref","expires_in":3600,"token_type":"bearer","user":{"id":"u1"}}""",
+                )
             endpoint == "/auth/v1/verify" -> SupabaseResult.Success(verifyResponse)
             else -> SupabaseResult.Success("{}")
         }
     }
+
     override suspend fun put(
         endpoint: String,
         body: String?,

--- a/supabase-auth/src/commonTest/kotlin/io/github/androidpoet/supabase/auth/session/SessionManagerExtTest.kt
+++ b/supabase-auth/src/commonTest/kotlin/io/github/androidpoet/supabase/auth/session/SessionManagerExtTest.kt
@@ -5,61 +5,64 @@ import io.github.androidpoet.supabase.auth.models.User
 import io.github.androidpoet.supabase.core.result.SupabaseError
 import io.github.androidpoet.supabase.core.result.SupabaseResult
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlin.test.Test
-import kotlin.test.assertEquals
 import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class SessionManagerExtTest {
     @Test
-    fun test_onAuthStateChange_emitsJsStyleEventsFromSessionState() = runTest {
-        val manager = StateFakeSessionManager()
-        val events = mutableListOf<AuthStateChangeEvent>()
-        val sessions = mutableListOf<Session?>()
-        val job = manager.onAuthStateChange(this) { event, session ->
-            events += event
-            sessions += session
+    fun test_onAuthStateChange_emitsJsStyleEventsFromSessionState() =
+        runTest {
+            val manager = StateFakeSessionManager()
+            val events = mutableListOf<AuthStateChangeEvent>()
+            val sessions = mutableListOf<Session?>()
+            val job =
+                manager.onAuthStateChange(this) { event, session ->
+                    events += event
+                    sessions += session
+                }
+            runCurrent()
+
+            manager.emit(SessionState.Authenticated(testSession(accessToken = "acc-1", refreshToken = "ref-1")))
+            runCurrent()
+            manager.emit(SessionState.Authenticated(testSession(accessToken = "acc-2", refreshToken = "ref-2")))
+            runCurrent()
+            manager.emit(SessionState.NotAuthenticated)
+            runCurrent()
+            job.cancelAndJoin()
+
+            assertEquals(
+                listOf(
+                    AuthStateChangeEvent.INITIAL_SESSION,
+                    AuthStateChangeEvent.SIGNED_IN,
+                    AuthStateChangeEvent.TOKEN_REFRESHED,
+                    AuthStateChangeEvent.SIGNED_OUT,
+                ),
+                events,
+            )
+            assertEquals(null, sessions[0])
+            assertEquals("acc-1", sessions[1]?.accessToken)
+            assertEquals("acc-2", sessions[2]?.accessToken)
+            assertEquals(null, sessions[3])
         }
-        runCurrent()
-
-        manager.emit(SessionState.Authenticated(testSession(accessToken = "acc-1", refreshToken = "ref-1")))
-        runCurrent()
-        manager.emit(SessionState.Authenticated(testSession(accessToken = "acc-2", refreshToken = "ref-2")))
-        runCurrent()
-        manager.emit(SessionState.NotAuthenticated)
-        runCurrent()
-        job.cancelAndJoin()
-
-        assertEquals(
-            listOf(
-                AuthStateChangeEvent.INITIAL_SESSION,
-                AuthStateChangeEvent.SIGNED_IN,
-                AuthStateChangeEvent.TOKEN_REFRESHED,
-                AuthStateChangeEvent.SIGNED_OUT,
-            ),
-            events,
-        )
-        assertEquals(null, sessions[0])
-        assertEquals("acc-1", sessions[1]?.accessToken)
-        assertEquals("acc-2", sessions[2]?.accessToken)
-        assertEquals(null, sessions[3])
-    }
 }
 
 private fun testSession(
     accessToken: String,
     refreshToken: String,
-): Session = Session(
-    accessToken = accessToken,
-    refreshToken = refreshToken,
-    expiresIn = 3600,
-    tokenType = "bearer",
-    user = User(id = "user-1"),
-)
+): Session =
+    Session(
+        accessToken = accessToken,
+        refreshToken = refreshToken,
+        expiresIn = 3600,
+        tokenType = "bearer",
+        user = User(id = "user-1"),
+    )
 
 private class StateFakeSessionManager : SessionManager {
     private val state = MutableStateFlow<SessionState>(SessionState.NotAuthenticated)
@@ -91,7 +94,10 @@ private class StateFakeSessionManager : SessionManager {
         restoreSession()
 
     override fun startAutoRefresh() = Unit
+
     override fun stopAutoRefresh() = Unit
+
     override fun dispose() = Unit
+
     override fun close() = Unit
 }

--- a/supabase-auth/src/commonTest/kotlin/io/github/androidpoet/supabase/auth/session/SessionManagerImplTest.kt
+++ b/supabase-auth/src/commonTest/kotlin/io/github/androidpoet/supabase/auth/session/SessionManagerImplTest.kt
@@ -6,67 +6,72 @@ import io.github.androidpoet.supabase.auth.models.User
 import io.github.androidpoet.supabase.client.SupabaseClient
 import io.github.androidpoet.supabase.core.result.SupabaseError
 import io.github.androidpoet.supabase.core.result.SupabaseResult
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
-import kotlinx.coroutines.channels.Channel
-import kotlinx.coroutines.test.runTest
 
 class SessionManagerImplTest {
     @Test
-    fun test_initialize_restoresAndRefreshesStoredSession() = runTest {
-        val client = SessionFakeSupabaseClient()
-        val storage = FakeSessionStorage(storedSession = staleSession)
-        val manager = SessionManagerImpl(
-            authClient = AuthClientImpl(client),
-            supabaseClient = client,
-            storage = storage,
-            autoRefresh = false,
-        )
+    fun test_initialize_restoresAndRefreshesStoredSession() =
+        runTest {
+            val client = SessionFakeSupabaseClient()
+            val storage = FakeSessionStorage(storedSession = staleSession)
+            val manager =
+                SessionManagerImpl(
+                    authClient = AuthClientImpl(client),
+                    supabaseClient = client,
+                    storage = storage,
+                    autoRefresh = false,
+                )
 
-        val result = manager.initialize()
+            val result = manager.initialize()
 
-        assertTrue(result is SupabaseResult.Success)
-        assertEquals("refreshed-acc", result.value.accessToken)
-        assertEquals("Bearer refreshed-acc", client.accessTokenHeader)
-        assertEquals("/auth/v1/token?grant_type=refresh_token", client.lastPostEndpoint)
-    }
+            assertTrue(result is SupabaseResult.Success)
+            assertEquals("refreshed-acc", result.value.accessToken)
+            assertEquals("Bearer refreshed-acc", client.accessTokenHeader)
+            assertEquals("/auth/v1/token?grant_type=refresh_token", client.lastPostEndpoint)
+        }
 
     @Test
-    fun test_startAndStopAutoRefresh_controlRefreshScheduling() = runTest {
-        val client = SessionFakeSupabaseClient()
-        val storage = FakeSessionStorage()
-        val manager = SessionManagerImpl(
-            authClient = AuthClientImpl(client),
-            supabaseClient = client,
-            storage = storage,
-            autoRefresh = false,
-            refreshBufferSeconds = 0,
-        )
-        try {
-            manager.saveSession(staleSession.copy(expiresIn = 0))
-            assertEquals(0, client.postCount)
+    fun test_startAndStopAutoRefresh_controlRefreshScheduling() =
+        runTest {
+            val client = SessionFakeSupabaseClient()
+            val storage = FakeSessionStorage()
+            val manager =
+                SessionManagerImpl(
+                    authClient = AuthClientImpl(client),
+                    supabaseClient = client,
+                    storage = storage,
+                    autoRefresh = false,
+                    refreshBufferSeconds = 0,
+                )
+            try {
+                manager.saveSession(staleSession.copy(expiresIn = 0))
+                assertEquals(0, client.postCount)
 
-            manager.startAutoRefresh()
-            client.awaitPostCount(1)
-            assertEquals(1, client.postCount)
+                manager.startAutoRefresh()
+                client.awaitPostCount(1)
+                assertEquals(1, client.postCount)
 
-            manager.stopAutoRefresh()
-            manager.saveSession(staleSession.copy(accessToken = "second-acc", expiresIn = 0))
-            assertEquals(1, client.postCount)
-        } finally {
-            manager.close()
+                manager.stopAutoRefresh()
+                manager.saveSession(staleSession.copy(accessToken = "second-acc", expiresIn = 0))
+                assertEquals(1, client.postCount)
+            } finally {
+                manager.close()
+            }
         }
-    }
 }
 
-private val staleSession = Session(
-    accessToken = "stale-acc",
-    refreshToken = "stale-ref",
-    expiresIn = 3600,
-    tokenType = "bearer",
-    user = User(id = "user-1"),
-)
+private val staleSession =
+    Session(
+        accessToken = "stale-acc",
+        refreshToken = "stale-ref",
+        expiresIn = 3600,
+        tokenType = "bearer",
+        user = User(id = "user-1"),
+    )
 
 private class FakeSessionStorage(
     private var storedSession: Session? = null,

--- a/supabase-client/src/commonMain/kotlin/io/github/androidpoet/supabase/client/Supabase.kt
+++ b/supabase-client/src/commonMain/kotlin/io/github/androidpoet/supabase/client/Supabase.kt
@@ -2,6 +2,7 @@ package io.github.androidpoet.supabase.client
 import io.github.androidpoet.supabase.client.transport.HttpTransport
 import io.github.androidpoet.supabase.client.transport.platformEngine
 import io.ktor.client.engine.HttpClientEngineFactory
+
 public object Supabase {
     public fun create(
         projectUrl: String,
@@ -15,12 +16,13 @@ public object Supabase {
         }
         require(apiKey.isNotBlank()) { "apiKey must not be blank" }
         val config = SupabaseConfigBuilder().apply(configure).build()
-        val transport = HttpTransport(
-            config = config,
-            engineFactory = engineFactory,
-            projectUrl = projectUrl,
-            apiKey = apiKey,
-        )
+        val transport =
+            HttpTransport(
+                config = config,
+                engineFactory = engineFactory,
+                projectUrl = projectUrl,
+                apiKey = apiKey,
+            )
         return SupabaseClientImpl(
             projectUrl = projectUrl,
             apiKey = apiKey,

--- a/supabase-client/src/commonMain/kotlin/io/github/androidpoet/supabase/client/SupabaseClient.kt
+++ b/supabase-client/src/commonMain/kotlin/io/github/androidpoet/supabase/client/SupabaseClient.kt
@@ -1,47 +1,58 @@
 package io.github.androidpoet.supabase.client
 import io.github.androidpoet.supabase.core.result.SupabaseResult
+
 public interface SupabaseClient : AutoCloseable {
     public val projectUrl: String
     public val apiKey: String
     public val accessTokenOrNull: String?
+
     public suspend fun get(
         endpoint: String,
         queryParams: List<Pair<String, String>> = emptyList(),
         headers: Map<String, String> = emptyMap(),
     ): SupabaseResult<String>
+
     public suspend fun post(
         endpoint: String,
         body: String? = null,
         headers: Map<String, String> = emptyMap(),
     ): SupabaseResult<String>
+
     public suspend fun put(
         endpoint: String,
         body: String? = null,
         headers: Map<String, String> = emptyMap(),
     ): SupabaseResult<String>
+
     public suspend fun patch(
         endpoint: String,
         body: String? = null,
         headers: Map<String, String> = emptyMap(),
     ): SupabaseResult<String>
+
     public suspend fun delete(
         endpoint: String,
         body: String? = null,
         headers: Map<String, String> = emptyMap(),
     ): SupabaseResult<String>
+
     public suspend fun postRaw(
         url: String,
         body: ByteArray,
         contentType: String,
         headers: Map<String, String> = emptyMap(),
     ): SupabaseResult<String>
+
     public suspend fun putRaw(
         url: String,
         body: ByteArray,
         contentType: String,
         headers: Map<String, String> = emptyMap(),
     ): SupabaseResult<String>
+
     public fun setAccessToken(token: String)
+
     public fun clearAccessToken()
+
     override fun close()
 }

--- a/supabase-client/src/commonMain/kotlin/io/github/androidpoet/supabase/client/SupabaseClientExt.kt
+++ b/supabase-client/src/commonMain/kotlin/io/github/androidpoet/supabase/client/SupabaseClientExt.kt
@@ -1,30 +1,37 @@
 package io.github.androidpoet.supabase.client
 import io.github.androidpoet.supabase.core.result.SupabaseResult
 import kotlinx.serialization.json.Json
-public val defaultJson: Json = Json {
-    ignoreUnknownKeys = true
-    isLenient = true
-    explicitNulls = false
-}
+
+public val defaultJson: Json =
+    Json {
+        ignoreUnknownKeys = true
+        isLenient = true
+        explicitNulls = false
+    }
+
 public suspend inline fun <reified T> SupabaseClient.getTyped(
     endpoint: String,
     queryParams: List<Pair<String, String>> = emptyList(),
     headers: Map<String, String> = emptyMap(),
 ): SupabaseResult<T> = get(endpoint, queryParams, headers).deserialize()
+
 public suspend inline fun <reified T> SupabaseClient.postTyped(
     endpoint: String,
     body: String? = null,
     headers: Map<String, String> = emptyMap(),
 ): SupabaseResult<T> = post(endpoint, body, headers).deserialize()
+
 public suspend inline fun <reified T> SupabaseClient.patchTyped(
     endpoint: String,
     body: String? = null,
     headers: Map<String, String> = emptyMap(),
 ): SupabaseResult<T> = patch(endpoint, body, headers).deserialize()
+
 public inline fun <reified T> SupabaseResult<String>.deserialize(): SupabaseResult<T> =
     when (this) {
-        is SupabaseResult.Success -> SupabaseResult.catching {
-            defaultJson.decodeFromString<T>(value)
-        }
+        is SupabaseResult.Success ->
+            SupabaseResult.catching {
+                defaultJson.decodeFromString<T>(value)
+            }
         is SupabaseResult.Failure -> this
     }

--- a/supabase-client/src/commonMain/kotlin/io/github/androidpoet/supabase/client/SupabaseClientImpl.kt
+++ b/supabase-client/src/commonMain/kotlin/io/github/androidpoet/supabase/client/SupabaseClientImpl.kt
@@ -1,6 +1,7 @@
 package io.github.androidpoet.supabase.client
 import io.github.androidpoet.supabase.client.transport.HttpTransport
 import io.github.androidpoet.supabase.core.result.SupabaseResult
+
 internal class SupabaseClientImpl(
     override val projectUrl: String,
     override val apiKey: String,
@@ -15,30 +16,35 @@ internal class SupabaseClientImpl(
         headers: Map<String, String>,
     ): SupabaseResult<String> =
         transport.get(url = "$projectUrl$endpoint", queryParams = queryParams, headers = headers)
+
     override suspend fun post(
         endpoint: String,
         body: String?,
         headers: Map<String, String>,
     ): SupabaseResult<String> =
         transport.post(url = "$projectUrl$endpoint", body = body, headers = headers)
+
     override suspend fun put(
         endpoint: String,
         body: String?,
         headers: Map<String, String>,
     ): SupabaseResult<String> =
         transport.put(url = "$projectUrl$endpoint", body = body, headers = headers)
+
     override suspend fun patch(
         endpoint: String,
         body: String?,
         headers: Map<String, String>,
     ): SupabaseResult<String> =
         transport.patch(url = "$projectUrl$endpoint", body = body, headers = headers)
+
     override suspend fun delete(
         endpoint: String,
         body: String?,
         headers: Map<String, String>,
     ): SupabaseResult<String> =
         transport.delete(url = "$projectUrl$endpoint", body = body, headers = headers)
+
     override suspend fun postRaw(
         url: String,
         body: ByteArray,
@@ -46,6 +52,7 @@ internal class SupabaseClientImpl(
         headers: Map<String, String>,
     ): SupabaseResult<String> =
         transport.postRaw(url = "$projectUrl$url", body = body, contentType = contentType, headers = headers)
+
     override suspend fun putRaw(
         url: String,
         body: ByteArray,
@@ -53,12 +60,15 @@ internal class SupabaseClientImpl(
         headers: Map<String, String>,
     ): SupabaseResult<String> =
         transport.putRaw(url = "$projectUrl$url", body = body, contentType = contentType, headers = headers)
+
     override fun setAccessToken(token: String) {
         transport.setAccessToken(token)
     }
+
     override fun clearAccessToken() {
         transport.clearAccessToken()
     }
+
     override fun close() {
         transport.close()
     }

--- a/supabase-client/src/commonMain/kotlin/io/github/androidpoet/supabase/client/SupabaseConfig.kt
+++ b/supabase-client/src/commonMain/kotlin/io/github/androidpoet/supabase/client/SupabaseConfig.kt
@@ -1,18 +1,23 @@
 package io.github.androidpoet.supabase.client
 import io.ktor.client.plugins.logging.LogLevel
+
 @DslMarker
 public annotation class SupabaseDsl
+
 @SupabaseDsl
 public class SupabaseConfigBuilder {
     public var logging: Boolean = false
     public var logLevel: LogLevel = LogLevel.NONE
     public val headers: MutableMap<String, String> = mutableMapOf()
-    internal fun build(): SupabaseConfig = SupabaseConfig(
-        logging = logging,
-        logLevel = logLevel,
-        headers = headers.toMap(),
-    )
+
+    internal fun build(): SupabaseConfig =
+        SupabaseConfig(
+            logging = logging,
+            logLevel = logLevel,
+            headers = headers.toMap(),
+        )
 }
+
 public data class SupabaseConfig(
     val logging: Boolean,
     val logLevel: LogLevel,

--- a/supabase-client/src/commonMain/kotlin/io/github/androidpoet/supabase/client/auth/AuthState.kt
+++ b/supabase-client/src/commonMain/kotlin/io/github/androidpoet/supabase/client/auth/AuthState.kt
@@ -1,16 +1,27 @@
 package io.github.androidpoet.supabase.client.auth
+
 public sealed interface AuthState {
     public data object None : AuthState
-    public data class ApiKey(val key: String) : AuthState
-    public data class Bearer(val token: String) : AuthState
+
+    public data class ApiKey(
+        val key: String,
+    ) : AuthState
+
+    public data class Bearer(
+        val token: String,
+    ) : AuthState
 }
-public fun AuthState.apiKeyHeader(): String? = when (this) {
-    is AuthState.None -> null
-    is AuthState.ApiKey -> key
-    is AuthState.Bearer -> null
-}
-public fun AuthState.authorizationHeader(): String? = when (this) {
-    is AuthState.None -> null
-    is AuthState.ApiKey -> "Bearer $key"
-    is AuthState.Bearer -> "Bearer $token"
-}
+
+public fun AuthState.apiKeyHeader(): String? =
+    when (this) {
+        is AuthState.None -> null
+        is AuthState.ApiKey -> key
+        is AuthState.Bearer -> null
+    }
+
+public fun AuthState.authorizationHeader(): String? =
+    when (this) {
+        is AuthState.None -> null
+        is AuthState.ApiKey -> "Bearer $key"
+        is AuthState.Bearer -> "Bearer $token"
+    }

--- a/supabase-client/src/commonMain/kotlin/io/github/androidpoet/supabase/client/transport/HttpTransport.kt
+++ b/supabase-client/src/commonMain/kotlin/io/github/androidpoet/supabase/client/transport/HttpTransport.kt
@@ -24,10 +24,12 @@ import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.delay
 import kotlinx.serialization.json.Json
 import kotlin.concurrent.Volatile
+
 private const val CLIENT_VERSION = "supabase-kmp/0.1.0"
 private const val INTERNAL_RETRY_HEADER = "X-Supabase-Kmp-Retry"
 private const val RETRY_COUNT_HEADER = "X-Retry-Count"
 private const val DEFAULT_MAX_RETRIES = 3
+
 internal class HttpTransport(
     private val config: SupabaseConfig,
     engineFactory: HttpClientEngineFactory<*>,
@@ -41,34 +43,36 @@ internal class HttpTransport(
     private var accessToken: String? = null
     internal val accessTokenOrNull: String? get() = accessToken
     private val errorJson = Json { ignoreUnknownKeys = true }
-    internal val httpClient: HttpClient = HttpClient(engineFactory) {
-        install(ContentNegotiation) {
-            json(
-                Json {
-                    ignoreUnknownKeys = true
-                    isLenient = true
-                    explicitNulls = false
-                },
-            )
-        }
-        if (config.logging) {
-            install(Logging) {
-                level = config.logLevel
-                // Never let credentials reach the log sink. This covers the anon/service
-                // apikey header and every Bearer token (including the auth-admin
-                // service-role key, which flows through this same client).
-                sanitizeHeader { name ->
-                    name.equals("Authorization", ignoreCase = true) ||
-                        name.equals("apikey", ignoreCase = true)
+    internal val httpClient: HttpClient =
+        HttpClient(engineFactory) {
+            install(ContentNegotiation) {
+                json(
+                    Json {
+                        ignoreUnknownKeys = true
+                        isLenient = true
+                        explicitNulls = false
+                    },
+                )
+            }
+            if (config.logging) {
+                install(Logging) {
+                    level = config.logLevel
+                    // Never let credentials reach the log sink. This covers the anon/service
+                    // apikey header and every Bearer token (including the auth-admin
+                    // service-role key, which flows through this same client).
+                    sanitizeHeader { name ->
+                        name.equals("Authorization", ignoreCase = true) ||
+                            name.equals("apikey", ignoreCase = true)
+                    }
                 }
             }
+            defaultRequest {
+                header("apikey", apiKey)
+                header("X-Client-Info", CLIENT_VERSION)
+                config.headers.forEach { (key, value) -> header(key, value) }
+            }
         }
-        defaultRequest {
-            header("apikey", apiKey)
-            header("X-Client-Info", CLIENT_VERSION)
-            config.headers.forEach { (key, value) -> header(key, value) }
-        }
-    }
+
     suspend fun get(
         url: String,
         queryParams: List<Pair<String, String>> = emptyList(),
@@ -77,16 +81,17 @@ internal class HttpTransport(
         val retryEnabled = headers[INTERNAL_RETRY_HEADER]?.toBooleanStrictOrNull() ?: false
         val outgoingHeaders = headers - INTERNAL_RETRY_HEADER
         return execute(retryEnabled = retryEnabled, retryableMethod = true) { attempt ->
-        httpClient.get(url) {
-            queryParams.forEach { (k, v) -> this.url.parameters.append(k, v) }
-            outgoingHeaders.forEach { (k, v) -> header(k, v) }
-            if (attempt > 0) header(RETRY_COUNT_HEADER, attempt.toString())
-            if ("Authorization" !in outgoingHeaders) {
-                header("Authorization", "Bearer ${accessToken ?: apiKey}")
+            httpClient.get(url) {
+                queryParams.forEach { (k, v) -> this.url.parameters.append(k, v) }
+                outgoingHeaders.forEach { (k, v) -> header(k, v) }
+                if (attempt > 0) header(RETRY_COUNT_HEADER, attempt.toString())
+                if ("Authorization" !in outgoingHeaders) {
+                    header("Authorization", "Bearer ${accessToken ?: apiKey}")
+                }
             }
         }
     }
-    }
+
     suspend fun post(
         url: String,
         body: String? = null,
@@ -94,16 +99,17 @@ internal class HttpTransport(
     ): SupabaseResult<String> {
         val outgoingHeaders = headers - INTERNAL_RETRY_HEADER
         return execute {
-        httpClient.post(url) {
-            contentType(ContentType.Application.Json)
-            body?.let { setBody(it) }
-            outgoingHeaders.forEach { (k, v) -> header(k, v) }
-            if ("Authorization" !in outgoingHeaders) {
-                header("Authorization", "Bearer ${accessToken ?: apiKey}")
+            httpClient.post(url) {
+                contentType(ContentType.Application.Json)
+                body?.let { setBody(it) }
+                outgoingHeaders.forEach { (k, v) -> header(k, v) }
+                if ("Authorization" !in outgoingHeaders) {
+                    header("Authorization", "Bearer ${accessToken ?: apiKey}")
+                }
             }
         }
     }
-    }
+
     suspend fun put(
         url: String,
         body: String? = null,
@@ -111,16 +117,17 @@ internal class HttpTransport(
     ): SupabaseResult<String> {
         val outgoingHeaders = headers - INTERNAL_RETRY_HEADER
         return execute {
-        httpClient.put(url) {
-            contentType(ContentType.Application.Json)
-            body?.let { setBody(it) }
-            outgoingHeaders.forEach { (k, v) -> header(k, v) }
-            if ("Authorization" !in outgoingHeaders) {
-                header("Authorization", "Bearer ${accessToken ?: apiKey}")
+            httpClient.put(url) {
+                contentType(ContentType.Application.Json)
+                body?.let { setBody(it) }
+                outgoingHeaders.forEach { (k, v) -> header(k, v) }
+                if ("Authorization" !in outgoingHeaders) {
+                    header("Authorization", "Bearer ${accessToken ?: apiKey}")
+                }
             }
         }
     }
-    }
+
     suspend fun patch(
         url: String,
         body: String? = null,
@@ -128,16 +135,17 @@ internal class HttpTransport(
     ): SupabaseResult<String> {
         val outgoingHeaders = headers - INTERNAL_RETRY_HEADER
         return execute {
-        httpClient.patch(url) {
-            contentType(ContentType.Application.Json)
-            body?.let { setBody(it) }
-            outgoingHeaders.forEach { (k, v) -> header(k, v) }
-            if ("Authorization" !in outgoingHeaders) {
-                header("Authorization", "Bearer ${accessToken ?: apiKey}")
+            httpClient.patch(url) {
+                contentType(ContentType.Application.Json)
+                body?.let { setBody(it) }
+                outgoingHeaders.forEach { (k, v) -> header(k, v) }
+                if ("Authorization" !in outgoingHeaders) {
+                    header("Authorization", "Bearer ${accessToken ?: apiKey}")
+                }
             }
         }
     }
-    }
+
     suspend fun delete(
         url: String,
         body: String? = null,
@@ -145,18 +153,19 @@ internal class HttpTransport(
     ): SupabaseResult<String> {
         val outgoingHeaders = headers - INTERNAL_RETRY_HEADER
         return execute {
-        httpClient.delete(url) {
-            if (body != null) {
-                contentType(ContentType.Application.Json)
-                setBody(body)
-            }
-            outgoingHeaders.forEach { (k, v) -> header(k, v) }
-            if ("Authorization" !in outgoingHeaders) {
-                header("Authorization", "Bearer ${accessToken ?: apiKey}")
+            httpClient.delete(url) {
+                if (body != null) {
+                    contentType(ContentType.Application.Json)
+                    setBody(body)
+                }
+                outgoingHeaders.forEach { (k, v) -> header(k, v) }
+                if ("Authorization" !in outgoingHeaders) {
+                    header("Authorization", "Bearer ${accessToken ?: apiKey}")
+                }
             }
         }
     }
-    }
+
     suspend fun postRaw(
         url: String,
         body: ByteArray,
@@ -165,16 +174,17 @@ internal class HttpTransport(
     ): SupabaseResult<String> {
         val outgoingHeaders = headers - INTERNAL_RETRY_HEADER
         return execute {
-        httpClient.post(url) {
-            contentType(ContentType.parse(contentType))
-            setBody(body)
-            outgoingHeaders.forEach { (k, v) -> header(k, v) }
-            if ("Authorization" !in outgoingHeaders) {
-                header("Authorization", "Bearer ${accessToken ?: apiKey}")
+            httpClient.post(url) {
+                contentType(ContentType.parse(contentType))
+                setBody(body)
+                outgoingHeaders.forEach { (k, v) -> header(k, v) }
+                if ("Authorization" !in outgoingHeaders) {
+                    header("Authorization", "Bearer ${accessToken ?: apiKey}")
+                }
             }
         }
     }
-    }
+
     suspend fun putRaw(
         url: String,
         body: ByteArray,
@@ -183,25 +193,29 @@ internal class HttpTransport(
     ): SupabaseResult<String> {
         val outgoingHeaders = headers - INTERNAL_RETRY_HEADER
         return execute {
-        httpClient.put(url) {
-            contentType(ContentType.parse(contentType))
-            setBody(body)
-            outgoingHeaders.forEach { (k, v) -> header(k, v) }
-            if ("Authorization" !in outgoingHeaders) {
-                header("Authorization", "Bearer ${accessToken ?: apiKey}")
+            httpClient.put(url) {
+                contentType(ContentType.parse(contentType))
+                setBody(body)
+                outgoingHeaders.forEach { (k, v) -> header(k, v) }
+                if ("Authorization" !in outgoingHeaders) {
+                    header("Authorization", "Bearer ${accessToken ?: apiKey}")
+                }
             }
         }
     }
-    }
+
     fun setAccessToken(token: String) {
         accessToken = token
     }
+
     fun clearAccessToken() {
         accessToken = null
     }
+
     fun close() {
         httpClient.close()
     }
+
     private suspend inline fun execute(
         retryEnabled: Boolean = false,
         retryableMethod: Boolean = false,
@@ -210,17 +224,18 @@ internal class HttpTransport(
         return try {
             var attempt = 0
             while (attempt <= DEFAULT_MAX_RETRIES) {
-                val response = try {
-                    request(attempt)
-                } catch (e: Throwable) {
-                    if (e is CancellationException) throw e
-                    if (retryEnabled && retryableMethod && attempt < DEFAULT_MAX_RETRIES) {
-                        delay(retryDelayMillis(attempt))
-                        attempt++
-                        continue
+                val response =
+                    try {
+                        request(attempt)
+                    } catch (e: Throwable) {
+                        if (e is CancellationException) throw e
+                        if (retryEnabled && retryableMethod && attempt < DEFAULT_MAX_RETRIES) {
+                            delay(retryDelayMillis(attempt))
+                            attempt++
+                            continue
+                        }
+                        throw e
                     }
-                    throw e
-                }
                 val text = response.bodyAsText()
                 val statusCode = response.status.value
                 if (response.status.isSuccess()) {
@@ -242,19 +257,24 @@ internal class HttpTransport(
             )
         }
     }
+
     private fun io.ktor.client.statement.HttpResponse.retryDelayMillis(attempt: Int): Long {
         val retryAfterSeconds = headers["Retry-After"]?.toLongOrNull()
         return if (retryAfterSeconds != null) retryAfterSeconds.coerceAtLeast(0) * 1_000 else retryDelayMillis(attempt)
     }
+
     private fun retryDelayMillis(attempt: Int): Long =
         1_000L shl attempt
+
     private fun Int.isRetryableStatus(): Boolean =
-        this == 429 || // Too Many Requests — Retry-After is honored above
+        this == 429 ||
+            // Too Many Requests — Retry-After is honored above
             this == 500 ||
             this == 502 ||
             this == 503 ||
             this == 504 ||
             this == 520
+
     private fun parseError(body: String, statusCode: Int): SupabaseError =
         try {
             errorJson.decodeFromString<SupabaseError>(body)

--- a/supabase-client/src/commonTest/kotlin/io/github/androidpoet/supabase/client/SupabaseTest.kt
+++ b/supabase-client/src/commonTest/kotlin/io/github/androidpoet/supabase/client/SupabaseTest.kt
@@ -6,32 +6,35 @@ import io.ktor.client.engine.mock.respond
 import io.ktor.http.HttpHeaders
 import io.ktor.http.HttpStatusCode
 import io.ktor.http.headersOf
+import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
-import kotlinx.coroutines.test.runTest
 
 class SupabaseTest {
     @Test
-    fun test_create_usesCustomEngineFactory() = runTest {
-        var requestedUrl: String? = null
-        val engineFactory = TestMockEngineFactory { request ->
-            requestedUrl = request.url.toString()
-            respond(
-                content = """{"ok":true}""",
-                status = HttpStatusCode.OK,
-                headers = headersOf(HttpHeaders.ContentType, "application/json"),
-            )
+    fun test_create_usesCustomEngineFactory() =
+        runTest {
+            var requestedUrl: String? = null
+            val engineFactory =
+                TestMockEngineFactory { request ->
+                    requestedUrl = request.url.toString()
+                    respond(
+                        content = """{"ok":true}""",
+                        status = HttpStatusCode.OK,
+                        headers = headersOf(HttpHeaders.ContentType, "application/json"),
+                    )
+                }
+            val client =
+                Supabase.create(
+                    projectUrl = "https://example.supabase.co",
+                    apiKey = "anon",
+                    engineFactory = engineFactory,
+                )
+
+            val result = client.get("/rest/v1/messages")
+
+            assertTrue(result is SupabaseResult.Success)
+            assertEquals("https://example.supabase.co/rest/v1/messages", requestedUrl)
         }
-        val client = Supabase.create(
-            projectUrl = "https://example.supabase.co",
-            apiKey = "anon",
-            engineFactory = engineFactory,
-        )
-
-        val result = client.get("/rest/v1/messages")
-
-        assertTrue(result is SupabaseResult.Success)
-        assertEquals("https://example.supabase.co/rest/v1/messages", requestedUrl)
-    }
 }

--- a/supabase-client/src/commonTest/kotlin/io/github/androidpoet/supabase/client/transport/HttpTransportTest.kt
+++ b/supabase-client/src/commonTest/kotlin/io/github/androidpoet/supabase/client/transport/HttpTransportTest.kt
@@ -9,90 +9,101 @@ import io.ktor.client.engine.mock.respond
 import io.ktor.http.HttpHeaders
 import io.ktor.http.HttpStatusCode
 import io.ktor.http.headersOf
-import kotlin.coroutines.cancellation.CancellationException
-import kotlin.test.Test
-import kotlin.test.assertEquals
-import kotlin.test.assertFailsWith
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.async
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
+import kotlin.coroutines.cancellation.CancellationException
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class HttpTransportTest {
     @Test
-    fun test_get_appliesGlobalHeadersAndAllowsPerCallOverride() = runTest {
-        var traceHeader: String? = null
-        var sourceHeader: String? = null
-        val engineFactory = object : HttpClientEngineFactory<MockEngineConfig> {
-            override fun create(block: MockEngineConfig.() -> Unit): HttpClientEngine {
-                val config = MockEngineConfig().apply {
-                    addHandler { request ->
-                        traceHeader = request.headers["X-Trace-Id"]
-                        sourceHeader = request.headers["X-Source"]
-                        respond(
-                            content = "{}",
-                            status = HttpStatusCode.OK,
-                            headers = headersOf(HttpHeaders.ContentType, "application/json"),
-                        )
+    fun test_get_appliesGlobalHeadersAndAllowsPerCallOverride() =
+        runTest {
+            var traceHeader: String? = null
+            var sourceHeader: String? = null
+            val engineFactory =
+                object : HttpClientEngineFactory<MockEngineConfig> {
+                    override fun create(block: MockEngineConfig.() -> Unit): HttpClientEngine {
+                        val config =
+                            MockEngineConfig().apply {
+                                addHandler { request ->
+                                    traceHeader = request.headers["X-Trace-Id"]
+                                    sourceHeader = request.headers["X-Source"]
+                                    respond(
+                                        content = "{}",
+                                        status = HttpStatusCode.OK,
+                                        headers = headersOf(HttpHeaders.ContentType, "application/json"),
+                                    )
+                                }
+                                block()
+                            }
+                        return MockEngine(config)
                     }
-                    block()
                 }
-                return MockEngine(config)
-            }
+            val transport =
+                HttpTransport(
+                    config =
+                        SupabaseConfig(
+                            logging = false,
+                            logLevel = io.ktor.client.plugins.logging.LogLevel.NONE,
+                            headers =
+                                mapOf(
+                                    "X-Trace-Id" to "global-trace",
+                                    "X-Source" to "global-source",
+                                ),
+                        ),
+                    engineFactory = engineFactory,
+                    projectUrl = "https://example.supabase.co",
+                    apiKey = "anon",
+                )
+
+            transport.get(
+                url = "https://example.supabase.co/rest/v1/messages",
+                headers = mapOf("X-Trace-Id" to "request-trace"),
+            )
+
+            assertEquals("request-trace", traceHeader)
+            assertEquals("global-source", sourceHeader)
         }
-        val transport = HttpTransport(
-            config = SupabaseConfig(
-                logging = false,
-                logLevel = io.ktor.client.plugins.logging.LogLevel.NONE,
-                headers = mapOf(
-                    "X-Trace-Id" to "global-trace",
-                    "X-Source" to "global-source",
-                ),
-            ),
-            engineFactory = engineFactory,
-            projectUrl = "https://example.supabase.co",
-            apiKey = "anon",
-        )
-
-        transport.get(
-            url = "https://example.supabase.co/rest/v1/messages",
-            headers = mapOf("X-Trace-Id" to "request-trace"),
-        )
-
-        assertEquals("request-trace", traceHeader)
-        assertEquals("global-source", sourceHeader)
-    }
 
     @Test
-    fun test_get_propagatesCoroutineCancellation() = runTest {
-        val transport = HttpTransport(
-            config = SupabaseConfig(
-                logging = false,
-                logLevel = io.ktor.client.plugins.logging.LogLevel.NONE,
-                headers = emptyMap(),
-            ),
-            engineFactory = TestMockEngineFactory {
-                delay(60_000)
-                respond(
-                    content = "{}",
-                    status = HttpStatusCode.OK,
-                    headers = headersOf(HttpHeaders.ContentType, "application/json"),
+    fun test_get_propagatesCoroutineCancellation() =
+        runTest {
+            val transport =
+                HttpTransport(
+                    config =
+                        SupabaseConfig(
+                            logging = false,
+                            logLevel = io.ktor.client.plugins.logging.LogLevel.NONE,
+                            headers = emptyMap(),
+                        ),
+                    engineFactory =
+                        TestMockEngineFactory {
+                            delay(60_000)
+                            respond(
+                                content = "{}",
+                                status = HttpStatusCode.OK,
+                                headers = headersOf(HttpHeaders.ContentType, "application/json"),
+                            )
+                        },
+                    projectUrl = "https://example.supabase.co",
+                    apiKey = "anon",
                 )
-            },
-            projectUrl = "https://example.supabase.co",
-            apiKey = "anon",
-        )
 
-        val request = async {
-            transport.get(url = "https://example.supabase.co/rest/v1/messages")
-        }
-        runCurrent()
-        request.cancel()
+            val request =
+                async {
+                    transport.get(url = "https://example.supabase.co/rest/v1/messages")
+                }
+            runCurrent()
+            request.cancel()
 
-        assertFailsWith<CancellationException> {
-            request.await()
+            assertFailsWith<CancellationException> {
+                request.await()
+            }
         }
-    }
 }

--- a/supabase-client/src/commonTest/kotlin/io/github/androidpoet/supabase/client/transport/TestMockEngineFactory.kt
+++ b/supabase-client/src/commonTest/kotlin/io/github/androidpoet/supabase/client/transport/TestMockEngineFactory.kt
@@ -12,10 +12,11 @@ internal class TestMockEngineFactory(
     private val handler: suspend MockRequestHandleScope.(HttpRequestData) -> HttpResponseData,
 ) : HttpClientEngineFactory<MockEngineConfig> {
     override fun create(block: MockEngineConfig.() -> Unit): HttpClientEngine {
-        val config = MockEngineConfig().apply {
-            addHandler(handler)
-            block()
-        }
+        val config =
+            MockEngineConfig().apply {
+                addHandler(handler)
+                block()
+            }
         return MockEngine(config)
     }
 }

--- a/supabase-core/src/commonMain/kotlin/io/github/androidpoet/supabase/core/models/Filters.kt
+++ b/supabase-core/src/commonMain/kotlin/io/github/androidpoet/supabase/core/models/Filters.kt
@@ -1,121 +1,160 @@
 package io.github.androidpoet.supabase.core.models
+
 @DslMarker
 public annotation class FilterDsl
-public enum class TextSearchType(internal val postgrestName: String) {
+
+public enum class TextSearchType(
+    internal val postgrestName: String,
+) {
     Plain("pl"),
     Phrase("ph"),
     Websearch("w"),
 }
+
 @FilterDsl
 public class FilterBuilder {
     @PublishedApi
     internal val params: MutableList<Pair<String, String>> = mutableListOf()
+
     public fun eq(column: String, value: String) {
         params += column to "eq.${encodeValue(value)}"
     }
+
     public fun eq(column: String, value: Number) {
         params += column to "eq.$value"
     }
+
     public fun neq(column: String, value: String) {
         params += column to "neq.${encodeValue(value)}"
     }
+
     public fun neq(column: String, value: Number) {
         params += column to "neq.$value"
     }
+
     public fun gt(column: String, value: String) {
         params += column to "gt.${encodeValue(value)}"
     }
+
     public fun gt(column: String, value: Number) {
         params += column to "gt.$value"
     }
+
     public fun gte(column: String, value: String) {
         params += column to "gte.${encodeValue(value)}"
     }
+
     public fun gte(column: String, value: Number) {
         params += column to "gte.$value"
     }
+
     public fun lt(column: String, value: String) {
         params += column to "lt.${encodeValue(value)}"
     }
+
     public fun lt(column: String, value: Number) {
         params += column to "lt.$value"
     }
+
     public fun lte(column: String, value: String) {
         params += column to "lte.${encodeValue(value)}"
     }
+
     public fun lte(column: String, value: Number) {
         params += column to "lte.$value"
     }
+
     public fun like(column: String, pattern: String) {
         params += column to "like.$pattern"
     }
+
     public fun likeAllOf(column: String, patterns: List<String>) {
         params += column to "like(all).{${patterns.joinToString(",")}}"
     }
+
     public fun likeAnyOf(column: String, patterns: List<String>) {
         params += column to "like(any).{${patterns.joinToString(",")}}"
     }
+
     public fun ilike(column: String, pattern: String) {
         params += column to "ilike.$pattern"
     }
+
     public fun ilikeAllOf(column: String, patterns: List<String>) {
         params += column to "ilike(all).{${patterns.joinToString(",")}}"
     }
+
     public fun ilikeAnyOf(column: String, patterns: List<String>) {
         params += column to "ilike(any).{${patterns.joinToString(",")}}"
     }
+
     public fun `is`(column: String, value: String) {
         params += column to "is.$value"
     }
+
     public fun `in`(column: String, values: List<String>) {
         params += column to "in.(${values.joinToString(",") { encodeValue(it) }})"
     }
+
     public fun match(values: Map<String, String>) {
         values.forEach { (column, value) -> eq(column, value) }
     }
+
     public fun contains(column: String, value: String) {
         params += column to "cs.$value"
     }
+
     public fun containedBy(column: String, value: String) {
         params += column to "cd.$value"
     }
+
     public fun overlaps(column: String, value: String) {
         params += column to "ov.$value"
     }
+
     public fun rangeGt(column: String, value: String) {
         params += column to "sr.$value"
     }
+
     public fun rangeGte(column: String, value: String) {
         params += column to "nxl.$value"
     }
+
     public fun rangeLt(column: String, value: String) {
         params += column to "sl.$value"
     }
+
     public fun rangeLte(column: String, value: String) {
         params += column to "nxr.$value"
     }
+
     public fun rangeAdj(column: String, value: String) {
         params += column to "adj.$value"
     }
+
     public fun not(block: FilterBuilder.() -> Unit) {
         val inner = FilterBuilder().apply(block).build()
         for ((key, value) in inner) {
             params += key to "not.$value"
         }
     }
+
     public fun not(column: String, operator: String, value: String) {
         params += column to "not.$operator.$value"
     }
+
     public fun or(block: FilterBuilder.() -> Unit) {
         val inner = FilterBuilder().apply(block).build()
         val combined = inner.joinToString(",") { (k, v) -> "$k.$v" }
         params += "or" to "($combined)"
     }
+
     public fun and(block: FilterBuilder.() -> Unit) {
         val inner = FilterBuilder().apply(block).build()
         val combined = inner.joinToString(",") { (k, v) -> "$k.$v" }
         params += "and" to "($combined)"
     }
+
     public fun textSearch(
         column: String,
         query: String,
@@ -125,9 +164,11 @@ public class FilterBuilder {
         val configPart = if (config != null) "($config)" else ""
         params += column to "${type.postgrestName}fts$configPart.$query"
     }
+
     public fun filter(column: String, operator: String, value: String) {
         params += column to "$operator.$value"
     }
+
     public fun order(
         column: String,
         ascending: Boolean = true,
@@ -135,36 +176,44 @@ public class FilterBuilder {
         referencedTable: String? = null,
     ) {
         val dir = if (ascending) "asc" else "desc"
-        val nulls = when (nullsFirst) {
-            true -> ".nullsfirst"
-            false -> ".nullslast"
-            null -> ""
-        }
+        val nulls =
+            when (nullsFirst) {
+                true -> ".nullsfirst"
+                false -> ".nullslast"
+                null -> ""
+            }
         val key = if (referencedTable == null) "order" else "$referencedTable.order"
         params += key to "$column.$dir$nulls"
     }
+
     public fun limit(count: Int, referencedTable: String? = null) {
         val key = if (referencedTable == null) "limit" else "$referencedTable.limit"
         params += key to count.toString()
     }
+
     public fun range(from: Int, to: Int, referencedTable: String? = null) {
         val offsetKey = if (referencedTable == null) "offset" else "$referencedTable.offset"
         val limitKey = if (referencedTable == null) "limit" else "$referencedTable.limit"
         params += offsetKey to from.toString()
         params += limitKey to (to - from + 1).toString()
     }
+
     public fun strictlyLeft(column: String, value: String) {
         rangeLt(column, value)
     }
+
     public fun strictlyRight(column: String, value: String) {
         rangeGt(column, value)
     }
+
     public fun notExtendRight(column: String, value: String) {
         rangeLte(column, value)
     }
+
     public fun notExtendLeft(column: String, value: String) {
         rangeGte(column, value)
     }
+
     public fun build(): List<Pair<String, String>> = params.toList()
 
     private companion object {
@@ -175,14 +224,17 @@ public class FilterBuilder {
         // so simple filters stay readable. Dots are left alone — PostgREST only
         // splits the operator from the value on the first dot.
         private fun encodeValue(value: String): String {
-            val needsQuoting = value.isEmpty() || value.any { ch ->
-                ch == ',' || ch == '(' || ch == ')' || ch == '"' || ch == '\\'
-            }
+            val needsQuoting =
+                value.isEmpty() ||
+                    value.any { ch ->
+                        ch == ',' || ch == '(' || ch == ')' || ch == '"' || ch == '\\'
+                    }
             if (!needsQuoting) return value
             val escaped = value.replace("\\", "\\\\").replace("\"", "\\\"")
             return "\"$escaped\""
         }
     }
 }
+
 public inline fun filters(block: FilterBuilder.() -> Unit): List<Pair<String, String>> =
     FilterBuilder().apply(block).build()

--- a/supabase-core/src/commonMain/kotlin/io/github/androidpoet/supabase/core/models/SupabaseResponse.kt
+++ b/supabase-core/src/commonMain/kotlin/io/github/androidpoet/supabase/core/models/SupabaseResponse.kt
@@ -1,10 +1,12 @@
 package io.github.androidpoet.supabase.core.models
 import kotlinx.serialization.Serializable
+
 @Serializable
 public data class PostgrestResponse<T>(
     public val data: T,
     public val count: Long? = null,
 )
+
 @Serializable
 public data class ErrorResponse(
     public val message: String,

--- a/supabase-core/src/commonMain/kotlin/io/github/androidpoet/supabase/core/result/SupabaseError.kt
+++ b/supabase-core/src/commonMain/kotlin/io/github/androidpoet/supabase/core/result/SupabaseError.kt
@@ -1,6 +1,7 @@
 package io.github.androidpoet.supabase.core.result
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.JsonElement
+
 @Serializable
 public data class SupabaseError(
     public val message: String,
@@ -8,10 +9,13 @@ public data class SupabaseError(
     public val details: JsonElement? = null,
     public val hint: String? = null,
 )
+
 public class SupabaseException(
     public val error: SupabaseError,
 ) : Exception(error.message)
+
 public fun SupabaseError.toException(): SupabaseException = SupabaseException(this)
+
 public enum class SupabaseErrorCategory {
     Conflict,
     NotFound,
@@ -19,100 +23,112 @@ public enum class SupabaseErrorCategory {
     RateLimited,
     Validation,
     Internal,
-    Unknown
+    Unknown,
 }
 
-private val conflictCodes = setOf(
-    SupabaseErrorCodes.Database.UNIQUENESS_VIOLATION,
-    SupabaseErrorCodes.Database.FOREIGN_KEY_VIOLATION,
-    SupabaseErrorCodes.Auth.USER_ALREADY_EXISTS,
-    SupabaseErrorCodes.Auth.IDENTITY_ALREADY_EXISTS,
-    SupabaseErrorCodes.Storage.BUCKET_ALREADY_EXISTS,
-    SupabaseErrorCodes.Storage.KEY_ALREADY_EXISTS,
-    SupabaseErrorCodes.Storage.ALREADY_EXISTS,
-)
+private val conflictCodes =
+    setOf(
+        SupabaseErrorCodes.Database.UNIQUENESS_VIOLATION,
+        SupabaseErrorCodes.Database.FOREIGN_KEY_VIOLATION,
+        SupabaseErrorCodes.Auth.USER_ALREADY_EXISTS,
+        SupabaseErrorCodes.Auth.IDENTITY_ALREADY_EXISTS,
+        SupabaseErrorCodes.Storage.BUCKET_ALREADY_EXISTS,
+        SupabaseErrorCodes.Storage.KEY_ALREADY_EXISTS,
+        SupabaseErrorCodes.Storage.ALREADY_EXISTS,
+    )
 
-private val notFoundCodes = setOf(
-    SupabaseErrorCodes.Database.TABLE_NOT_FOUND,
-    SupabaseErrorCodes.Database.COLUMN_NOT_FOUND,
-    SupabaseErrorCodes.Database.FUNCTION_NOT_FOUND,
-    SupabaseErrorCodes.Database.UNDEFINED_TABLE,
-    SupabaseErrorCodes.Auth.USER_NOT_FOUND,
-    SupabaseErrorCodes.Auth.INVITE_NOT_FOUND,
-    SupabaseErrorCodes.Storage.NO_SUCH_BUCKET,
-    SupabaseErrorCodes.Storage.NO_SUCH_KEY,
-    SupabaseErrorCodes.Storage.NOT_FOUND,
-    SupabaseErrorCodes.Management.PROJECT_NOT_FOUND,
-    SupabaseErrorCodes.Management.ORGANIZATION_NOT_FOUND,
-)
+private val notFoundCodes =
+    setOf(
+        SupabaseErrorCodes.Database.TABLE_NOT_FOUND,
+        SupabaseErrorCodes.Database.COLUMN_NOT_FOUND,
+        SupabaseErrorCodes.Database.FUNCTION_NOT_FOUND,
+        SupabaseErrorCodes.Database.UNDEFINED_TABLE,
+        SupabaseErrorCodes.Auth.USER_NOT_FOUND,
+        SupabaseErrorCodes.Auth.INVITE_NOT_FOUND,
+        SupabaseErrorCodes.Storage.NO_SUCH_BUCKET,
+        SupabaseErrorCodes.Storage.NO_SUCH_KEY,
+        SupabaseErrorCodes.Storage.NOT_FOUND,
+        SupabaseErrorCodes.Management.PROJECT_NOT_FOUND,
+        SupabaseErrorCodes.Management.ORGANIZATION_NOT_FOUND,
+    )
 
-private val unauthorizedCodes = setOf(
-    SupabaseErrorCodes.Database.JWT_INVALID,
-    SupabaseErrorCodes.Database.INSUFFICIENT_PRIVILEGE,
-    SupabaseErrorCodes.Database.ANONYMOUS_ROLE_DISABLED,
-    SupabaseErrorCodes.Auth.INVALID_CREDENTIALS,
-    SupabaseErrorCodes.Auth.PROVIDER_DISABLED,
-    SupabaseErrorCodes.Auth.SIGNUP_DISABLED,
-    SupabaseErrorCodes.Storage.INVALID_JWT,
-    SupabaseErrorCodes.Storage.ACCESS_DENIED,
-    SupabaseErrorCodes.Storage.UNAUTHORIZED,
-    SupabaseErrorCodes.Realtime.ERROR_AUTHORIZING_WEBSOCKET,
-    SupabaseErrorCodes.Management.UNAUTHORIZED,
-    SupabaseErrorCodes.Management.FORBIDDEN,
-)
+private val unauthorizedCodes =
+    setOf(
+        SupabaseErrorCodes.Database.JWT_INVALID,
+        SupabaseErrorCodes.Database.INSUFFICIENT_PRIVILEGE,
+        SupabaseErrorCodes.Database.ANONYMOUS_ROLE_DISABLED,
+        SupabaseErrorCodes.Auth.INVALID_CREDENTIALS,
+        SupabaseErrorCodes.Auth.PROVIDER_DISABLED,
+        SupabaseErrorCodes.Auth.SIGNUP_DISABLED,
+        SupabaseErrorCodes.Storage.INVALID_JWT,
+        SupabaseErrorCodes.Storage.ACCESS_DENIED,
+        SupabaseErrorCodes.Storage.UNAUTHORIZED,
+        SupabaseErrorCodes.Realtime.ERROR_AUTHORIZING_WEBSOCKET,
+        SupabaseErrorCodes.Management.UNAUTHORIZED,
+        SupabaseErrorCodes.Management.FORBIDDEN,
+    )
 
-private val rateLimitedCodes = setOf(
-    SupabaseErrorCodes.Auth.OVER_CONFIRMATION_RATE_LIMIT,
-    SupabaseErrorCodes.Auth.TOO_MANY_REQUESTS,
-    SupabaseErrorCodes.Storage.THROTTLING,
-    SupabaseErrorCodes.Storage.TOO_MANY_REQUESTS,
-    SupabaseErrorCodes.Realtime.CHANNEL_RATE_LIMIT_REACHED,
-    SupabaseErrorCodes.Realtime.CONNECTION_RATE_LIMIT_REACHED,
-    SupabaseErrorCodes.Management.RATE_LIMIT_EXCEEDED,
-)
+private val rateLimitedCodes =
+    setOf(
+        SupabaseErrorCodes.Auth.OVER_CONFIRMATION_RATE_LIMIT,
+        SupabaseErrorCodes.Auth.TOO_MANY_REQUESTS,
+        SupabaseErrorCodes.Storage.THROTTLING,
+        SupabaseErrorCodes.Storage.TOO_MANY_REQUESTS,
+        SupabaseErrorCodes.Realtime.CHANNEL_RATE_LIMIT_REACHED,
+        SupabaseErrorCodes.Realtime.CONNECTION_RATE_LIMIT_REACHED,
+        SupabaseErrorCodes.Management.RATE_LIMIT_EXCEEDED,
+    )
 
-private val validationCodes = setOf(
-    SupabaseErrorCodes.Database.QUERY_PARSING_ERROR,
-    SupabaseErrorCodes.Database.INVALID_REQUEST_BODY,
-    SupabaseErrorCodes.Auth.WEAK_PASSWORD,
-    SupabaseErrorCodes.Auth.BAD_CODE_VERIFIER,
-    SupabaseErrorCodes.Storage.INVALID_BUCKET_NAME,
-    SupabaseErrorCodes.Storage.ENTITY_TOO_LARGE,
-    SupabaseErrorCodes.Storage.INVALID_MIME_TYPE,
-)
+private val validationCodes =
+    setOf(
+        SupabaseErrorCodes.Database.QUERY_PARSING_ERROR,
+        SupabaseErrorCodes.Database.INVALID_REQUEST_BODY,
+        SupabaseErrorCodes.Auth.WEAK_PASSWORD,
+        SupabaseErrorCodes.Auth.BAD_CODE_VERIFIER,
+        SupabaseErrorCodes.Storage.INVALID_BUCKET_NAME,
+        SupabaseErrorCodes.Storage.ENTITY_TOO_LARGE,
+        SupabaseErrorCodes.Storage.INVALID_MIME_TYPE,
+    )
 
-private val internalCodes = setOf(
-    SupabaseErrorCodes.Database.CONNECTION_ERROR,
-    SupabaseErrorCodes.Database.STATEMENT_TIMEOUT,
-    SupabaseErrorCodes.Storage.DATABASE_TIMEOUT,
-    SupabaseErrorCodes.Storage.INTERNAL_ERROR,
-    SupabaseErrorCodes.Functions.BOOT_ERROR,
-    SupabaseErrorCodes.Functions.WORKER_LIMIT,
-)
+private val internalCodes =
+    setOf(
+        SupabaseErrorCodes.Database.CONNECTION_ERROR,
+        SupabaseErrorCodes.Database.STATEMENT_TIMEOUT,
+        SupabaseErrorCodes.Storage.DATABASE_TIMEOUT,
+        SupabaseErrorCodes.Storage.INTERNAL_ERROR,
+        SupabaseErrorCodes.Functions.BOOT_ERROR,
+        SupabaseErrorCodes.Functions.WORKER_LIMIT,
+    )
 
 public val SupabaseError.category: SupabaseErrorCategory
-    get() = when {
-        code in conflictCodes -> SupabaseErrorCategory.Conflict
-        code in notFoundCodes -> SupabaseErrorCategory.NotFound
-        code in unauthorizedCodes -> SupabaseErrorCategory.Unauthorized
-        code in rateLimitedCodes -> SupabaseErrorCategory.RateLimited
-        code in validationCodes -> SupabaseErrorCategory.Validation
-        code in internalCodes -> SupabaseErrorCategory.Internal
-        code?.toIntOrNull() in setOf(401, 403) -> SupabaseErrorCategory.Unauthorized
-        code?.toIntOrNull() == 404 -> SupabaseErrorCategory.NotFound
-        code?.toIntOrNull() == 409 -> SupabaseErrorCategory.Conflict
-        code?.toIntOrNull() == 422 -> SupabaseErrorCategory.Validation
-        code?.toIntOrNull() == 429 -> SupabaseErrorCategory.RateLimited
-        code?.toIntOrNull() in setOf(500, 502, 503, 504) -> SupabaseErrorCategory.Internal
-        else -> SupabaseErrorCategory.Unknown
-    }
+    get() =
+        when {
+            code in conflictCodes -> SupabaseErrorCategory.Conflict
+            code in notFoundCodes -> SupabaseErrorCategory.NotFound
+            code in unauthorizedCodes -> SupabaseErrorCategory.Unauthorized
+            code in rateLimitedCodes -> SupabaseErrorCategory.RateLimited
+            code in validationCodes -> SupabaseErrorCategory.Validation
+            code in internalCodes -> SupabaseErrorCategory.Internal
+            code?.toIntOrNull() in setOf(401, 403) -> SupabaseErrorCategory.Unauthorized
+            code?.toIntOrNull() == 404 -> SupabaseErrorCategory.NotFound
+            code?.toIntOrNull() == 409 -> SupabaseErrorCategory.Conflict
+            code?.toIntOrNull() == 422 -> SupabaseErrorCategory.Validation
+            code?.toIntOrNull() == 429 -> SupabaseErrorCategory.RateLimited
+            code?.toIntOrNull() in setOf(500, 502, 503, 504) -> SupabaseErrorCategory.Internal
+            else -> SupabaseErrorCategory.Unknown
+        }
+
 public fun SupabaseError.isUniquenessViolation(): Boolean =
     code == SupabaseErrorCodes.Database.UNIQUENESS_VIOLATION
+
 public fun SupabaseError.isForeignKeyViolation(): Boolean =
     code == SupabaseErrorCodes.Database.FOREIGN_KEY_VIOLATION
+
 public fun SupabaseError.isInvalidCredentials(): Boolean =
     code == SupabaseErrorCodes.Auth.INVALID_CREDENTIALS
+
 public fun SupabaseError.isUserAlreadyExists(): Boolean =
     code == SupabaseErrorCodes.Auth.USER_ALREADY_EXISTS
+
 public fun SupabaseError.isFileNotFound(): Boolean =
     code == SupabaseErrorCodes.Storage.NO_SUCH_KEY

--- a/supabase-core/src/commonMain/kotlin/io/github/androidpoet/supabase/core/result/SupabaseErrorCodes.kt
+++ b/supabase-core/src/commonMain/kotlin/io/github/androidpoet/supabase/core/result/SupabaseErrorCodes.kt
@@ -1,4 +1,5 @@
 package io.github.androidpoet.supabase.core.result
+
 public object SupabaseErrorCodes {
     public object Database {
         public const val CONNECTION_ERROR: String = "PGRST000"
@@ -51,6 +52,7 @@ public object SupabaseErrorCodes {
         public const val INSUFFICIENT_PRIVILEGE: String = "42501"
         public const val STATEMENT_TIMEOUT: String = "57014"
     }
+
     public object Auth {
         public const val INVALID_CREDENTIALS: String = "invalid_credentials"
         public const val USER_NOT_FOUND: String = "user_not_found"
@@ -72,6 +74,7 @@ public object SupabaseErrorCodes {
         public const val MFA_CHALLENGE_EXPIRED: String = "mfa_challenge_expired"
         public const val MFA_VERIFICATION_FAILED: String = "mfa_verification_failed"
     }
+
     public object Storage {
         public const val NO_SUCH_BUCKET: String = "NoSuchBucket"
         public const val BUCKET_ALREADY_EXISTS: String = "BucketAlreadyExists"
@@ -106,6 +109,7 @@ public object SupabaseErrorCodes {
         public const val DATABASE_TIMEOUT_SNAKE: String = "database_timeout"
         public const val INTERNAL_SERVER_ERROR: String = "internal_server_error"
     }
+
     public object Realtime {
         public const val CHANNEL_RATE_LIMIT_REACHED: String = "ChannelRateLimitReached"
         public const val CONNECTION_RATE_LIMIT_REACHED: String = "ConnectionRateLimitReached"
@@ -116,6 +120,7 @@ public object SupabaseErrorCodes {
         public const val INVALID_TOPIC: String = "InvalidTopic"
         public const val PAYLOAD_TOO_LARGE: String = "PayloadTooLarge"
     }
+
     public object Functions {
         public const val BOOT_ERROR: String = "BOOT_ERROR"
         public const val WORKER_ERROR: String = "WORKER_ERROR"
@@ -124,6 +129,7 @@ public object SupabaseErrorCodes {
         public const val UNSUPPORTED_NODE_VERSION: String = "EF015"
         public const val FUNCTION_NOT_RETURNING_RESPONSE: String = "EF028"
     }
+
     public object Management {
         public const val PROJECT_NOT_FOUND: String = "PROJECT_NOT_FOUND"
         public const val ORGANIZATION_NOT_FOUND: String = "ORGANIZATION_NOT_FOUND"

--- a/supabase-core/src/commonMain/kotlin/io/github/androidpoet/supabase/core/result/SupabaseResult.kt
+++ b/supabase-core/src/commonMain/kotlin/io/github/androidpoet/supabase/core/result/SupabaseResult.kt
@@ -3,22 +3,35 @@ package io.github.androidpoet.supabase.core.result
 import kotlinx.coroutines.CancellationException
 
 public sealed interface SupabaseResult<out T> {
-    public data class Success<out T>(public val value: T) : SupabaseResult<T>
-    public data class Failure(public val error: SupabaseError) : SupabaseResult<Nothing>
+    public data class Success<out T>(
+        public val value: T,
+    ) : SupabaseResult<T>
+
+    public data class Failure(
+        public val error: SupabaseError,
+    ) : SupabaseResult<Nothing>
+
     public val isSuccess: Boolean get() = this is Success
     public val isFailure: Boolean get() = this is Failure
-    public fun getOrNull(): T? = when (this) {
-        is Success -> value
-        is Failure -> null
-    }
-    public fun getOrThrow(): T = when (this) {
-        is Success -> value
-        is Failure -> throw error.toException()
-    }
-    public fun errorOrNull(): SupabaseError? = when (this) {
-        is Success -> null
-        is Failure -> error
-    }
+
+    public fun getOrNull(): T? =
+        when (this) {
+            is Success -> value
+            is Failure -> null
+        }
+
+    public fun getOrThrow(): T =
+        when (this) {
+            is Success -> value
+            is Failure -> throw error.toException()
+        }
+
+    public fun errorOrNull(): SupabaseError? =
+        when (this) {
+            is Success -> null
+            is Failure -> error
+        }
+
     public companion object {
         public inline fun <T> catching(block: () -> T): SupabaseResult<T> =
             try {
@@ -32,161 +45,194 @@ public sealed interface SupabaseResult<out T> {
 
         public suspend inline fun <T> suspendCatching(
             crossinline block: suspend () -> T,
-        ): SupabaseResult<T> = try {
-            Success(block())
-        } catch (e: SupabaseException) {
-            Failure(e.error)
-        } catch (e: Throwable) {
-            if (e is CancellationException) throw e
-            Failure(SupabaseError(message = e.message ?: "Unknown error"))
-        }
+        ): SupabaseResult<T> =
+            try {
+                Success(block())
+            } catch (e: SupabaseException) {
+                Failure(e.error)
+            } catch (e: Throwable) {
+                if (e is CancellationException) throw e
+                Failure(SupabaseError(message = e.message ?: "Unknown error"))
+            }
     }
 }
+
 public inline fun <T, R> SupabaseResult<T>.map(
     transform: (T) -> R,
-): SupabaseResult<R> = when (this) {
-    is SupabaseResult.Success -> SupabaseResult.Success(transform(value))
-    is SupabaseResult.Failure -> this
-}
+): SupabaseResult<R> =
+    when (this) {
+        is SupabaseResult.Success -> SupabaseResult.Success(transform(value))
+        is SupabaseResult.Failure -> this
+    }
+
 public inline fun <T, R> SupabaseResult<T>.flatMap(
     transform: (T) -> SupabaseResult<R>,
-): SupabaseResult<R> = when (this) {
-    is SupabaseResult.Success -> transform(value)
-    is SupabaseResult.Failure -> this
-}
+): SupabaseResult<R> =
+    when (this) {
+        is SupabaseResult.Success -> transform(value)
+        is SupabaseResult.Failure -> this
+    }
+
 public inline fun <T> SupabaseResult<T>.onSuccess(
     action: (T) -> Unit,
-): SupabaseResult<T> = apply {
-    if (this is SupabaseResult.Success) action(value)
-}
+): SupabaseResult<T> =
+    apply {
+        if (this is SupabaseResult.Success) action(value)
+    }
+
 public inline fun <T> SupabaseResult<T>.onFailure(
     action: (SupabaseError) -> Unit,
-): SupabaseResult<T> = apply {
-    if (this is SupabaseResult.Failure) action(error)
-}
+): SupabaseResult<T> =
+    apply {
+        if (this is SupabaseResult.Failure) action(error)
+    }
+
 public inline fun <T> SupabaseResult<T>.onFailureCategory(
     category: SupabaseErrorCategory,
     action: (SupabaseError) -> Unit,
-): SupabaseResult<T> = apply {
-    if (this is SupabaseResult.Failure && error.category == category) {
-        action(error)
+): SupabaseResult<T> =
+    apply {
+        if (this is SupabaseResult.Failure && error.category == category) {
+            action(error)
+        }
     }
-}
+
 public inline fun <T, C> SupabaseResult<T>.onFailureCategory(
     category: C,
     classifier: (SupabaseError) -> C,
     action: (SupabaseError) -> Unit,
-): SupabaseResult<T> = apply {
-    if (this is SupabaseResult.Failure && classifier(error) == category) {
-        action(error)
+): SupabaseResult<T> =
+    apply {
+        if (this is SupabaseResult.Failure && classifier(error) == category) {
+            action(error)
+        }
     }
-}
+
 public inline fun <T> SupabaseResult<T>.onConflict(
     action: (SupabaseError) -> Unit,
 ): SupabaseResult<T> = onFailureCategory(SupabaseErrorCategory.Conflict, action)
+
 public inline fun <T> SupabaseResult<T>.onNotFound(
     action: (SupabaseError) -> Unit,
 ): SupabaseResult<T> = onFailureCategory(SupabaseErrorCategory.NotFound, action)
+
 public inline fun <T> SupabaseResult<T>.onUnauthorized(
     action: (SupabaseError) -> Unit,
 ): SupabaseResult<T> = onFailureCategory(SupabaseErrorCategory.Unauthorized, action)
+
 public inline fun <T> SupabaseResult<T>.onRateLimited(
     action: (SupabaseError) -> Unit,
 ): SupabaseResult<T> = onFailureCategory(SupabaseErrorCategory.RateLimited, action)
+
 public inline fun <T> SupabaseResult<T>.mapError(
     transform: (SupabaseError) -> SupabaseError,
-): SupabaseResult<T> = when (this) {
-    is SupabaseResult.Success -> this
-    is SupabaseResult.Failure -> SupabaseResult.Failure(transform(error))
-}
+): SupabaseResult<T> =
+    when (this) {
+        is SupabaseResult.Success -> this
+        is SupabaseResult.Failure -> SupabaseResult.Failure(transform(error))
+    }
+
 public inline fun <T> SupabaseResult<T>.recover(
     transform: (SupabaseError) -> T,
-): SupabaseResult<T> = when (this) {
-    is SupabaseResult.Success -> this
-    is SupabaseResult.Failure -> SupabaseResult.Success(transform(error))
-}
+): SupabaseResult<T> =
+    when (this) {
+        is SupabaseResult.Success -> this
+        is SupabaseResult.Failure -> SupabaseResult.Success(transform(error))
+    }
+
 public inline fun <T> SupabaseResult<T>.getOrElse(
     defaultValue: (SupabaseError) -> T,
-): T = when (this) {
-    is SupabaseResult.Success -> value
-    is SupabaseResult.Failure -> defaultValue(error)
-}
+): T =
+    when (this) {
+        is SupabaseResult.Success -> value
+        is SupabaseResult.Failure -> defaultValue(error)
+    }
 
 public inline fun <T, R> SupabaseResult<T>.fold(
     onSuccess: (T) -> R,
     onFailure: (SupabaseError) -> R,
-): R = when (this) {
-    is SupabaseResult.Success -> onSuccess(value)
-    is SupabaseResult.Failure -> onFailure(error)
-}
+): R =
+    when (this) {
+        is SupabaseResult.Success -> onSuccess(value)
+        is SupabaseResult.Failure -> onFailure(error)
+    }
 
 public suspend inline fun <T> SupabaseResult<T>.onSuccessSuspend(
     crossinline action: suspend (T) -> Unit,
-): SupabaseResult<T> = apply {
-    if (this is SupabaseResult.Success) action(value)
-}
+): SupabaseResult<T> =
+    apply {
+        if (this is SupabaseResult.Success) action(value)
+    }
 
 public suspend inline fun <T> SupabaseResult<T>.onFailureSuspend(
     crossinline action: suspend (SupabaseError) -> Unit,
-): SupabaseResult<T> = apply {
-    if (this is SupabaseResult.Failure) action(error)
-}
+): SupabaseResult<T> =
+    apply {
+        if (this is SupabaseResult.Failure) action(error)
+    }
 
 public suspend inline fun <T> SupabaseResult<T>.onFailureCategorySuspend(
     category: SupabaseErrorCategory,
     crossinline action: suspend (SupabaseError) -> Unit,
-): SupabaseResult<T> = apply {
-    if (this is SupabaseResult.Failure && error.category == category) {
-        action(error)
+): SupabaseResult<T> =
+    apply {
+        if (this is SupabaseResult.Failure && error.category == category) {
+            action(error)
+        }
     }
-}
 
 public suspend inline fun <T, C> SupabaseResult<T>.onFailureCategorySuspend(
     category: C,
     crossinline classifier: (SupabaseError) -> C,
     crossinline action: suspend (SupabaseError) -> Unit,
-): SupabaseResult<T> = apply {
-    if (this is SupabaseResult.Failure && classifier(error) == category) {
-        action(error)
+): SupabaseResult<T> =
+    apply {
+        if (this is SupabaseResult.Failure && classifier(error) == category) {
+            action(error)
+        }
     }
-}
 
 public suspend inline fun <T, R> SupabaseResult<T>.foldSuspend(
     crossinline onSuccess: suspend (T) -> R,
     crossinline onFailure: suspend (SupabaseError) -> R,
-): R = when (this) {
-    is SupabaseResult.Success -> onSuccess(value)
-    is SupabaseResult.Failure -> onFailure(error)
-}
+): R =
+    when (this) {
+        is SupabaseResult.Success -> onSuccess(value)
+        is SupabaseResult.Failure -> onFailure(error)
+    }
 
 public suspend inline fun <T, R> SupabaseResult<T>.mapSuspend(
     crossinline transform: suspend (T) -> R,
-): SupabaseResult<R> = when (this) {
-    is SupabaseResult.Success -> SupabaseResult.Success(transform(value))
-    is SupabaseResult.Failure -> this
-}
+): SupabaseResult<R> =
+    when (this) {
+        is SupabaseResult.Success -> SupabaseResult.Success(transform(value))
+        is SupabaseResult.Failure -> this
+    }
 
 public suspend inline fun <T> SupabaseResult<T>.recoverSuspend(
     crossinline transform: suspend (SupabaseError) -> T,
-): SupabaseResult<T> = when (this) {
-    is SupabaseResult.Success -> this
-    is SupabaseResult.Failure -> SupabaseResult.Success(transform(error))
-}
+): SupabaseResult<T> =
+    when (this) {
+        is SupabaseResult.Success -> this
+        is SupabaseResult.Failure -> SupabaseResult.Success(transform(error))
+    }
 
-public fun <T> SupabaseResult<T>.toKotlinResult(): Result<T> = when (this) {
-    is SupabaseResult.Success -> Result.success(value)
-    is SupabaseResult.Failure -> Result.failure(error.toException())
-}
+public fun <T> SupabaseResult<T>.toKotlinResult(): Result<T> =
+    when (this) {
+        is SupabaseResult.Success -> Result.success(value)
+        is SupabaseResult.Failure -> Result.failure(error.toException())
+    }
 
 public inline fun <T> Result<T>.toSupabaseResult(
     mapThrowable: (Throwable) -> SupabaseError = { throwable ->
         val supabaseException = throwable as? SupabaseException
         supabaseException?.error ?: SupabaseError(message = throwable.message ?: "Unknown error")
     },
-): SupabaseResult<T> = fold(
-    onSuccess = { SupabaseResult.Success(it) },
-    onFailure = { throwable ->
-        if (throwable is CancellationException) throw throwable
-        SupabaseResult.Failure(mapThrowable(throwable))
-    },
-)
+): SupabaseResult<T> =
+    fold(
+        onSuccess = { SupabaseResult.Success(it) },
+        onFailure = { throwable ->
+            if (throwable is CancellationException) throw throwable
+            SupabaseResult.Failure(mapThrowable(throwable))
+        },
+    )

--- a/supabase-core/src/commonMain/kotlin/io/github/androidpoet/supabase/core/types/Ids.kt
+++ b/supabase-core/src/commonMain/kotlin/io/github/androidpoet/supabase/core/types/Ids.kt
@@ -1,21 +1,36 @@
 package io.github.androidpoet.supabase.core.types
 import kotlinx.serialization.Serializable
 import kotlin.jvm.JvmInline
+
 @JvmInline
 @Serializable
-public value class UserId(public val value: String)
+public value class UserId(
+    public val value: String,
+)
+
 @JvmInline
 @Serializable
-public value class SessionId(public val value: String)
+public value class SessionId(
+    public val value: String,
+)
+
 @JvmInline
 @Serializable
-public value class BucketId(public val value: String)
+public value class BucketId(
+    public val value: String,
+)
+
 @JvmInline
 @Serializable
-public value class ChannelId(public val value: String)
+public value class ChannelId(
+    public val value: String,
+)
+
 @JvmInline
 @Serializable
-public value class ProjectUrl(public val value: String) {
+public value class ProjectUrl(
+    public val value: String,
+) {
     public val restUrl: String get() = "$value/rest/v1"
     public val authUrl: String get() = "$value/auth/v1"
     public val storageUrl: String get() = "$value/storage/v1"

--- a/supabase-core/src/commonMain/kotlin/io/github/androidpoet/supabase/core/util/UrlEncoding.kt
+++ b/supabase-core/src/commonMain/kotlin/io/github/androidpoet/supabase/core/util/UrlEncoding.kt
@@ -8,16 +8,17 @@ private const val HEX_CHARS = "0123456789ABCDEF"
  * else is encoded from its UTF-8 bytes. Shared so the auth modules don't each
  * carry their own copy.
  */
-public fun urlEncode(value: String): String = buildString {
-    for (char in value) {
-        if (char.isLetterOrDigit() || char in "-._~") {
-            append(char)
-        } else {
-            for (byte in char.toString().encodeToByteArray()) {
-                append('%')
-                append(HEX_CHARS[(byte.toInt() shr 4) and 0x0F])
-                append(HEX_CHARS[byte.toInt() and 0x0F])
+public fun urlEncode(value: String): String =
+    buildString {
+        for (char in value) {
+            if (char.isLetterOrDigit() || char in "-._~") {
+                append(char)
+            } else {
+                for (byte in char.toString().encodeToByteArray()) {
+                    append('%')
+                    append(HEX_CHARS[(byte.toInt() shr 4) and 0x0F])
+                    append(HEX_CHARS[byte.toInt() and 0x0F])
+                }
             }
         }
     }
-}

--- a/supabase-core/src/commonTest/kotlin/io/github/androidpoet/supabase/core/FiltersTest.kt
+++ b/supabase-core/src/commonTest/kotlin/io/github/androidpoet/supabase/core/FiltersTest.kt
@@ -5,126 +5,151 @@ import io.github.androidpoet.supabase.core.models.filters
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
+
 class FiltersTest {
     @Test
     fun test_eq_producesCorrectParam() {
         val result = filters { eq("status", "active") }
         assertEquals(listOf("status" to "eq.active"), result)
     }
+
     @Test
     fun test_neq_producesCorrectParam() {
         val result = filters { neq("role", "admin") }
         assertEquals(listOf("role" to "neq.admin"), result)
     }
+
     @Test
     fun test_gt_producesCorrectParam() {
         val result = filters { gt("age", "18") }
         assertEquals(listOf("age" to "gt.18"), result)
     }
+
     @Test
     fun test_gte_producesCorrectParam() {
         val result = filters { gte("score", "90") }
         assertEquals(listOf("score" to "gte.90"), result)
     }
+
     @Test
     fun test_lt_producesCorrectParam() {
         val result = filters { lt("price", "100") }
         assertEquals(listOf("price" to "lt.100"), result)
     }
+
     @Test
     fun test_lte_producesCorrectParam() {
         val result = filters { lte("quantity", "0") }
         assertEquals(listOf("quantity" to "lte.0"), result)
     }
+
     @Test
     fun test_like_producesCorrectParam() {
         val result = filters { like("name", "%john%") }
         assertEquals(listOf("name" to "like.%john%"), result)
     }
+
     @Test
     fun test_likeAllOf_producesCorrectParam() {
         val result = filters { likeAllOf("name", listOf("O%", "%n")) }
         assertEquals(listOf("name" to "like(all).{O%,%n}"), result)
     }
+
     @Test
     fun test_likeAnyOf_producesCorrectParam() {
         val result = filters { likeAnyOf("name", listOf("O%", "P%")) }
         assertEquals(listOf("name" to "like(any).{O%,P%}"), result)
     }
+
     @Test
     fun test_ilike_producesCorrectParam() {
         val result = filters { ilike("email", "%@EXAMPLE.COM") }
         assertEquals(listOf("email" to "ilike.%@EXAMPLE.COM"), result)
     }
+
     @Test
     fun test_ilikeAllOf_producesCorrectParam() {
         val result = filters { ilikeAllOf("email", listOf("%@example.com", "%admin%")) }
         assertEquals(listOf("email" to "ilike(all).{%@example.com,%admin%}"), result)
     }
+
     @Test
     fun test_ilikeAnyOf_producesCorrectParam() {
         val result = filters { ilikeAnyOf("email", listOf("%@example.com", "%@test.com")) }
         assertEquals(listOf("email" to "ilike(any).{%@example.com,%@test.com}"), result)
     }
+
     @Test
     fun test_in_producesCorrectParam() {
         val result = filters { `in`("id", listOf("1", "2", "3")) }
         assertEquals(listOf("id" to "in.(1,2,3)"), result)
     }
+
     @Test
     fun test_is_producesCorrectParam() {
         val result = filters { `is`("deleted_at", "null") }
         assertEquals(listOf("deleted_at" to "is.null"), result)
     }
+
     @Test
     fun test_or_combinesFilters() {
-        val result = filters {
-            or {
-                eq("status", "active")
-                eq("status", "pending")
+        val result =
+            filters {
+                or {
+                    eq("status", "active")
+                    eq("status", "pending")
+                }
             }
-        }
         assertEquals(1, result.size)
         assertEquals("or", result[0].first)
         assertEquals("(status.eq.active,status.eq.pending)", result[0].second)
     }
+
     @Test
     fun test_not_negatesFilter() {
-        val result = filters {
-            not { eq("role", "admin") }
-        }
+        val result =
+            filters {
+                not { eq("role", "admin") }
+            }
         assertEquals(listOf("role" to "not.eq.admin"), result)
     }
+
     @Test
     fun test_order_ascending() {
         val result = filters { order("created_at") }
         assertEquals(listOf("order" to "created_at.asc"), result)
     }
+
     @Test
     fun test_order_descending() {
         val result = filters { order("created_at", ascending = false) }
         assertEquals(listOf("order" to "created_at.desc"), result)
     }
+
     @Test
     fun test_order_nullsFirst() {
         val result = filters { order("name", nullsFirst = true) }
         assertEquals(listOf("order" to "name.asc.nullsfirst"), result)
     }
+
     @Test
     fun test_order_withReferencedTable() {
         val result = filters { order("created_at", referencedTable = "profiles") }
         assertEquals(listOf("profiles.order" to "created_at.asc"), result)
     }
+
     @Test
     fun test_limit_producesCorrectParam() {
         val result = filters { limit(25) }
         assertEquals(listOf("limit" to "25"), result)
     }
+
     @Test
     fun test_limit_withReferencedTable() {
         val result = filters { limit(5, referencedTable = "profiles") }
         assertEquals(listOf("profiles.limit" to "5"), result)
     }
+
     @Test
     fun test_range_producesOffsetAndLimit() {
         val result = filters { range(10, 19) }
@@ -132,6 +157,7 @@ class FiltersTest {
         assertEquals("offset" to "10", result[0])
         assertEquals("limit" to "10", result[1])
     }
+
     @Test
     fun test_range_withReferencedTable() {
         val result = filters { range(0, 9, referencedTable = "profiles") }
@@ -139,42 +165,50 @@ class FiltersTest {
         assertEquals("profiles.offset" to "0", result[0])
         assertEquals("profiles.limit" to "10", result[1])
     }
+
     @Test
     fun test_multipleFilters_accumulate() {
-        val result = filters {
-            eq("team", "engineering")
-            gte("level", "3")
-            order("name")
-            limit(50)
-        }
+        val result =
+            filters {
+                eq("team", "engineering")
+                gte("level", "3")
+                order("name")
+                limit(50)
+            }
         assertEquals(4, result.size)
         assertEquals("team" to "eq.engineering", result[0])
         assertEquals("level" to "gte.3", result[1])
         assertEquals("order" to "name.asc", result[2])
         assertEquals("limit" to "50", result[3])
     }
+
     @Test
     fun test_textSearch_plain() {
         val result = filters { textSearch("body", "hello world") }
         assertEquals(listOf("body" to "plfts.hello world"), result)
     }
+
     @Test
     fun test_textSearch_withConfig() {
-        val result = filters {
-            textSearch("body", "hello", config = "english", type = TextSearchType.Websearch)
-        }
+        val result =
+            filters {
+                textSearch("body", "hello", config = "english", type = TextSearchType.Websearch)
+            }
         assertEquals(listOf("body" to "wfts(english).hello"), result)
     }
+
     @Test
     fun test_filter_rawOperator() {
         val result = filters { filter("col", "eq", "val") }
         assertEquals(listOf("col" to "eq.val"), result)
     }
+
     @Test
     fun test_contains_producesCorrectParam() {
         val result = filters { contains("tags", "{a,b}") }
         assertEquals(listOf("tags" to "cs.{a,b}"), result)
     }
+
     @Test
     fun test_containedBy_producesCorrectParam() {
         val result = filters { containedBy("tags", "{a,b,c}") }

--- a/supabase-core/src/commonTest/kotlin/io/github/androidpoet/supabase/core/IdsTest.kt
+++ b/supabase-core/src/commonTest/kotlin/io/github/androidpoet/supabase/core/IdsTest.kt
@@ -6,52 +6,62 @@ import io.github.androidpoet.supabase.core.types.SessionId
 import io.github.androidpoet.supabase.core.types.UserId
 import kotlin.test.Test
 import kotlin.test.assertEquals
+
 class IdsTest {
     @Test
     fun test_userId_wrapsString() {
         val id = UserId("usr_abc123")
         assertEquals("usr_abc123", id.value)
     }
+
     @Test
     fun test_sessionId_wrapsString() {
         val id = SessionId("sess_xyz")
         assertEquals("sess_xyz", id.value)
     }
+
     @Test
     fun test_bucketId_wrapsString() {
         val id = BucketId("avatars")
         assertEquals("avatars", id.value)
     }
+
     @Test
     fun test_channelId_wrapsString() {
         val id = ChannelId("room:42")
         assertEquals("room:42", id.value)
     }
+
     @Test
     fun test_projectUrl_restUrl() {
         val url = ProjectUrl("https://xyzcompany.supabase.co")
         assertEquals("https://xyzcompany.supabase.co/rest/v1", url.restUrl)
     }
+
     @Test
     fun test_projectUrl_authUrl() {
         val url = ProjectUrl("https://xyzcompany.supabase.co")
         assertEquals("https://xyzcompany.supabase.co/auth/v1", url.authUrl)
     }
+
     @Test
     fun test_projectUrl_storageUrl() {
         val url = ProjectUrl("https://xyzcompany.supabase.co")
         assertEquals("https://xyzcompany.supabase.co/storage/v1", url.storageUrl)
     }
+
     @Test
     fun test_projectUrl_realtimeUrl() {
         val url = ProjectUrl("https://xyzcompany.supabase.co")
         assertEquals("https://xyzcompany.supabase.co/realtime/v1", url.realtimeUrl)
     }
+
     @Test
     fun test_projectUrl_functionsUrl() {
         val url = ProjectUrl("https://xyzcompany.supabase.co")
         assertEquals("https://xyzcompany.supabase.co/functions/v1", url.functionsUrl)
     }
+
     @Test
     fun test_projectUrl_stripsNoTrailingSlash() {
         val url = ProjectUrl("https://example.supabase.co")

--- a/supabase-core/src/commonTest/kotlin/io/github/androidpoet/supabase/core/SupabaseErrorCategoryTest.kt
+++ b/supabase-core/src/commonTest/kotlin/io/github/androidpoet/supabase/core/SupabaseErrorCategoryTest.kt
@@ -10,10 +10,11 @@ import kotlin.test.assertEquals
 class SupabaseErrorCategoryTest {
     @Test
     fun test_category_mapsKnownSupabaseCode() {
-        val error = SupabaseError(
-            message = "duplicate",
-            code = SupabaseErrorCodes.Database.UNIQUENESS_VIOLATION,
-        )
+        val error =
+            SupabaseError(
+                message = "duplicate",
+                code = SupabaseErrorCodes.Database.UNIQUENESS_VIOLATION,
+            )
 
         assertEquals(SupabaseErrorCategory.Conflict, error.category)
     }

--- a/supabase-core/src/commonTest/kotlin/io/github/androidpoet/supabase/core/SupabaseResultTest.kt
+++ b/supabase-core/src/commonTest/kotlin/io/github/androidpoet/supabase/core/SupabaseResultTest.kt
@@ -23,13 +23,15 @@ import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 import kotlin.test.assertFalse
 import kotlin.test.assertIs
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
-import kotlin.test.assertFailsWith
+
 class SupabaseResultTest {
     private val error = SupabaseError(message = "not found", code = "PGRST116")
+
     @Test
     fun test_success_holdsValue() {
         val result: SupabaseResult<Int> = SupabaseResult.Success(42)
@@ -39,6 +41,7 @@ class SupabaseResultTest {
         assertEquals(42, result.getOrThrow())
         assertNull(result.errorOrNull())
     }
+
     @Test
     fun test_failure_holdsError() {
         val result: SupabaseResult<Int> = SupabaseResult.Failure(error)
@@ -47,17 +50,20 @@ class SupabaseResultTest {
         assertNull(result.getOrNull())
         assertEquals(error, result.errorOrNull())
     }
+
     @Test
     fun test_failure_getOrThrowThrowsSupabaseException() {
         val result: SupabaseResult<Int> = SupabaseResult.Failure(error)
         val exception = assertFailsWith<SupabaseException> { result.getOrThrow() }
         assertEquals(error, exception.error)
     }
+
     @Test
     fun test_map_transformsSuccess() {
         val result = SupabaseResult.Success(10).map { it * 2 }
         assertEquals(20, result.getOrNull())
     }
+
     @Test
     fun test_map_preservesFailure() {
         val result: SupabaseResult<Int> = SupabaseResult.Failure(error)
@@ -65,70 +71,89 @@ class SupabaseResultTest {
         assertTrue(mapped.isFailure)
         assertEquals(error, mapped.errorOrNull())
     }
+
     @Test
     fun test_flatMap_chainsSuccesses() {
-        val result = SupabaseResult.Success(5)
-            .flatMap { SupabaseResult.Success(it.toString()) }
+        val result =
+            SupabaseResult
+                .Success(5)
+                .flatMap { SupabaseResult.Success(it.toString()) }
         assertEquals("5", result.getOrNull())
     }
+
     @Test
     fun test_flatMap_shortCircuitsOnFailure() {
         val result: SupabaseResult<Int> = SupabaseResult.Failure(error)
         val chained = result.flatMap { SupabaseResult.Success(it.toString()) }
         assertTrue(chained.isFailure)
     }
+
     @Test
     fun test_onSuccess_invokesForSuccess() {
         var captured = 0
         SupabaseResult.Success(7).onSuccess { captured = it }
         assertEquals(7, captured)
     }
+
     @Test
     fun test_onFailure_invokesForFailure() {
         var captured: SupabaseError? = null
         SupabaseResult.Failure(error).onFailure { captured = it }
         assertEquals(error, captured)
     }
+
     @Test
     fun test_recover_convertsFailureToSuccess() {
-        val result: SupabaseResult<String> = SupabaseResult.Failure(error)
-            .recover { "default" }
+        val result: SupabaseResult<String> =
+            SupabaseResult
+                .Failure(error)
+                .recover { "default" }
         assertEquals("default", result.getOrNull())
     }
+
     @Test
     fun test_recover_leavesSuccessUntouched() {
-        val result = SupabaseResult.Success("original")
-            .recover { "default" }
+        val result =
+            SupabaseResult
+                .Success("original")
+                .recover { "default" }
         assertEquals("original", result.getOrNull())
     }
+
     @Test
     fun test_getOrElse_returnsValueOnSuccess() {
         val value = SupabaseResult.Success(99).getOrElse { -1 }
         assertEquals(99, value)
     }
+
     @Test
     fun test_getOrElse_returnsDefaultOnFailure() {
         val value: Int = SupabaseResult.Failure(error).getOrElse { -1 }
         assertEquals(-1, value)
     }
+
     @Test
     fun test_catching_wrapsSuccessfulBlock() {
         val result = SupabaseResult.catching { 42 }
         assertEquals(42, result.getOrNull())
     }
+
     @Test
     fun test_catching_wrapsSupabaseException() {
-        val result = SupabaseResult.catching {
-            throw SupabaseException(error)
-        }
+        val result =
+            SupabaseResult.catching {
+                throw SupabaseException(error)
+            }
         assertTrue(result.isFailure)
         assertEquals(error, result.errorOrNull())
     }
+
     @Test
     fun test_catching_wrapsGenericException() {
-        val result = SupabaseResult.catching<Int> {
-            throw IllegalStateException("boom")
-        }
+        val result =
+            SupabaseResult.catching<Int> {
+                throw IllegalStateException("boom")
+            }
         assertTrue(result.isFailure)
         assertEquals("boom", result.errorOrNull()?.message)
     }
@@ -159,12 +184,14 @@ class SupabaseResultTest {
 
     @Test
     fun test_mapError_transformsFailureOnly() {
-        val transformed = SupabaseResult.Failure(error).mapError {
-            it.copy(message = "mapped")
-        }
-        val successUnchanged = SupabaseResult.Success(1).mapError {
-            it.copy(message = "ignored")
-        }
+        val transformed =
+            SupabaseResult.Failure(error).mapError {
+                it.copy(message = "mapped")
+            }
+        val successUnchanged =
+            SupabaseResult.Success(1).mapError {
+                it.copy(message = "ignored")
+            }
 
         assertEquals("mapped", transformed.errorOrNull()?.message)
         assertEquals(1, successUnchanged.getOrNull())
@@ -214,142 +241,169 @@ class SupabaseResultTest {
     }
 
     @Test
-    fun test_suspendCatching_wrapsSuccessfulSuspend() = runTest {
-        val result = SupabaseResult.suspendCatching { 42 }
-        assertEquals(42, result.getOrNull())
-    }
-
-    @Test
-    fun test_suspendCatching_wrapsSupabaseException() = runTest {
-        val result = SupabaseResult.suspendCatching<Int> {
-            throw SupabaseException(error)
+    fun test_suspendCatching_wrapsSuccessfulSuspend() =
+        runTest {
+            val result = SupabaseResult.suspendCatching { 42 }
+            assertEquals(42, result.getOrNull())
         }
-        assertTrue(result.isFailure)
-        assertEquals(error, result.errorOrNull())
-    }
 
     @Test
-    fun test_suspendCatching_wrapsGenericException() = runTest {
-        val result = SupabaseResult.suspendCatching<Int> {
-            throw IllegalStateException("boom")
+    fun test_suspendCatching_wrapsSupabaseException() =
+        runTest {
+            val result =
+                SupabaseResult.suspendCatching<Int> {
+                    throw SupabaseException(error)
+                }
+            assertTrue(result.isFailure)
+            assertEquals(error, result.errorOrNull())
         }
-        assertTrue(result.isFailure)
-        assertEquals("boom", result.errorOrNull()?.message)
-    }
 
     @Test
-    fun test_suspendCatching_rethrowsCancellationException() = runTest {
-        assertFailsWith<CancellationException> {
-            SupabaseResult.suspendCatching<Int> {
-                throw CancellationException("cancel")
+    fun test_suspendCatching_wrapsGenericException() =
+        runTest {
+            val result =
+                SupabaseResult.suspendCatching<Int> {
+                    throw IllegalStateException("boom")
+                }
+            assertTrue(result.isFailure)
+            assertEquals("boom", result.errorOrNull()?.message)
+        }
+
+    @Test
+    fun test_suspendCatching_rethrowsCancellationException() =
+        runTest {
+            assertFailsWith<CancellationException> {
+                SupabaseResult.suspendCatching<Int> {
+                    throw CancellationException("cancel")
+                }
             }
         }
-    }
 
     @Test
     fun test_fold_invokesOnSuccess() {
-        val value = SupabaseResult.Success(10).fold(
-            onSuccess = { it * 2 },
-            onFailure = { -1 },
-        )
+        val value =
+            SupabaseResult.Success(10).fold(
+                onSuccess = { it * 2 },
+                onFailure = { -1 },
+            )
         assertEquals(20, value)
     }
 
     @Test
     fun test_fold_invokesOnFailure() {
-        val value: Int = SupabaseResult.Failure(error).fold(
-            onSuccess = { 0 },
-            onFailure = { -1 },
-        )
+        val value: Int =
+            SupabaseResult.Failure(error).fold(
+                onSuccess = { 0 },
+                onFailure = { -1 },
+            )
         assertEquals(-1, value)
     }
 
     @Test
-    fun test_onSuccessSuspend_invokesForSuccess() = runTest {
-        var captured = 0
-        SupabaseResult.Success(7).onSuccessSuspend { captured = it * 2 }
-        assertEquals(14, captured)
-    }
+    fun test_onSuccessSuspend_invokesForSuccess() =
+        runTest {
+            var captured = 0
+            SupabaseResult.Success(7).onSuccessSuspend { captured = it * 2 }
+            assertEquals(14, captured)
+        }
 
     @Test
-    fun test_onFailureSuspend_invokesForFailure() = runTest {
-        var captured: SupabaseError? = null
-        SupabaseResult.Failure(error).onFailureSuspend { captured = it }
-        assertEquals(error, captured)
-    }
+    fun test_onFailureSuspend_invokesForFailure() =
+        runTest {
+            var captured: SupabaseError? = null
+            SupabaseResult.Failure(error).onFailureSuspend { captured = it }
+            assertEquals(error, captured)
+        }
 
     @Test
-    fun test_foldSuspend_invokesOnSuccess() = runTest {
-        val value = SupabaseResult.Success(10).foldSuspend(
-            onSuccess = { it * 2 },
-            onFailure = { -1 },
-        )
-        assertEquals(20, value)
-    }
+    fun test_foldSuspend_invokesOnSuccess() =
+        runTest {
+            val value =
+                SupabaseResult.Success(10).foldSuspend(
+                    onSuccess = { it * 2 },
+                    onFailure = { -1 },
+                )
+            assertEquals(20, value)
+        }
 
     @Test
-    fun test_foldSuspend_invokesOnFailure() = runTest {
-        val value: Int = SupabaseResult.Failure(error).foldSuspend(
-            onSuccess = { 0 },
-            onFailure = { -1 },
-        )
-        assertEquals(-1, value)
-    }
+    fun test_foldSuspend_invokesOnFailure() =
+        runTest {
+            val value: Int =
+                SupabaseResult.Failure(error).foldSuspend(
+                    onSuccess = { 0 },
+                    onFailure = { -1 },
+                )
+            assertEquals(-1, value)
+        }
 
     @Test
-    fun test_mapSuspend_transformsSuccess() = runTest {
-        val result = SupabaseResult.Success(10).mapSuspend { it * 2 }
-        assertEquals(20, result.getOrNull())
-    }
+    fun test_mapSuspend_transformsSuccess() =
+        runTest {
+            val result = SupabaseResult.Success(10).mapSuspend { it * 2 }
+            assertEquals(20, result.getOrNull())
+        }
 
     @Test
-    fun test_mapSuspend_preservesFailure() = runTest {
-        val mapped: SupabaseResult<Int> = SupabaseResult.Failure(error)
-            .mapSuspend { 0 }
-        assertTrue(mapped.isFailure)
-        assertEquals(error, mapped.errorOrNull())
-    }
+    fun test_mapSuspend_preservesFailure() =
+        runTest {
+            val mapped: SupabaseResult<Int> =
+                SupabaseResult
+                    .Failure(error)
+                    .mapSuspend { 0 }
+            assertTrue(mapped.isFailure)
+            assertEquals(error, mapped.errorOrNull())
+        }
 
     @Test
-    fun test_recoverSuspend_convertsFailureToSuccess() = runTest {
-        val result: SupabaseResult<String> = SupabaseResult.Failure(error)
-            .recoverSuspend { "default" }
-        assertEquals("default", result.getOrNull())
-    }
+    fun test_recoverSuspend_convertsFailureToSuccess() =
+        runTest {
+            val result: SupabaseResult<String> =
+                SupabaseResult
+                    .Failure(error)
+                    .recoverSuspend { "default" }
+            assertEquals("default", result.getOrNull())
+        }
 
     @Test
-    fun test_recoverSuspend_leavesSuccessUntouched() = runTest {
-        val result = SupabaseResult.Success("original")
-            .recoverSuspend { "default" }
-        assertEquals("original", result.getOrNull())
-    }
+    fun test_recoverSuspend_leavesSuccessUntouched() =
+        runTest {
+            val result =
+                SupabaseResult
+                    .Success("original")
+                    .recoverSuspend { "default" }
+            assertEquals("original", result.getOrNull())
+        }
 
     @Test
-    fun test_onFailureCategorySuspend_invokesForMatchingCategory() = runTest {
-        val notFoundError = SupabaseError(message = "table not found", code = "PGRST205")
-        var called = false
-        SupabaseResult.Failure(notFoundError).onFailureCategorySuspend(
-            category = io.github.androidpoet.supabase.core.result.SupabaseErrorCategory.NotFound,
-        ) { called = true }
-        assertTrue(called)
-    }
+    fun test_onFailureCategorySuspend_invokesForMatchingCategory() =
+        runTest {
+            val notFoundError = SupabaseError(message = "table not found", code = "PGRST205")
+            var called = false
+            SupabaseResult.Failure(notFoundError).onFailureCategorySuspend(
+                category = io.github.androidpoet.supabase.core.result.SupabaseErrorCategory.NotFound,
+            ) { called = true }
+            assertTrue(called)
+        }
 
     @Test
-    fun test_onFailureCategorySuspend_withClassifier_invokesOnMatch() = runTest {
-        var called = false
-        SupabaseResult.Failure(error).onFailureCategorySuspend(
-            category = "pgrst",
-            classifier = { if (it.code?.startsWith("PGRST") == true) "pgrst" else "other" },
-        ) { called = true }
-        assertTrue(called)
-    }
+    fun test_onFailureCategorySuspend_withClassifier_invokesOnMatch() =
+        runTest {
+            var called = false
+            SupabaseResult.Failure(error).onFailureCategorySuspend(
+                category = "pgrst",
+                classifier = { if (it.code?.startsWith("PGRST") == true) "pgrst" else "other" },
+            ) { called = true }
+            assertTrue(called)
+        }
 
     @Test
-    fun test_onFailureCategorySuspend_skipsNonMatchingCategory() = runTest {
-        var called = false
-        SupabaseResult.Failure(error).onFailureCategorySuspend(
-            category = io.github.androidpoet.supabase.core.result.SupabaseErrorCategory.Conflict,
-        ) { called = true }
-        assertFalse(called)
-    }
+    fun test_onFailureCategorySuspend_skipsNonMatchingCategory() =
+        runTest {
+            var called = false
+            SupabaseResult.Failure(error).onFailureCategorySuspend(
+                category = io.github.androidpoet.supabase.core.result.SupabaseErrorCategory.Conflict,
+            ) { called = true }
+            assertFalse(called)
+        }
 }

--- a/supabase-database/src/commonMain/kotlin/io/github/androidpoet/supabase/database/DatabaseClient.kt
+++ b/supabase-database/src/commonMain/kotlin/io/github/androidpoet/supabase/database/DatabaseClient.kt
@@ -1,23 +1,36 @@
 package io.github.androidpoet.supabase.database
 import io.github.androidpoet.supabase.core.models.FilterBuilder
 import io.github.androidpoet.supabase.core.result.SupabaseResult
-public enum class CountOption(internal val headerValue: String) {
+
+public enum class CountOption(
+    internal val headerValue: String,
+) {
     EXACT("exact"),
     PLANNED("planned"),
     ESTIMATED("estimated"),
 }
-public enum class ReturnOption(internal val headerValue: String) {
+
+public enum class ReturnOption(
+    internal val headerValue: String,
+) {
     MINIMAL("minimal"),
     REPRESENTATION("representation"),
 }
-public enum class UpsertResolution(internal val headerValue: String) {
+
+public enum class UpsertResolution(
+    internal val headerValue: String,
+) {
     MERGE_DUPLICATES("merge-duplicates"),
     IGNORE_DUPLICATES("ignore-duplicates"),
 }
-public enum class ExplainFormat(internal val headerValue: String) {
+
+public enum class ExplainFormat(
+    internal val headerValue: String,
+) {
     TEXT("text"),
     JSON("json"),
 }
+
 public data class ExplainOptions(
     public val analyze: Boolean = false,
     public val verbose: Boolean = false,
@@ -26,6 +39,7 @@ public data class ExplainOptions(
     public val wal: Boolean = false,
     public val format: ExplainFormat = ExplainFormat.TEXT,
 )
+
 public interface DatabaseClient {
     public suspend fun select(
         table: String,
@@ -41,6 +55,7 @@ public interface DatabaseClient {
         headers: Map<String, String> = emptyMap(),
         filters: FilterBuilder.() -> Unit = {},
     ): SupabaseResult<String>
+
     public suspend fun insert(
         table: String,
         schema: String? = null,
@@ -56,6 +71,7 @@ public interface DatabaseClient {
         rollback: Boolean = false,
         headers: Map<String, String> = emptyMap(),
     ): SupabaseResult<String>
+
     public suspend fun update(
         table: String,
         schema: String? = null,
@@ -69,6 +85,7 @@ public interface DatabaseClient {
         headers: Map<String, String> = emptyMap(),
         filters: FilterBuilder.() -> Unit = {},
     ): SupabaseResult<String>
+
     public suspend fun delete(
         table: String,
         schema: String? = null,
@@ -81,6 +98,7 @@ public interface DatabaseClient {
         headers: Map<String, String> = emptyMap(),
         filters: FilterBuilder.() -> Unit = {},
     ): SupabaseResult<String>
+
     public suspend fun rpc(
         function: String,
         schema: String? = null,
@@ -95,6 +113,7 @@ public interface DatabaseClient {
         explain: ExplainOptions? = null,
         headers: Map<String, String> = emptyMap(),
     ): SupabaseResult<String>
+
     public suspend fun rpcGet(
         function: String,
         schema: String? = null,

--- a/supabase-database/src/commonMain/kotlin/io/github/androidpoet/supabase/database/DatabaseClientExt.kt
+++ b/supabase-database/src/commonMain/kotlin/io/github/androidpoet/supabase/database/DatabaseClientExt.kt
@@ -9,7 +9,6 @@ import io.github.androidpoet.supabase.core.result.map
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonObject
-import kotlinx.serialization.json.jsonPrimitive
 
 public suspend inline fun <reified T> DatabaseClient.selectTyped(
     table: String,
@@ -21,6 +20,7 @@ public suspend inline fun <reified T> DatabaseClient.selectTyped(
     val result = select(table = table, schema = schema, columns = columns, single = single, filters = filters)
     return if (single) result.deserialize<T>().map { listOf(it) } else result.deserialize()
 }
+
 public suspend inline fun <reified T> DatabaseClient.selectSingleTyped(
     table: String,
     schema: String? = null,
@@ -70,6 +70,7 @@ public suspend fun DatabaseClient.selectHead(
         count = count,
         filters = filters,
     ).map { }
+
 public suspend inline fun <reified T> DatabaseClient.insertTyped(
     table: String,
     schema: String? = null,
@@ -137,6 +138,7 @@ public suspend inline fun <reified T> DatabaseClient.insertUnitTyped(
         onConflict = onConflict,
         count = count,
     )
+
 public suspend inline fun <reified T> DatabaseClient.insertTypedMany(
     table: String,
     schema: String? = null,
@@ -197,6 +199,7 @@ public suspend inline fun <reified T> DatabaseClient.upsertTypedMany(
         defaultToNull = defaultToNull,
         onConflict = onConflict,
     )
+
 public suspend inline fun <reified T> DatabaseClient.updateTyped(
     table: String,
     schema: String? = null,
@@ -269,6 +272,7 @@ public suspend fun DatabaseClient.deleteUnit(
         count = count,
         filters = filters,
     ).map { }
+
 public suspend inline fun <reified T> DatabaseClient.rpcTyped(
     function: String,
     schema: String? = null,
@@ -365,12 +369,13 @@ public suspend inline fun <reified Request : Any, reified Response> DatabaseClie
     params: Request,
 ): SupabaseResult<Response?> =
     when (
-        val result = rpc(
-            function = function,
-            schema = schema,
-            params = defaultJson.encodeToString(params),
-            single = true,
-        )
+        val result =
+            rpc(
+                function = function,
+                schema = schema,
+                params = defaultJson.encodeToString(params),
+                single = true,
+            )
     ) {
         is SupabaseResult.Success -> result.deserialize<Response>().map { it as Response? }
         is SupabaseResult.Failure ->

--- a/supabase-database/src/commonMain/kotlin/io/github/androidpoet/supabase/database/DatabaseClientImpl.kt
+++ b/supabase-database/src/commonMain/kotlin/io/github/androidpoet/supabase/database/DatabaseClientImpl.kt
@@ -27,20 +27,24 @@ internal class DatabaseClientImpl(
         require(!(csv && stripNulls)) { "stripNulls cannot be used with csv" }
         val safeTable = validatePathSegment(table, "table")
         val safeSchema = schema?.let { validatePathSegment(it, "schema") }
-        val queryParams = buildList {
-            add("select" to columns)
-            addAll(FilterBuilder().apply(filters).build())
-        }
-        val requestHeaders = headers + buildPreferHeader {
-            count?.let { add("count=${it.headerValue}") }
-        } + retryHeader(retry)
+        val queryParams =
+            buildList {
+                add("select" to columns)
+                addAll(FilterBuilder().apply(filters).build())
+            }
+        val requestHeaders =
+            headers +
+                buildPreferHeader {
+                    count?.let { add("count=${it.headerValue}") }
+                } + retryHeader(retry)
         val headersWithSchema = addSchemaHeaders(requestHeaders, safeSchema, isReadRequest = true)
         if (head) {
-            val result = client.get(
-                endpoint = "/rest/v1/$safeTable",
-                queryParams = queryParams,
-                headers = headersWithSchema + ("Accept" to acceptHeader(single, csv, stripNulls, explain)),
-            )
+            val result =
+                client.get(
+                    endpoint = "/rest/v1/$safeTable",
+                    queryParams = queryParams,
+                    headers = headersWithSchema + ("Accept" to acceptHeader(single, csv, stripNulls, explain)),
+                )
             return when (result) {
                 is SupabaseResult.Success -> SupabaseResult.Success("")
                 is SupabaseResult.Failure -> result
@@ -70,23 +74,27 @@ internal class DatabaseClientImpl(
     ): SupabaseResult<String> {
         val safeTable = validatePathSegment(table, "table")
         val safeSchema = schema?.let { validatePathSegment(it, "schema") }
-        val endpoint = buildEndpoint("/rest/v1/$safeTable") {
-            if (onConflict != null) add("on_conflict" to onConflict)
-            if (!columns.isNullOrEmpty()) add("columns" to columns.joinToString(","))
-        }
-        val requestHeaders = headers + buildPreferHeader {
-            add("return=${returning.headerValue}")
-            count?.let { add("count=${it.headerValue}") }
-            if (upsert) add("resolution=${upsertResolution.headerValue}")
-            if (!defaultToNull) add("missing=default")
-            if (rollback) add("tx=rollback")
-        }
+        val endpoint =
+            buildEndpoint("/rest/v1/$safeTable") {
+                if (onConflict != null) add("on_conflict" to onConflict)
+                if (!columns.isNullOrEmpty()) add("columns" to columns.joinToString(","))
+            }
+        val requestHeaders =
+            headers +
+                buildPreferHeader {
+                    add("return=${returning.headerValue}")
+                    count?.let { add("count=${it.headerValue}") }
+                    if (upsert) add("resolution=${upsertResolution.headerValue}")
+                    if (!defaultToNull) add("missing=default")
+                    if (rollback) add("tx=rollback")
+                }
         return client.post(
             endpoint = endpoint,
             body = body,
-            headers = addSchemaHeaders(requestHeaders, safeSchema, isReadRequest = false) +
-                jsonContentHeaders() +
-                ("Accept" to acceptHeader(stripNulls = stripNulls)),
+            headers =
+                addSchemaHeaders(requestHeaders, safeSchema, isReadRequest = false) +
+                    jsonContentHeaders() +
+                    ("Accept" to acceptHeader(stripNulls = stripNulls)),
         )
     }
 
@@ -108,21 +116,24 @@ internal class DatabaseClientImpl(
         val safeSchema = schema?.let { validatePathSegment(it, "schema") }
         val filterParams = FilterBuilder().apply(filters).build()
         val endpoint = buildEndpoint("/rest/v1/$safeTable", filterParams)
-        val requestHeaders = headers + buildPreferHeader {
-            add("return=${returning.headerValue}")
-            count?.let { add("count=${it.headerValue}") }
-            if (rollback) add("tx=rollback")
-            maxAffected?.let {
-                add("handling=strict")
-                add("max-affected=$it")
-            }
-        }
+        val requestHeaders =
+            headers +
+                buildPreferHeader {
+                    add("return=${returning.headerValue}")
+                    count?.let { add("count=${it.headerValue}") }
+                    if (rollback) add("tx=rollback")
+                    maxAffected?.let {
+                        add("handling=strict")
+                        add("max-affected=$it")
+                    }
+                }
         return client.patch(
             endpoint = endpoint,
             body = body,
-            headers = addSchemaHeaders(requestHeaders, safeSchema, isReadRequest = false) +
-                jsonContentHeaders() +
-                ("Accept" to acceptHeader(stripNulls = stripNulls, explain = explain)),
+            headers =
+                addSchemaHeaders(requestHeaders, safeSchema, isReadRequest = false) +
+                    jsonContentHeaders() +
+                    ("Accept" to acceptHeader(stripNulls = stripNulls, explain = explain)),
         )
     }
 
@@ -143,19 +154,22 @@ internal class DatabaseClientImpl(
         val safeSchema = schema?.let { validatePathSegment(it, "schema") }
         val filterParams = FilterBuilder().apply(filters).build()
         val endpoint = buildEndpoint("/rest/v1/$safeTable", filterParams)
-        val requestHeaders = headers + buildPreferHeader {
-            add("return=${returning.headerValue}")
-            count?.let { add("count=${it.headerValue}") }
-            if (rollback) add("tx=rollback")
-            maxAffected?.let {
-                add("handling=strict")
-                add("max-affected=$it")
-            }
-        }
+        val requestHeaders =
+            headers +
+                buildPreferHeader {
+                    add("return=${returning.headerValue}")
+                    count?.let { add("count=${it.headerValue}") }
+                    if (rollback) add("tx=rollback")
+                    maxAffected?.let {
+                        add("handling=strict")
+                        add("max-affected=$it")
+                    }
+                }
         return client.delete(
             endpoint = endpoint,
-            headers = addSchemaHeaders(requestHeaders, safeSchema, isReadRequest = false) +
-                ("Accept" to acceptHeader(stripNulls = stripNulls, explain = explain)),
+            headers =
+                addSchemaHeaders(requestHeaders, safeSchema, isReadRequest = false) +
+                    ("Accept" to acceptHeader(stripNulls = stripNulls, explain = explain)),
         )
     }
 
@@ -178,21 +192,25 @@ internal class DatabaseClientImpl(
         maxAffected?.let { require(it > 0) { "maxAffected must be greater than 0" } }
         val safeFunction = validatePathSegment(function, "function")
         val safeSchema = schema?.let { validatePathSegment(it, "schema") }
-        val requestHeaders = headers + buildPreferHeader {
-            count?.let { add("count=${it.headerValue}") }
-            if (rollback) add("tx=rollback")
-            maxAffected?.let {
-                add("handling=strict")
-                add("max-affected=$it")
-            }
-        }
+        val requestHeaders =
+            headers +
+                buildPreferHeader {
+                    count?.let { add("count=${it.headerValue}") }
+                    if (rollback) add("tx=rollback")
+                    maxAffected?.let {
+                        add("handling=strict")
+                        add("max-affected=$it")
+                    }
+                }
         if (head) {
-            val result = client.post(
-                endpoint = "/rest/v1/rpc/$safeFunction",
-                body = params,
-                headers = addSchemaHeaders(requestHeaders, safeSchema, isReadRequest = true) +
-                    ("Accept" to acceptHeader(single, csv, stripNulls, explain)),
-            )
+            val result =
+                client.post(
+                    endpoint = "/rest/v1/rpc/$safeFunction",
+                    body = params,
+                    headers =
+                        addSchemaHeaders(requestHeaders, safeSchema, isReadRequest = true) +
+                            ("Accept" to acceptHeader(single, csv, stripNulls, explain)),
+                )
             return when (result) {
                 is SupabaseResult.Success -> SupabaseResult.Success("")
                 is SupabaseResult.Failure -> result
@@ -201,9 +219,10 @@ internal class DatabaseClientImpl(
         return client.post(
             endpoint = "/rest/v1/rpc/$safeFunction",
             body = params,
-            headers = addSchemaHeaders(requestHeaders, safeSchema, isReadRequest = false) +
-                jsonContentHeaders() +
-                ("Accept" to acceptHeader(single, csv, stripNulls, explain)),
+            headers =
+                addSchemaHeaders(requestHeaders, safeSchema, isReadRequest = false) +
+                    jsonContentHeaders() +
+                    ("Accept" to acceptHeader(single, csv, stripNulls, explain)),
         )
     }
 
@@ -224,16 +243,19 @@ internal class DatabaseClientImpl(
         require(!(csv && stripNulls)) { "stripNulls cannot be used with csv" }
         val safeFunction = validatePathSegment(function, "function")
         val safeSchema = schema?.let { validatePathSegment(it, "schema") }
-        val requestHeaders = headers + buildPreferHeader {
-            count?.let { add("count=${it.headerValue}") }
-        } + retryHeader(retry)
+        val requestHeaders =
+            headers +
+                buildPreferHeader {
+                    count?.let { add("count=${it.headerValue}") }
+                } + retryHeader(retry)
         val readHeaders = addSchemaHeaders(requestHeaders, safeSchema, isReadRequest = true)
         val endpoint = buildEndpoint("/rest/v1/rpc/$safeFunction", queryParams)
         if (head) {
-            val result = client.get(
-                endpoint = endpoint,
-                headers = readHeaders + ("Accept" to acceptHeader(single, csv, stripNulls, explain)),
-            )
+            val result =
+                client.get(
+                    endpoint = endpoint,
+                    headers = readHeaders + ("Accept" to acceptHeader(single, csv, stripNulls, explain)),
+                )
             return when (result) {
                 is SupabaseResult.Success -> SupabaseResult.Success("")
                 is SupabaseResult.Failure -> result
@@ -249,8 +271,11 @@ internal class DatabaseClientImpl(
         block: MutableList<String>.() -> Unit,
     ): Map<String, String> {
         val directives = buildList(block)
-        return if (directives.isEmpty()) emptyMap()
-        else mapOf("Prefer" to directives.joinToString(", "))
+        return if (directives.isEmpty()) {
+            emptyMap()
+        } else {
+            mapOf("Prefer" to directives.joinToString(", "))
+        }
     }
 
     private fun buildEndpoint(
@@ -258,14 +283,16 @@ internal class DatabaseClientImpl(
         params: List<Pair<String, String>> = emptyList(),
         extra: MutableList<Pair<String, String>>.() -> Unit = {},
     ): String {
-        val all = buildList {
-            addAll(params)
-            extra()
-        }
+        val all =
+            buildList {
+                addAll(params)
+                extra()
+            }
         if (all.isEmpty()) return base
-        val qs = all.joinToString("&") { (k, v) ->
-            "${encodeQueryComponent(k)}=${encodeQueryComponent(v)}"
-        }
+        val qs =
+            all.joinToString("&") { (k, v) ->
+                "${encodeQueryComponent(k)}=${encodeQueryComponent(v)}"
+            }
         return "$base?$qs"
     }
 
@@ -281,24 +308,26 @@ internal class DatabaseClientImpl(
         stripNulls: Boolean = false,
         explain: ExplainOptions? = null,
     ): String {
-        val base = when {
-            single && stripNulls -> "application/vnd.pgrst.object+json;nulls=stripped"
-            single -> "application/vnd.pgrst.object+json"
-            csv -> "text/csv"
-            stripNulls -> "application/vnd.pgrst.array+json;nulls=stripped"
-            else -> "application/json"
-        }
+        val base =
+            when {
+                single && stripNulls -> "application/vnd.pgrst.object+json;nulls=stripped"
+                single -> "application/vnd.pgrst.object+json"
+                csv -> "text/csv"
+                stripNulls -> "application/vnd.pgrst.array+json;nulls=stripped"
+                else -> "application/json"
+            }
         return explain?.acceptHeader(base) ?: base
     }
 
     private fun ExplainOptions.acceptHeader(baseMediaType: String): String {
-        val options = buildList {
-            if (analyze) add("analyze")
-            if (verbose) add("verbose")
-            if (settings) add("settings")
-            if (buffers) add("buffers")
-            if (wal) add("wal")
-        }.joinToString("|")
+        val options =
+            buildList {
+                if (analyze) add("analyze")
+                if (verbose) add("verbose")
+                if (settings) add("settings")
+                if (buffers) add("buffers")
+                if (wal) add("wal")
+            }.joinToString("|")
         return "application/vnd.pgrst.plan+${format.headerValue}; for=\"$baseMediaType\"; options=$options;"
     }
 

--- a/supabase-database/src/commonTest/kotlin/io/github/androidpoet/supabase/database/DatabaseClientExtTest.kt
+++ b/supabase-database/src/commonTest/kotlin/io/github/androidpoet/supabase/database/DatabaseClientExtTest.kt
@@ -11,538 +11,632 @@ import kotlin.test.assertTrue
 
 class DatabaseClientExtTest {
     @Test
-    fun test_selectHead_mapsSuccessToUnit() = runTest {
-        val client = FakeDatabaseClient(
-            selectResult = SupabaseResult.Success(""),
-        )
+    fun test_selectHead_mapsSuccessToUnit() =
+        runTest {
+            val client =
+                FakeDatabaseClient(
+                    selectResult = SupabaseResult.Success(""),
+                )
 
-        val result = client.selectHead(table = "items")
-        assertTrue(result is SupabaseResult.Success)
-        assertEquals(Unit, result.value)
-    }
-
-    @Test
-    fun test_selectMaybeSingleTyped_returnsDecodedEntity() = runTest {
-        val client = FakeDatabaseClient(
-            selectResult = SupabaseResult.Success("""{"id":1}"""),
-        )
-
-        val result = client.selectMaybeSingleTyped<TestItem>(table = "items")
-
-        assertTrue(result is SupabaseResult.Success)
-        assertEquals(TestItem(id = 1), result.value)
-    }
+            val result = client.selectHead(table = "items")
+            assertTrue(result is SupabaseResult.Success)
+            assertEquals(Unit, result.value)
+        }
 
     @Test
-    fun test_selectMaybeSingleTyped_returnsNullOn406() = runTest {
-        val client = FakeDatabaseClient(
-            selectResult = SupabaseResult.Failure(SupabaseError(message = "no rows", code = "406")),
-        )
+    fun test_selectMaybeSingleTyped_returnsDecodedEntity() =
+        runTest {
+            val client =
+                FakeDatabaseClient(
+                    selectResult = SupabaseResult.Success("""{"id":1}"""),
+                )
 
-        val result = client.selectMaybeSingleTyped<TestItem>(table = "items")
+            val result = client.selectMaybeSingleTyped<TestItem>(table = "items")
 
-        assertTrue(result is SupabaseResult.Success)
-        assertEquals(null, result.value)
-    }
-
-    @Test
-    fun test_upsertTyped_setsUpsertFlag() = runTest {
-        val client = FakeDatabaseClient(
-            selectResult = SupabaseResult.Success("""{"id":1}"""),
-        )
-
-        client.upsertTyped(
-            table = "items",
-            value = TestItem(id = 1),
-        )
-
-        assertEquals(true, client.lastInsertUpsert)
-    }
+            assertTrue(result is SupabaseResult.Success)
+            assertEquals(TestItem(id = 1), result.value)
+        }
 
     @Test
-    fun test_insertUnit_mapsSuccessToUnit() = runTest {
-        val client = FakeDatabaseClient(
-            selectResult = SupabaseResult.Success("""{"id":1}"""),
-            insertResult = SupabaseResult.Success(""),
-        )
+    fun test_selectMaybeSingleTyped_returnsNullOn406() =
+        runTest {
+            val client =
+                FakeDatabaseClient(
+                    selectResult = SupabaseResult.Failure(SupabaseError(message = "no rows", code = "406")),
+                )
 
-        val result = client.insertUnit(
-            table = "items",
-            body = """{"id":10}""",
-        )
+            val result = client.selectMaybeSingleTyped<TestItem>(table = "items")
 
-        assertTrue(result is SupabaseResult.Success)
-        assertEquals(Unit, result.value)
-    }
+            assertTrue(result is SupabaseResult.Success)
+            assertEquals(null, result.value)
+        }
 
     @Test
-    fun test_insertUnitTyped_setsUpsertFlagAndMapsUnit() = runTest {
-        val client = FakeDatabaseClient(
-            selectResult = SupabaseResult.Success("""{"id":1}"""),
-            insertResult = SupabaseResult.Success(""),
-        )
+    fun test_upsertTyped_setsUpsertFlag() =
+        runTest {
+            val client =
+                FakeDatabaseClient(
+                    selectResult = SupabaseResult.Success("""{"id":1}"""),
+                )
 
-        val result = client.insertUnitTyped(
-            table = "items",
-            value = TestItem(id = 14),
-            upsert = true,
-        )
+            client.upsertTyped(
+                table = "items",
+                value = TestItem(id = 1),
+            )
 
-        assertTrue(result is SupabaseResult.Success)
-        assertEquals(Unit, result.value)
-        assertEquals(true, client.lastInsertUpsert)
-    }
+            assertEquals(true, client.lastInsertUpsert)
+        }
 
     @Test
-    fun test_deleteTyped_deserializesList() = runTest {
-        val client = FakeDatabaseClient(
-            selectResult = SupabaseResult.Success("""{"id":1}"""),
-            deleteResult = SupabaseResult.Success("""[{"id":2}]"""),
-        )
+    fun test_insertUnit_mapsSuccessToUnit() =
+        runTest {
+            val client =
+                FakeDatabaseClient(
+                    selectResult = SupabaseResult.Success("""{"id":1}"""),
+                    insertResult = SupabaseResult.Success(""),
+                )
 
-        val result = client.deleteTyped<TestItem>(table = "items")
+            val result =
+                client.insertUnit(
+                    table = "items",
+                    body = """{"id":10}""",
+                )
 
-        assertTrue(result is SupabaseResult.Success)
-        assertEquals(listOf(TestItem(id = 2)), result.value)
-    }
-
-    @Test
-    fun test_updateUnit_mapsSuccessToUnit() = runTest {
-        val client = FakeDatabaseClient(
-            selectResult = SupabaseResult.Success("""{"id":1}"""),
-            updateResult = SupabaseResult.Success(""),
-        )
-
-        val result = client.updateUnit(
-            table = "items",
-            body = """{"name":"x"}""",
-        )
-
-        assertTrue(result is SupabaseResult.Success)
-        assertEquals(Unit, result.value)
-    }
+            assertTrue(result is SupabaseResult.Success)
+            assertEquals(Unit, result.value)
+        }
 
     @Test
-    fun test_updateUnitTyped_mapsSuccessToUnit() = runTest {
-        val client = FakeDatabaseClient(
-            selectResult = SupabaseResult.Success("""{"id":1}"""),
-            updateResult = SupabaseResult.Success(""),
-        )
+    fun test_insertUnitTyped_setsUpsertFlagAndMapsUnit() =
+        runTest {
+            val client =
+                FakeDatabaseClient(
+                    selectResult = SupabaseResult.Success("""{"id":1}"""),
+                    insertResult = SupabaseResult.Success(""),
+                )
 
-        val result = client.updateUnitTyped(
-            table = "items",
-            value = TestItem(id = 15),
-        )
+            val result =
+                client.insertUnitTyped(
+                    table = "items",
+                    value = TestItem(id = 14),
+                    upsert = true,
+                )
 
-        assertTrue(result is SupabaseResult.Success)
-        assertEquals(Unit, result.value)
-    }
-
-    @Test
-    fun test_deleteUnit_mapsSuccessToUnit() = runTest {
-        val client = FakeDatabaseClient(
-            selectResult = SupabaseResult.Success("""{"id":1}"""),
-            deleteResult = SupabaseResult.Success(""),
-        )
-
-        val result = client.deleteUnit(table = "items")
-
-        assertTrue(result is SupabaseResult.Success)
-        assertEquals(Unit, result.value)
-    }
+            assertTrue(result is SupabaseResult.Success)
+            assertEquals(Unit, result.value)
+            assertEquals(true, client.lastInsertUpsert)
+        }
 
     @Test
-    fun test_rpcGetTyped_deserializesValue() = runTest {
-        val client = FakeDatabaseClient(
-            selectResult = SupabaseResult.Success("""{"id":1}"""),
-            rpcGetResult = SupabaseResult.Success("""{"id":3}"""),
-        )
+    fun test_deleteTyped_deserializesList() =
+        runTest {
+            val client =
+                FakeDatabaseClient(
+                    selectResult = SupabaseResult.Success("""{"id":1}"""),
+                    deleteResult = SupabaseResult.Success("""[{"id":2}]"""),
+                )
 
-        val result = client.rpcGetTyped<TestItem>(
-            function = "get_item",
-            queryParams = listOf("id" to "3"),
-        )
+            val result = client.deleteTyped<TestItem>(table = "items")
 
-        assertTrue(result is SupabaseResult.Success)
-        assertEquals(TestItem(id = 3), result.value)
-    }
-
-    @Test
-    fun test_rpcGet_mapOverload_mapsParamsToPairs() = runTest {
-        val client = FakeDatabaseClient(
-            selectResult = SupabaseResult.Success("""{"id":1}"""),
-            rpcGetResult = SupabaseResult.Success("""{"id":3}"""),
-        )
-
-        client.rpcGet(
-            function = "get_item",
-            queryParams = linkedMapOf("id" to "3", "active" to "true"),
-        )
-
-        assertEquals(listOf("id" to "3", "active" to "true"), client.lastRpcGetQueryParams)
-    }
+            assertTrue(result is SupabaseResult.Success)
+            assertEquals(listOf(TestItem(id = 2)), result.value)
+        }
 
     @Test
-    fun test_rpcGet_mapOverload_withOptions_mapsParamsToPairs() = runTest {
-        val client = FakeDatabaseClient(
-            selectResult = SupabaseResult.Success("""{"id":1}"""),
-            rpcGetResult = SupabaseResult.Success(""),
-        )
+    fun test_updateUnit_mapsSuccessToUnit() =
+        runTest {
+            val client =
+                FakeDatabaseClient(
+                    selectResult = SupabaseResult.Success("""{"id":1}"""),
+                    updateResult = SupabaseResult.Success(""),
+                )
 
-        client.rpcGet(
-            function = "get_item",
-            queryParams = linkedMapOf("id" to "3", "active" to "true"),
-            head = true,
-            count = CountOption.EXACT,
-        )
+            val result =
+                client.updateUnit(
+                    table = "items",
+                    body = """{"name":"x"}""",
+                )
 
-        assertEquals(listOf("id" to "3", "active" to "true"), client.lastRpcGetQueryParams)
-    }
-
-    @Test
-    fun test_rpcGetTyped_mapOverload_deserializesValue() = runTest {
-        val client = FakeDatabaseClient(
-            selectResult = SupabaseResult.Success("""{"id":1}"""),
-            rpcGetResult = SupabaseResult.Success("""{"id":8}"""),
-        )
-
-        val result = client.rpcGetTyped<TestItem>(
-            function = "get_item",
-            queryParams = mapOf("id" to "8"),
-        )
-
-        assertTrue(result is SupabaseResult.Success)
-        assertEquals(TestItem(id = 8), result.value)
-    }
+            assertTrue(result is SupabaseResult.Success)
+            assertEquals(Unit, result.value)
+        }
 
     @Test
-    fun test_rpcGetTyped_requestObject_mapsToQueryParams() = runTest {
-        val client = FakeDatabaseClient(
-            selectResult = SupabaseResult.Success("""{"id":1}"""),
-            rpcGetResult = SupabaseResult.Success("""{"id":13}"""),
-        )
+    fun test_updateUnitTyped_mapsSuccessToUnit() =
+        runTest {
+            val client =
+                FakeDatabaseClient(
+                    selectResult = SupabaseResult.Success("""{"id":1}"""),
+                    updateResult = SupabaseResult.Success(""),
+                )
 
-        val result = client.rpcGetTyped<TestRequest, TestItem>(
-            function = "get_item",
-            params = TestRequest(id = 13),
-        )
+            val result =
+                client.updateUnitTyped(
+                    table = "items",
+                    value = TestItem(id = 15),
+                )
 
-        assertTrue(result is SupabaseResult.Success)
-        assertEquals(TestItem(id = 13), result.value)
-        assertEquals(listOf("id" to "13"), client.lastRpcGetQueryParams)
-    }
-
-    @Test
-    fun test_rpcGetSingleTyped_mapOverload_deserializesValue() = runTest {
-        val client = FakeDatabaseClient(
-            selectResult = SupabaseResult.Success("""{"id":1}"""),
-            rpcGetResult = SupabaseResult.Success("""{"id":9}"""),
-        )
-
-        val result = client.rpcGetSingleTyped<TestItem>(
-            function = "get_item",
-            queryParams = mapOf("id" to "9"),
-        )
-
-        assertTrue(result is SupabaseResult.Success)
-        assertEquals(TestItem(id = 9), result.value)
-    }
+            assertTrue(result is SupabaseResult.Success)
+            assertEquals(Unit, result.value)
+        }
 
     @Test
-    fun test_rpcGetListTyped_mapOverload_deserializesList() = runTest {
-        val client = FakeDatabaseClient(
-            selectResult = SupabaseResult.Success("""{"id":1}"""),
-            rpcGetResult = SupabaseResult.Success("""[{"id":1},{"id":2}]"""),
-        )
+    fun test_deleteUnit_mapsSuccessToUnit() =
+        runTest {
+            val client =
+                FakeDatabaseClient(
+                    selectResult = SupabaseResult.Success("""{"id":1}"""),
+                    deleteResult = SupabaseResult.Success(""),
+                )
 
-        val result = client.rpcGetListTyped<TestItem>(
-            function = "get_items",
-            queryParams = mapOf("active" to "true"),
-        )
+            val result = client.deleteUnit(table = "items")
 
-        assertTrue(result is SupabaseResult.Success)
-        assertEquals(listOf(TestItem(id = 1), TestItem(id = 2)), result.value)
-    }
-
-    @Test
-    fun test_rpcGetCsv_mapOverload_returnsRawCsv() = runTest {
-        val client = FakeDatabaseClient(
-            selectResult = SupabaseResult.Success("""{"id":1}"""),
-            rpcGetResult = SupabaseResult.Success("id\n10"),
-        )
-
-        val result = client.rpcGetCsv(
-            function = "get_csv",
-            queryParams = mapOf("x" to "10"),
-        )
-
-        assertTrue(result is SupabaseResult.Success)
-        assertEquals("id\n10", result.value)
-    }
+            assertTrue(result is SupabaseResult.Success)
+            assertEquals(Unit, result.value)
+        }
 
     @Test
-    fun test_rpcGetHead_mapOverload_mapsSuccessToUnit() = runTest {
-        val client = FakeDatabaseClient(
-            selectResult = SupabaseResult.Success("""{"id":1}"""),
-            rpcGetResult = SupabaseResult.Success(""),
-        )
+    fun test_rpcGetTyped_deserializesValue() =
+        runTest {
+            val client =
+                FakeDatabaseClient(
+                    selectResult = SupabaseResult.Success("""{"id":1}"""),
+                    rpcGetResult = SupabaseResult.Success("""{"id":3}"""),
+                )
 
-        val result = client.rpcGetHead(
-            function = "get_count",
-            queryParams = mapOf("only" to "count"),
-            count = CountOption.EXACT,
-        )
+            val result =
+                client.rpcGetTyped<TestItem>(
+                    function = "get_item",
+                    queryParams = listOf("id" to "3"),
+                )
 
-        assertTrue(result is SupabaseResult.Success)
-        assertEquals(Unit, result.value)
-    }
-
-    @Test
-    fun test_rpcListTyped_deserializesList() = runTest {
-        val client = FakeDatabaseClient(
-            selectResult = SupabaseResult.Success("""{"id":1}"""),
-            rpcResult = SupabaseResult.Success("""[{"id":4},{"id":5}]"""),
-        )
-
-        val result = client.rpcListTyped<TestItem>(function = "get_items")
-        assertTrue(result is SupabaseResult.Success)
-        assertEquals(listOf(TestItem(id = 4), TestItem(id = 5)), result.value)
-    }
+            assertTrue(result is SupabaseResult.Success)
+            assertEquals(TestItem(id = 3), result.value)
+        }
 
     @Test
-    fun test_rpcTyped_requestObject_isSerializedToParams() = runTest {
-        val client = FakeDatabaseClient(
-            selectResult = SupabaseResult.Success("""{"id":1}"""),
-            rpcResult = SupabaseResult.Success("""{"id":11}"""),
-        )
+    fun test_rpcGet_mapOverload_mapsParamsToPairs() =
+        runTest {
+            val client =
+                FakeDatabaseClient(
+                    selectResult = SupabaseResult.Success("""{"id":1}"""),
+                    rpcGetResult = SupabaseResult.Success("""{"id":3}"""),
+                )
 
-        val result = client.rpcTyped<TestRequest, TestItem>(
-            function = "echo",
-            params = TestRequest(id = 11),
-        )
+            client.rpcGet(
+                function = "get_item",
+                queryParams = linkedMapOf("id" to "3", "active" to "true"),
+            )
 
-        assertTrue(result is SupabaseResult.Success)
-        assertEquals(TestItem(id = 11), result.value)
-        assertEquals("""{"id":11}""", client.lastRpcParams)
-    }
-
-    @Test
-    fun test_rpcSingleTyped_requestObject_isSerializedToParams() = runTest {
-        val client = FakeDatabaseClient(
-            selectResult = SupabaseResult.Success("""{"id":1}"""),
-            rpcResult = SupabaseResult.Success("""{"id":12}"""),
-        )
-
-        val result = client.rpcSingleTyped<TestRequest, TestItem>(
-            function = "echo_one",
-            params = TestRequest(id = 12),
-        )
-
-        assertTrue(result is SupabaseResult.Success)
-        assertEquals(TestItem(id = 12), result.value)
-        assertEquals("""{"id":12}""", client.lastRpcParams)
-    }
+            assertEquals(listOf("id" to "3", "active" to "true"), client.lastRpcGetQueryParams)
+        }
 
     @Test
-    fun test_rpcUnit_requestObject_isSerializedToParams() = runTest {
-        val client = FakeDatabaseClient(
-            selectResult = SupabaseResult.Success("""{"id":1}"""),
-            rpcResult = SupabaseResult.Success("{}"),
-        )
+    fun test_rpcGet_mapOverload_withOptions_mapsParamsToPairs() =
+        runTest {
+            val client =
+                FakeDatabaseClient(
+                    selectResult = SupabaseResult.Success("""{"id":1}"""),
+                    rpcGetResult = SupabaseResult.Success(""),
+                )
 
-        val result = client.rpcUnit(
-            function = "do_work",
-            params = TestRequest(id = 42),
-        )
+            client.rpcGet(
+                function = "get_item",
+                queryParams = linkedMapOf("id" to "3", "active" to "true"),
+                head = true,
+                count = CountOption.EXACT,
+            )
 
-        assertTrue(result is SupabaseResult.Success)
-        assertEquals(Unit, result.value)
-        assertEquals("""{"id":42}""", client.lastRpcParams)
-    }
-
-    @Test
-    fun test_rpcHead_requestObject_isSerializedToParams() = runTest {
-        val client = FakeDatabaseClient(
-            selectResult = SupabaseResult.Success("""{"id":1}"""),
-            rpcResult = SupabaseResult.Success(""),
-        )
-
-        val result = client.rpcHead(
-            function = "get_count",
-            params = TestRequest(id = 60),
-            count = CountOption.EXACT,
-        )
-
-        assertTrue(result is SupabaseResult.Success)
-        assertEquals(Unit, result.value)
-        assertEquals("""{"id":60}""", client.lastRpcParams)
-    }
+            assertEquals(listOf("id" to "3", "active" to "true"), client.lastRpcGetQueryParams)
+        }
 
     @Test
-    fun test_rpcCsv_requestObject_isSerializedToParams() = runTest {
-        val client = FakeDatabaseClient(
-            selectResult = SupabaseResult.Success("""{"id":1}"""),
-            rpcResult = SupabaseResult.Success("id\n50"),
-        )
+    fun test_rpcGetTyped_mapOverload_deserializesValue() =
+        runTest {
+            val client =
+                FakeDatabaseClient(
+                    selectResult = SupabaseResult.Success("""{"id":1}"""),
+                    rpcGetResult = SupabaseResult.Success("""{"id":8}"""),
+                )
 
-        val result = client.rpcCsv(
-            function = "get_csv",
-            params = TestRequest(id = 50),
-        )
+            val result =
+                client.rpcGetTyped<TestItem>(
+                    function = "get_item",
+                    queryParams = mapOf("id" to "8"),
+                )
 
-        assertTrue(result is SupabaseResult.Success)
-        assertEquals("id\n50", result.value)
-        assertEquals("""{"id":50}""", client.lastRpcParams)
-    }
-
-    @Test
-    fun test_rpcGetListTyped_deserializesList() = runTest {
-        val client = FakeDatabaseClient(
-            selectResult = SupabaseResult.Success("""{"id":1}"""),
-            rpcGetResult = SupabaseResult.Success("""[{"id":6},{"id":7}]"""),
-        )
-
-        val result = client.rpcGetListTyped<TestItem>(function = "get_items")
-        assertTrue(result is SupabaseResult.Success)
-        assertEquals(listOf(TestItem(id = 6), TestItem(id = 7)), result.value)
-    }
+            assertTrue(result is SupabaseResult.Success)
+            assertEquals(TestItem(id = 8), result.value)
+        }
 
     @Test
-    fun test_rpcMaybeSingleTyped_returnsNullOn406() = runTest {
-        val client = FakeDatabaseClient(
-            selectResult = SupabaseResult.Success("""{"id":1}"""),
-            rpcResult = SupabaseResult.Failure(SupabaseError(message = "no rows", code = "406")),
-        )
+    fun test_rpcGetTyped_requestObject_mapsToQueryParams() =
+        runTest {
+            val client =
+                FakeDatabaseClient(
+                    selectResult = SupabaseResult.Success("""{"id":1}"""),
+                    rpcGetResult = SupabaseResult.Success("""{"id":13}"""),
+                )
 
-        val result = client.rpcMaybeSingleTyped<TestItem>(function = "get_item")
+            val result =
+                client.rpcGetTyped<TestRequest, TestItem>(
+                    function = "get_item",
+                    params = TestRequest(id = 13),
+                )
 
-        assertTrue(result is SupabaseResult.Success)
-        assertEquals(null, result.value)
-    }
-
-    @Test
-    fun test_rpcGetMaybeSingleTyped_returnsNullOn406() = runTest {
-        val client = FakeDatabaseClient(
-            selectResult = SupabaseResult.Success("""{"id":1}"""),
-            rpcGetResult = SupabaseResult.Failure(SupabaseError(message = "no rows", code = "406")),
-        )
-
-        val result = client.rpcGetMaybeSingleTyped<TestItem>(function = "get_item")
-
-        assertTrue(result is SupabaseResult.Success)
-        assertEquals(null, result.value)
-    }
+            assertTrue(result is SupabaseResult.Success)
+            assertEquals(TestItem(id = 13), result.value)
+            assertEquals(listOf("id" to "13"), client.lastRpcGetQueryParams)
+        }
 
     @Test
-    fun test_rpcCsv_returnsRawCsvString() = runTest {
-        val client = FakeDatabaseClient(
-            selectResult = SupabaseResult.Success("""{"id":1}"""),
-            rpcResult = SupabaseResult.Success("id\n1"),
-        )
+    fun test_rpcGetSingleTyped_mapOverload_deserializesValue() =
+        runTest {
+            val client =
+                FakeDatabaseClient(
+                    selectResult = SupabaseResult.Success("""{"id":1}"""),
+                    rpcGetResult = SupabaseResult.Success("""{"id":9}"""),
+                )
 
-        val result = client.rpcCsv(function = "get_csv")
-        assertTrue(result is SupabaseResult.Success)
-        assertEquals("id\n1", result.value)
-    }
+            val result =
+                client.rpcGetSingleTyped<TestItem>(
+                    function = "get_item",
+                    queryParams = mapOf("id" to "9"),
+                )
 
-    @Test
-    fun test_rpcGetCsv_returnsRawCsvString() = runTest {
-        val client = FakeDatabaseClient(
-            selectResult = SupabaseResult.Success("""{"id":1}"""),
-            rpcGetResult = SupabaseResult.Success("id\n3"),
-        )
-
-        val result = client.rpcGetCsv(function = "get_csv")
-        assertTrue(result is SupabaseResult.Success)
-        assertEquals("id\n3", result.value)
-    }
+            assertTrue(result is SupabaseResult.Success)
+            assertEquals(TestItem(id = 9), result.value)
+        }
 
     @Test
-    fun test_rpcUnit_mapsSuccessToUnit() = runTest {
-        val client = FakeDatabaseClient(
-            selectResult = SupabaseResult.Success("""{"id":1}"""),
-            rpcResult = SupabaseResult.Success("{}"),
-        )
+    fun test_rpcGetListTyped_mapOverload_deserializesList() =
+        runTest {
+            val client =
+                FakeDatabaseClient(
+                    selectResult = SupabaseResult.Success("""{"id":1}"""),
+                    rpcGetResult = SupabaseResult.Success("""[{"id":1},{"id":2}]"""),
+                )
 
-        val result = client.rpcUnit(function = "do_work")
-        assertTrue(result is SupabaseResult.Success)
-        assertEquals(Unit, result.value)
-    }
+            val result =
+                client.rpcGetListTyped<TestItem>(
+                    function = "get_items",
+                    queryParams = mapOf("active" to "true"),
+                )
 
-    @Test
-    fun test_rpcGetUnit_mapsSuccessToUnit() = runTest {
-        val client = FakeDatabaseClient(
-            selectResult = SupabaseResult.Success("""{"id":1}"""),
-            rpcGetResult = SupabaseResult.Success("{}"),
-        )
-
-        val result = client.rpcGetUnit(function = "do_work")
-        assertTrue(result is SupabaseResult.Success)
-        assertEquals(Unit, result.value)
-    }
+            assertTrue(result is SupabaseResult.Success)
+            assertEquals(listOf(TestItem(id = 1), TestItem(id = 2)), result.value)
+        }
 
     @Test
-    fun test_rpcGetUnit_mapOverload_mapsParamsToPairs() = runTest {
-        val client = FakeDatabaseClient(
-            selectResult = SupabaseResult.Success("""{"id":1}"""),
-            rpcGetResult = SupabaseResult.Success("{}"),
-        )
+    fun test_rpcGetCsv_mapOverload_returnsRawCsv() =
+        runTest {
+            val client =
+                FakeDatabaseClient(
+                    selectResult = SupabaseResult.Success("""{"id":1}"""),
+                    rpcGetResult = SupabaseResult.Success("id\n10"),
+                )
 
-        val result = client.rpcGetUnit(
-            function = "do_work",
-            queryParams = linkedMapOf("a" to "1", "b" to "2"),
-        )
+            val result =
+                client.rpcGetCsv(
+                    function = "get_csv",
+                    queryParams = mapOf("x" to "10"),
+                )
 
-        assertTrue(result is SupabaseResult.Success)
-        assertEquals(listOf("a" to "1", "b" to "2"), client.lastRpcGetQueryParams)
-    }
-
-    @Test
-    fun test_rpcGetUnit_requestObject_mapsToQueryParams() = runTest {
-        val client = FakeDatabaseClient(
-            selectResult = SupabaseResult.Success("""{"id":1}"""),
-            rpcGetResult = SupabaseResult.Success("{}"),
-        )
-
-        val result = client.rpcGetUnit(
-            function = "do_work",
-            params = TestRequest(id = 77),
-        )
-
-        assertTrue(result is SupabaseResult.Success)
-        assertEquals(listOf("id" to "77"), client.lastRpcGetQueryParams)
-    }
+            assertTrue(result is SupabaseResult.Success)
+            assertEquals("id\n10", result.value)
+        }
 
     @Test
-    fun test_rpcHead_mapsSuccessToUnit() = runTest {
-        val client = FakeDatabaseClient(
-            selectResult = SupabaseResult.Success("""{"id":1}"""),
-            rpcResult = SupabaseResult.Success(""),
-        )
+    fun test_rpcGetHead_mapOverload_mapsSuccessToUnit() =
+        runTest {
+            val client =
+                FakeDatabaseClient(
+                    selectResult = SupabaseResult.Success("""{"id":1}"""),
+                    rpcGetResult = SupabaseResult.Success(""),
+                )
 
-        val result = client.rpcHead(function = "get_count", count = CountOption.EXACT)
-        assertTrue(result is SupabaseResult.Success)
-        assertEquals(Unit, result.value)
-    }
+            val result =
+                client.rpcGetHead(
+                    function = "get_count",
+                    queryParams = mapOf("only" to "count"),
+                    count = CountOption.EXACT,
+                )
+
+            assertTrue(result is SupabaseResult.Success)
+            assertEquals(Unit, result.value)
+        }
 
     @Test
-    fun test_rpcGetHead_mapsSuccessToUnit() = runTest {
-        val client = FakeDatabaseClient(
-            selectResult = SupabaseResult.Success("""{"id":1}"""),
-            rpcGetResult = SupabaseResult.Success(""),
-        )
+    fun test_rpcListTyped_deserializesList() =
+        runTest {
+            val client =
+                FakeDatabaseClient(
+                    selectResult = SupabaseResult.Success("""{"id":1}"""),
+                    rpcResult = SupabaseResult.Success("""[{"id":4},{"id":5}]"""),
+                )
 
-        val result = client.rpcGetHead(function = "get_count", count = CountOption.EXACT)
-        assertTrue(result is SupabaseResult.Success)
-        assertEquals(Unit, result.value)
-    }
+            val result = client.rpcListTyped<TestItem>(function = "get_items")
+            assertTrue(result is SupabaseResult.Success)
+            assertEquals(listOf(TestItem(id = 4), TestItem(id = 5)), result.value)
+        }
+
+    @Test
+    fun test_rpcTyped_requestObject_isSerializedToParams() =
+        runTest {
+            val client =
+                FakeDatabaseClient(
+                    selectResult = SupabaseResult.Success("""{"id":1}"""),
+                    rpcResult = SupabaseResult.Success("""{"id":11}"""),
+                )
+
+            val result =
+                client.rpcTyped<TestRequest, TestItem>(
+                    function = "echo",
+                    params = TestRequest(id = 11),
+                )
+
+            assertTrue(result is SupabaseResult.Success)
+            assertEquals(TestItem(id = 11), result.value)
+            assertEquals("""{"id":11}""", client.lastRpcParams)
+        }
+
+    @Test
+    fun test_rpcSingleTyped_requestObject_isSerializedToParams() =
+        runTest {
+            val client =
+                FakeDatabaseClient(
+                    selectResult = SupabaseResult.Success("""{"id":1}"""),
+                    rpcResult = SupabaseResult.Success("""{"id":12}"""),
+                )
+
+            val result =
+                client.rpcSingleTyped<TestRequest, TestItem>(
+                    function = "echo_one",
+                    params = TestRequest(id = 12),
+                )
+
+            assertTrue(result is SupabaseResult.Success)
+            assertEquals(TestItem(id = 12), result.value)
+            assertEquals("""{"id":12}""", client.lastRpcParams)
+        }
+
+    @Test
+    fun test_rpcUnit_requestObject_isSerializedToParams() =
+        runTest {
+            val client =
+                FakeDatabaseClient(
+                    selectResult = SupabaseResult.Success("""{"id":1}"""),
+                    rpcResult = SupabaseResult.Success("{}"),
+                )
+
+            val result =
+                client.rpcUnit(
+                    function = "do_work",
+                    params = TestRequest(id = 42),
+                )
+
+            assertTrue(result is SupabaseResult.Success)
+            assertEquals(Unit, result.value)
+            assertEquals("""{"id":42}""", client.lastRpcParams)
+        }
+
+    @Test
+    fun test_rpcHead_requestObject_isSerializedToParams() =
+        runTest {
+            val client =
+                FakeDatabaseClient(
+                    selectResult = SupabaseResult.Success("""{"id":1}"""),
+                    rpcResult = SupabaseResult.Success(""),
+                )
+
+            val result =
+                client.rpcHead(
+                    function = "get_count",
+                    params = TestRequest(id = 60),
+                    count = CountOption.EXACT,
+                )
+
+            assertTrue(result is SupabaseResult.Success)
+            assertEquals(Unit, result.value)
+            assertEquals("""{"id":60}""", client.lastRpcParams)
+        }
+
+    @Test
+    fun test_rpcCsv_requestObject_isSerializedToParams() =
+        runTest {
+            val client =
+                FakeDatabaseClient(
+                    selectResult = SupabaseResult.Success("""{"id":1}"""),
+                    rpcResult = SupabaseResult.Success("id\n50"),
+                )
+
+            val result =
+                client.rpcCsv(
+                    function = "get_csv",
+                    params = TestRequest(id = 50),
+                )
+
+            assertTrue(result is SupabaseResult.Success)
+            assertEquals("id\n50", result.value)
+            assertEquals("""{"id":50}""", client.lastRpcParams)
+        }
+
+    @Test
+    fun test_rpcGetListTyped_deserializesList() =
+        runTest {
+            val client =
+                FakeDatabaseClient(
+                    selectResult = SupabaseResult.Success("""{"id":1}"""),
+                    rpcGetResult = SupabaseResult.Success("""[{"id":6},{"id":7}]"""),
+                )
+
+            val result = client.rpcGetListTyped<TestItem>(function = "get_items")
+            assertTrue(result is SupabaseResult.Success)
+            assertEquals(listOf(TestItem(id = 6), TestItem(id = 7)), result.value)
+        }
+
+    @Test
+    fun test_rpcMaybeSingleTyped_returnsNullOn406() =
+        runTest {
+            val client =
+                FakeDatabaseClient(
+                    selectResult = SupabaseResult.Success("""{"id":1}"""),
+                    rpcResult = SupabaseResult.Failure(SupabaseError(message = "no rows", code = "406")),
+                )
+
+            val result = client.rpcMaybeSingleTyped<TestItem>(function = "get_item")
+
+            assertTrue(result is SupabaseResult.Success)
+            assertEquals(null, result.value)
+        }
+
+    @Test
+    fun test_rpcGetMaybeSingleTyped_returnsNullOn406() =
+        runTest {
+            val client =
+                FakeDatabaseClient(
+                    selectResult = SupabaseResult.Success("""{"id":1}"""),
+                    rpcGetResult = SupabaseResult.Failure(SupabaseError(message = "no rows", code = "406")),
+                )
+
+            val result = client.rpcGetMaybeSingleTyped<TestItem>(function = "get_item")
+
+            assertTrue(result is SupabaseResult.Success)
+            assertEquals(null, result.value)
+        }
+
+    @Test
+    fun test_rpcCsv_returnsRawCsvString() =
+        runTest {
+            val client =
+                FakeDatabaseClient(
+                    selectResult = SupabaseResult.Success("""{"id":1}"""),
+                    rpcResult = SupabaseResult.Success("id\n1"),
+                )
+
+            val result = client.rpcCsv(function = "get_csv")
+            assertTrue(result is SupabaseResult.Success)
+            assertEquals("id\n1", result.value)
+        }
+
+    @Test
+    fun test_rpcGetCsv_returnsRawCsvString() =
+        runTest {
+            val client =
+                FakeDatabaseClient(
+                    selectResult = SupabaseResult.Success("""{"id":1}"""),
+                    rpcGetResult = SupabaseResult.Success("id\n3"),
+                )
+
+            val result = client.rpcGetCsv(function = "get_csv")
+            assertTrue(result is SupabaseResult.Success)
+            assertEquals("id\n3", result.value)
+        }
+
+    @Test
+    fun test_rpcUnit_mapsSuccessToUnit() =
+        runTest {
+            val client =
+                FakeDatabaseClient(
+                    selectResult = SupabaseResult.Success("""{"id":1}"""),
+                    rpcResult = SupabaseResult.Success("{}"),
+                )
+
+            val result = client.rpcUnit(function = "do_work")
+            assertTrue(result is SupabaseResult.Success)
+            assertEquals(Unit, result.value)
+        }
+
+    @Test
+    fun test_rpcGetUnit_mapsSuccessToUnit() =
+        runTest {
+            val client =
+                FakeDatabaseClient(
+                    selectResult = SupabaseResult.Success("""{"id":1}"""),
+                    rpcGetResult = SupabaseResult.Success("{}"),
+                )
+
+            val result = client.rpcGetUnit(function = "do_work")
+            assertTrue(result is SupabaseResult.Success)
+            assertEquals(Unit, result.value)
+        }
+
+    @Test
+    fun test_rpcGetUnit_mapOverload_mapsParamsToPairs() =
+        runTest {
+            val client =
+                FakeDatabaseClient(
+                    selectResult = SupabaseResult.Success("""{"id":1}"""),
+                    rpcGetResult = SupabaseResult.Success("{}"),
+                )
+
+            val result =
+                client.rpcGetUnit(
+                    function = "do_work",
+                    queryParams = linkedMapOf("a" to "1", "b" to "2"),
+                )
+
+            assertTrue(result is SupabaseResult.Success)
+            assertEquals(listOf("a" to "1", "b" to "2"), client.lastRpcGetQueryParams)
+        }
+
+    @Test
+    fun test_rpcGetUnit_requestObject_mapsToQueryParams() =
+        runTest {
+            val client =
+                FakeDatabaseClient(
+                    selectResult = SupabaseResult.Success("""{"id":1}"""),
+                    rpcGetResult = SupabaseResult.Success("{}"),
+                )
+
+            val result =
+                client.rpcGetUnit(
+                    function = "do_work",
+                    params = TestRequest(id = 77),
+                )
+
+            assertTrue(result is SupabaseResult.Success)
+            assertEquals(listOf("id" to "77"), client.lastRpcGetQueryParams)
+        }
+
+    @Test
+    fun test_rpcHead_mapsSuccessToUnit() =
+        runTest {
+            val client =
+                FakeDatabaseClient(
+                    selectResult = SupabaseResult.Success("""{"id":1}"""),
+                    rpcResult = SupabaseResult.Success(""),
+                )
+
+            val result = client.rpcHead(function = "get_count", count = CountOption.EXACT)
+            assertTrue(result is SupabaseResult.Success)
+            assertEquals(Unit, result.value)
+        }
+
+    @Test
+    fun test_rpcGetHead_mapsSuccessToUnit() =
+        runTest {
+            val client =
+                FakeDatabaseClient(
+                    selectResult = SupabaseResult.Success("""{"id":1}"""),
+                    rpcGetResult = SupabaseResult.Success(""),
+                )
+
+            val result = client.rpcGetHead(function = "get_count", count = CountOption.EXACT)
+            assertTrue(result is SupabaseResult.Success)
+            assertEquals(Unit, result.value)
+        }
 }
 
 @Serializable
-private data class TestItem(val id: Int)
+private data class TestItem(
+    val id: Int,
+)
 
 @Serializable
-private data class TestRequest(val id: Int)
+private data class TestRequest(
+    val id: Int,
+)
 
 private class FakeDatabaseClient(
     private val selectResult: SupabaseResult<String>,

--- a/supabase-database/src/commonTest/kotlin/io/github/androidpoet/supabase/database/DatabaseClientImplTest.kt
+++ b/supabase-database/src/commonTest/kotlin/io/github/androidpoet/supabase/database/DatabaseClientImplTest.kt
@@ -11,427 +11,459 @@ import kotlin.test.assertTrue
 
 class DatabaseClientImplTest {
     @Test
-    fun test_select_headReturnsFailureWhenRequestFails() = runTest {
-        val client = FakeSupabaseClient(getResult = SupabaseResult.Failure(SupabaseError("boom")))
-        val sut = DatabaseClientImpl(client)
+    fun test_select_headReturnsFailureWhenRequestFails() =
+        runTest {
+            val client = FakeSupabaseClient(getResult = SupabaseResult.Failure(SupabaseError("boom")))
+            val sut = DatabaseClientImpl(client)
 
-        val result = runSuspend {
-            sut.select(table = "messages", columns = "*", head = true, count = null) {}
+            val result =
+                runSuspend {
+                    sut.select(table = "messages", columns = "*", head = true, count = null) {}
+                }
+
+            assertTrue(result is SupabaseResult.Failure)
         }
 
-        assertTrue(result is SupabaseResult.Failure)
-    }
-
     @Test
-    fun test_insert_onConflictIsUrlEncodedInEndpoint() = runTest {
-        val client = FakeSupabaseClient()
-        val sut = DatabaseClientImpl(client)
+    fun test_insert_onConflictIsUrlEncodedInEndpoint() =
+        runTest {
+            val client = FakeSupabaseClient()
+            val sut = DatabaseClientImpl(client)
 
-        runSuspend {
-            sut.insert(
-                table = "messages",
-                body = "{}",
-                upsert = true,
-                onConflict = "email,name",
-                returning = ReturnOption.REPRESENTATION,
-                count = null,
-            )
-        }
-
-        assertEquals("/rest/v1/messages?on_conflict=email%2Cname", client.lastPostEndpoint)
-    }
-
-    @Test
-    fun test_insert_columnsAreEncodedInEndpoint() = runTest {
-        val client = FakeSupabaseClient()
-        val sut = DatabaseClientImpl(client)
-
-        runSuspend {
-            sut.insert(
-                table = "messages",
-                body = "{}",
-                columns = listOf("id", "name"),
-            )
-        }
-
-        assertEquals("/rest/v1/messages?columns=id%2Cname", client.lastPostEndpoint)
-    }
-
-    @Test
-    fun test_select_singleUsesObjectAcceptHeader() = runTest {
-        val client = FakeSupabaseClient()
-        val sut = DatabaseClientImpl(client)
-
-        runSuspend {
-            sut.select(table = "messages", single = true) {}
-        }
-
-        assertEquals("application/vnd.pgrst.object+json", client.lastGetHeaders["Accept"])
-    }
-
-    @Test
-    fun test_select_customHeadersAreMergedAndCoreHeadersWin() = runTest {
-        val client = FakeSupabaseClient()
-        val sut = DatabaseClientImpl(client)
-
-        runSuspend {
-            sut.select(
-                table = "messages",
-                schema = "private",
-                headers = mapOf(
-                    "X-Trace-Id" to "trace-1",
-                    "Accept" to "text/plain",
-                    "Accept-Profile" to "wrong",
-                ),
-            ) {}
-        }
-
-        assertEquals("trace-1", client.lastGetHeaders["X-Trace-Id"])
-        assertEquals("application/json", client.lastGetHeaders["Accept"])
-        assertEquals("private", client.lastGetHeaders["Accept-Profile"])
-    }
-
-    @Test
-    fun test_select_csvUsesTextCsvAcceptHeader() = runTest {
-        val client = FakeSupabaseClient()
-        val sut = DatabaseClientImpl(client)
-
-        runSuspend {
-            sut.select(table = "messages", csv = true) {}
-        }
-
-        assertEquals("text/csv", client.lastGetHeaders["Accept"])
-    }
-
-    @Test
-    fun test_select_stripNullsUsesStrippedArrayAcceptHeader() = runTest {
-        val client = FakeSupabaseClient()
-        val sut = DatabaseClientImpl(client)
-
-        runSuspend {
-            sut.select(table = "messages", stripNulls = true) {}
-        }
-
-        assertEquals("application/vnd.pgrst.array+json;nulls=stripped", client.lastGetHeaders["Accept"])
-    }
-
-    @Test
-    fun test_select_explainUsesPlanAcceptHeader() = runTest {
-        val client = FakeSupabaseClient()
-        val sut = DatabaseClientImpl(client)
-
-        runSuspend {
-            sut.select(
-                table = "messages",
-                explain = ExplainOptions(analyze = true, verbose = true, format = ExplainFormat.JSON),
-            ) {}
-        }
-
-        assertEquals(
-            """application/vnd.pgrst.plan+json; for="application/json"; options=analyze|verbose;""",
-            client.lastGetHeaders["Accept"],
-        )
-    }
-
-    @Test
-    fun test_select_stripNullsWithCsvThrows() = runTest {
-        val client = FakeSupabaseClient()
-        val sut = DatabaseClientImpl(client)
-
-        assertFailsWith<IllegalArgumentException> {
             runSuspend {
-                sut.select(table = "messages", csv = true, stripNulls = true) {}
+                sut.insert(
+                    table = "messages",
+                    body = "{}",
+                    upsert = true,
+                    onConflict = "email,name",
+                    returning = ReturnOption.REPRESENTATION,
+                    count = null,
+                )
+            }
+
+            assertEquals("/rest/v1/messages?on_conflict=email%2Cname", client.lastPostEndpoint)
+        }
+
+    @Test
+    fun test_insert_columnsAreEncodedInEndpoint() =
+        runTest {
+            val client = FakeSupabaseClient()
+            val sut = DatabaseClientImpl(client)
+
+            runSuspend {
+                sut.insert(
+                    table = "messages",
+                    body = "{}",
+                    columns = listOf("id", "name"),
+                )
+            }
+
+            assertEquals("/rest/v1/messages?columns=id%2Cname", client.lastPostEndpoint)
+        }
+
+    @Test
+    fun test_select_singleUsesObjectAcceptHeader() =
+        runTest {
+            val client = FakeSupabaseClient()
+            val sut = DatabaseClientImpl(client)
+
+            runSuspend {
+                sut.select(table = "messages", single = true) {}
+            }
+
+            assertEquals("application/vnd.pgrst.object+json", client.lastGetHeaders["Accept"])
+        }
+
+    @Test
+    fun test_select_customHeadersAreMergedAndCoreHeadersWin() =
+        runTest {
+            val client = FakeSupabaseClient()
+            val sut = DatabaseClientImpl(client)
+
+            runSuspend {
+                sut.select(
+                    table = "messages",
+                    schema = "private",
+                    headers =
+                        mapOf(
+                            "X-Trace-Id" to "trace-1",
+                            "Accept" to "text/plain",
+                            "Accept-Profile" to "wrong",
+                        ),
+                ) {}
+            }
+
+            assertEquals("trace-1", client.lastGetHeaders["X-Trace-Id"])
+            assertEquals("application/json", client.lastGetHeaders["Accept"])
+            assertEquals("private", client.lastGetHeaders["Accept-Profile"])
+        }
+
+    @Test
+    fun test_select_csvUsesTextCsvAcceptHeader() =
+        runTest {
+            val client = FakeSupabaseClient()
+            val sut = DatabaseClientImpl(client)
+
+            runSuspend {
+                sut.select(table = "messages", csv = true) {}
+            }
+
+            assertEquals("text/csv", client.lastGetHeaders["Accept"])
+        }
+
+    @Test
+    fun test_select_stripNullsUsesStrippedArrayAcceptHeader() =
+        runTest {
+            val client = FakeSupabaseClient()
+            val sut = DatabaseClientImpl(client)
+
+            runSuspend {
+                sut.select(table = "messages", stripNulls = true) {}
+            }
+
+            assertEquals("application/vnd.pgrst.array+json;nulls=stripped", client.lastGetHeaders["Accept"])
+        }
+
+    @Test
+    fun test_select_explainUsesPlanAcceptHeader() =
+        runTest {
+            val client = FakeSupabaseClient()
+            val sut = DatabaseClientImpl(client)
+
+            runSuspend {
+                sut.select(
+                    table = "messages",
+                    explain = ExplainOptions(analyze = true, verbose = true, format = ExplainFormat.JSON),
+                ) {}
+            }
+
+            assertEquals(
+                """application/vnd.pgrst.plan+json; for="application/json"; options=analyze|verbose;""",
+                client.lastGetHeaders["Accept"],
+            )
+        }
+
+    @Test
+    fun test_select_stripNullsWithCsvThrows() =
+        runTest {
+            val client = FakeSupabaseClient()
+            val sut = DatabaseClientImpl(client)
+
+            assertFailsWith<IllegalArgumentException> {
+                runSuspend {
+                    sut.select(table = "messages", csv = true, stripNulls = true) {}
+                }
             }
         }
-    }
 
     @Test
-    fun test_select_retryEnabledByDefault() = runTest {
-        val client = FakeSupabaseClient()
-        val sut = DatabaseClientImpl(client)
+    fun test_select_retryEnabledByDefault() =
+        runTest {
+            val client = FakeSupabaseClient()
+            val sut = DatabaseClientImpl(client)
 
-        runSuspend {
-            sut.select(table = "messages") {}
+            runSuspend {
+                sut.select(table = "messages") {}
+            }
+
+            assertEquals("true", client.lastGetHeaders["X-Supabase-Kmp-Retry"])
         }
 
-        assertEquals("true", client.lastGetHeaders["X-Supabase-Kmp-Retry"])
-    }
-
     @Test
-    fun test_select_retryFalseDisablesRetry() = runTest {
-        val client = FakeSupabaseClient()
-        val sut = DatabaseClientImpl(client)
+    fun test_select_retryFalseDisablesRetry() =
+        runTest {
+            val client = FakeSupabaseClient()
+            val sut = DatabaseClientImpl(client)
 
-        runSuspend {
-            sut.select(table = "messages", retry = false) {}
+            runSuspend {
+                sut.select(table = "messages", retry = false) {}
+            }
+
+            assertEquals("false", client.lastGetHeaders["X-Supabase-Kmp-Retry"])
         }
 
-        assertEquals("false", client.lastGetHeaders["X-Supabase-Kmp-Retry"])
-    }
-
     @Test
-    fun test_insert_upsertIgnoreDuplicatesSetsPreferResolution() = runTest {
-        val client = FakeSupabaseClient()
-        val sut = DatabaseClientImpl(client)
+    fun test_insert_upsertIgnoreDuplicatesSetsPreferResolution() =
+        runTest {
+            val client = FakeSupabaseClient()
+            val sut = DatabaseClientImpl(client)
 
-        runSuspend {
-            sut.insert(
-                table = "messages",
-                body = "{}",
-                upsert = true,
-                upsertResolution = UpsertResolution.IGNORE_DUPLICATES,
-            )
+            runSuspend {
+                sut.insert(
+                    table = "messages",
+                    body = "{}",
+                    upsert = true,
+                    upsertResolution = UpsertResolution.IGNORE_DUPLICATES,
+                )
+            }
+
+            assertTrue(client.lastPostHeaders["Prefer"]?.contains("resolution=ignore-duplicates") == true)
         }
 
-        assertTrue(client.lastPostHeaders["Prefer"]?.contains("resolution=ignore-duplicates") == true)
-    }
-
     @Test
-    fun test_insert_defaultToNullFalse_setsMissingDefaultPreferDirective() = runTest {
-        val client = FakeSupabaseClient()
-        val sut = DatabaseClientImpl(client)
+    fun test_insert_defaultToNullFalse_setsMissingDefaultPreferDirective() =
+        runTest {
+            val client = FakeSupabaseClient()
+            val sut = DatabaseClientImpl(client)
 
-        runSuspend {
-            sut.insert(
-                table = "messages",
-                body = "{}",
-                defaultToNull = false,
-            )
+            runSuspend {
+                sut.insert(
+                    table = "messages",
+                    body = "{}",
+                    defaultToNull = false,
+                )
+            }
+
+            assertTrue(client.lastPostHeaders["Prefer"]?.contains("missing=default") == true)
         }
 
-        assertTrue(client.lastPostHeaders["Prefer"]?.contains("missing=default") == true)
-    }
-
     @Test
-    fun test_insert_rollbackSetsPreferTxRollback() = runTest {
-        val client = FakeSupabaseClient()
-        val sut = DatabaseClientImpl(client)
+    fun test_insert_rollbackSetsPreferTxRollback() =
+        runTest {
+            val client = FakeSupabaseClient()
+            val sut = DatabaseClientImpl(client)
 
-        runSuspend {
-            sut.insert(
-                table = "messages",
-                body = "{}",
-                rollback = true,
-            )
+            runSuspend {
+                sut.insert(
+                    table = "messages",
+                    body = "{}",
+                    rollback = true,
+                )
+            }
+
+            assertTrue(client.lastPostHeaders["Prefer"]?.contains("tx=rollback") == true)
         }
 
-        assertTrue(client.lastPostHeaders["Prefer"]?.contains("tx=rollback") == true)
-    }
-
     @Test
-    fun test_update_maxAffectedSetsStrictHandlingPreferDirectives() = runTest {
-        val client = FakeSupabaseClient()
-        val sut = DatabaseClientImpl(client)
+    fun test_update_maxAffectedSetsStrictHandlingPreferDirectives() =
+        runTest {
+            val client = FakeSupabaseClient()
+            val sut = DatabaseClientImpl(client)
 
-        runSuspend {
-            sut.update(
-                table = "messages",
-                body = "{}",
-                maxAffected = 1,
-            ) {}
-        }
-
-        val prefer = client.lastPatchHeaders["Prefer"].orEmpty()
-        assertTrue(prefer.contains("handling=strict"))
-        assertTrue(prefer.contains("max-affected=1"))
-    }
-
-    @Test
-    fun test_update_maxAffectedZeroThrows() = runTest {
-        val client = FakeSupabaseClient()
-        val sut = DatabaseClientImpl(client)
-
-        assertFailsWith<IllegalArgumentException> {
             runSuspend {
                 sut.update(
                     table = "messages",
                     body = "{}",
-                    maxAffected = 0,
+                    maxAffected = 1,
                 ) {}
             }
-        }
-    }
 
-    @Test
-    fun test_delete_stripNullsAndExplainUsesPlanForStrippedAcceptHeader() = runTest {
-        val client = FakeSupabaseClient()
-        val sut = DatabaseClientImpl(client)
-
-        runSuspend {
-            sut.delete(
-                table = "messages",
-                stripNulls = true,
-                explain = ExplainOptions(buffers = true),
-            ) {}
+            val prefer = client.lastPatchHeaders["Prefer"].orEmpty()
+            assertTrue(prefer.contains("handling=strict"))
+            assertTrue(prefer.contains("max-affected=1"))
         }
 
-        assertEquals(
-            """application/vnd.pgrst.plan+text; for="application/vnd.pgrst.array+json;nulls=stripped"; options=buffers;""",
-            client.lastDeleteHeaders["Accept"],
-        )
-    }
-
     @Test
-    fun test_select_withSchema_setsAcceptProfileHeader() = runTest {
-        val client = FakeSupabaseClient()
-        val sut = DatabaseClientImpl(client)
+    fun test_update_maxAffectedZeroThrows() =
+        runTest {
+            val client = FakeSupabaseClient()
+            val sut = DatabaseClientImpl(client)
 
-        runSuspend {
-            sut.select(table = "messages", schema = "private") {}
+            assertFailsWith<IllegalArgumentException> {
+                runSuspend {
+                    sut.update(
+                        table = "messages",
+                        body = "{}",
+                        maxAffected = 0,
+                    ) {}
+                }
+            }
         }
 
-        assertEquals("private", client.lastGetHeaders["Accept-Profile"])
-    }
-
     @Test
-    fun test_update_withSchema_setsContentProfileHeader() = runTest {
-        val client = FakeSupabaseClient()
-        val sut = DatabaseClientImpl(client)
+    fun test_delete_stripNullsAndExplainUsesPlanForStrippedAcceptHeader() =
+        runTest {
+            val client = FakeSupabaseClient()
+            val sut = DatabaseClientImpl(client)
 
-        runSuspend {
-            sut.update(table = "messages", schema = "analytics", body = "{}") {}
-        }
-
-        assertEquals("analytics", client.lastPatchHeaders["Content-Profile"])
-    }
-
-    @Test
-    fun test_rpc_withSchema_setsContentProfileHeader() = runTest {
-        val client = FakeSupabaseClient()
-        val sut = DatabaseClientImpl(client)
-
-        runSuspend {
-            sut.rpc(function = "my_fn", schema = "rpc_schema", params = "{}")
-        }
-
-        assertEquals("rpc_schema", client.lastPostHeaders["Content-Profile"])
-    }
-
-    @Test
-    fun test_update_invalidTableThrows() = runTest {
-        val client = FakeSupabaseClient()
-        val sut = DatabaseClientImpl(client)
-
-        assertFailsWith<IllegalArgumentException> {
             runSuspend {
-                sut.update(
-                    table = "messages/users",
-                    body = "{}",
-                    returning = ReturnOption.MINIMAL,
-                    count = null,
+                sut.delete(
+                    table = "messages",
+                    stripNulls = true,
+                    explain = ExplainOptions(buffers = true),
                 ) {}
             }
-        }
-    }
 
-    @Test
-    fun test_rpcGet_withQueryParams_buildsEncodedEndpointAndAcceptHeader() = runTest {
-        val client = FakeSupabaseClient()
-        val sut = DatabaseClientImpl(client)
-
-        runSuspend {
-            sut.rpcGet(
-                function = "get_messages",
-                queryParams = listOf("user_id" to "u 1", "limit" to "10"),
+            assertEquals(
+                """application/vnd.pgrst.plan+text; for="application/vnd.pgrst.array+json;nulls=stripped"; options=buffers;""",
+                client.lastDeleteHeaders["Accept"],
             )
         }
 
-        assertEquals("/rest/v1/rpc/get_messages?user_id=u%201&limit=10", client.lastGetEndpoint)
-        assertEquals("application/json", client.lastGetHeaders["Accept"])
-    }
-
     @Test
-    fun test_rpc_customHeadersAreMergedWithJsonHeaders() = runTest {
-        val client = FakeSupabaseClient()
-        val sut = DatabaseClientImpl(client)
+    fun test_select_withSchema_setsAcceptProfileHeader() =
+        runTest {
+            val client = FakeSupabaseClient()
+            val sut = DatabaseClientImpl(client)
 
-        runSuspend {
-            sut.rpc(
-                function = "archive_messages",
-                params = "{}",
-                headers = mapOf("X-Trace-Id" to "trace-rpc", "Content-Type" to "text/plain"),
-            )
+            runSuspend {
+                sut.select(table = "messages", schema = "private") {}
+            }
+
+            assertEquals("private", client.lastGetHeaders["Accept-Profile"])
         }
 
-        assertEquals("trace-rpc", client.lastPostHeaders["X-Trace-Id"])
-        assertEquals("application/json", client.lastPostHeaders["Content-Type"])
-        assertEquals("application/json", client.lastPostHeaders["Accept"])
-    }
-
     @Test
-    fun test_rpcGet_headReturnsFailureWhenRequestFails() = runTest {
-        val client = FakeSupabaseClient(getResult = SupabaseResult.Failure(SupabaseError("boom")))
-        val sut = DatabaseClientImpl(client)
+    fun test_update_withSchema_setsContentProfileHeader() =
+        runTest {
+            val client = FakeSupabaseClient()
+            val sut = DatabaseClientImpl(client)
 
-        val result = runSuspend {
-            sut.rpcGet(function = "get_messages", head = true)
+            runSuspend {
+                sut.update(table = "messages", schema = "analytics", body = "{}") {}
+            }
+
+            assertEquals("analytics", client.lastPatchHeaders["Content-Profile"])
         }
 
-        assertTrue(result is SupabaseResult.Failure)
-    }
-
     @Test
-    fun test_rpc_singleUsesObjectAcceptHeader() = runTest {
-        val client = FakeSupabaseClient()
-        val sut = DatabaseClientImpl(client)
+    fun test_rpc_withSchema_setsContentProfileHeader() =
+        runTest {
+            val client = FakeSupabaseClient()
+            val sut = DatabaseClientImpl(client)
 
-        runSuspend {
-            sut.rpc(function = "get_one", single = true)
+            runSuspend {
+                sut.rpc(function = "my_fn", schema = "rpc_schema", params = "{}")
+            }
+
+            assertEquals("rpc_schema", client.lastPostHeaders["Content-Profile"])
         }
 
-        assertEquals("application/vnd.pgrst.object+json", client.lastPostHeaders["Accept"])
-    }
-
     @Test
-    fun test_rpc_maxAffectedAndRollbackSetPreferDirectives() = runTest {
-        val client = FakeSupabaseClient()
-        val sut = DatabaseClientImpl(client)
+    fun test_update_invalidTableThrows() =
+        runTest {
+            val client = FakeSupabaseClient()
+            val sut = DatabaseClientImpl(client)
 
-        runSuspend {
-            sut.rpc(function = "archive_messages", rollback = true, maxAffected = 2)
+            assertFailsWith<IllegalArgumentException> {
+                runSuspend {
+                    sut.update(
+                        table = "messages/users",
+                        body = "{}",
+                        returning = ReturnOption.MINIMAL,
+                        count = null,
+                    ) {}
+                }
+            }
         }
 
-        val prefer = client.lastPostHeaders["Prefer"].orEmpty()
-        assertTrue(prefer.contains("tx=rollback"))
-        assertTrue(prefer.contains("handling=strict"))
-        assertTrue(prefer.contains("max-affected=2"))
-    }
-
     @Test
-    fun test_rpcGet_csvUsesTextCsvAcceptHeader() = runTest {
-        val client = FakeSupabaseClient()
-        val sut = DatabaseClientImpl(client)
+    fun test_rpcGet_withQueryParams_buildsEncodedEndpointAndAcceptHeader() =
+        runTest {
+            val client = FakeSupabaseClient()
+            val sut = DatabaseClientImpl(client)
 
-        runSuspend {
-            sut.rpcGet(function = "get_many", csv = true)
+            runSuspend {
+                sut.rpcGet(
+                    function = "get_messages",
+                    queryParams = listOf("user_id" to "u 1", "limit" to "10"),
+                )
+            }
+
+            assertEquals("/rest/v1/rpc/get_messages?user_id=u%201&limit=10", client.lastGetEndpoint)
+            assertEquals("application/json", client.lastGetHeaders["Accept"])
         }
 
-        assertEquals("text/csv", client.lastGetHeaders["Accept"])
-    }
-
     @Test
-    fun test_rpcGet_retryEnabledByDefault() = runTest {
-        val client = FakeSupabaseClient()
-        val sut = DatabaseClientImpl(client)
+    fun test_rpc_customHeadersAreMergedWithJsonHeaders() =
+        runTest {
+            val client = FakeSupabaseClient()
+            val sut = DatabaseClientImpl(client)
 
-        runSuspend {
-            sut.rpcGet(function = "get_many")
+            runSuspend {
+                sut.rpc(
+                    function = "archive_messages",
+                    params = "{}",
+                    headers = mapOf("X-Trace-Id" to "trace-rpc", "Content-Type" to "text/plain"),
+                )
+            }
+
+            assertEquals("trace-rpc", client.lastPostHeaders["X-Trace-Id"])
+            assertEquals("application/json", client.lastPostHeaders["Content-Type"])
+            assertEquals("application/json", client.lastPostHeaders["Accept"])
         }
 
-        assertEquals("true", client.lastGetHeaders["X-Supabase-Kmp-Retry"])
-    }
-
     @Test
-    fun test_rpcGet_stripNullsSingleUsesStrippedObjectAcceptHeader() = runTest {
-        val client = FakeSupabaseClient()
-        val sut = DatabaseClientImpl(client)
+    fun test_rpcGet_headReturnsFailureWhenRequestFails() =
+        runTest {
+            val client = FakeSupabaseClient(getResult = SupabaseResult.Failure(SupabaseError("boom")))
+            val sut = DatabaseClientImpl(client)
 
-        runSuspend {
-            sut.rpcGet(function = "get_one", single = true, stripNulls = true)
+            val result =
+                runSuspend {
+                    sut.rpcGet(function = "get_messages", head = true)
+                }
+
+            assertTrue(result is SupabaseResult.Failure)
         }
 
-        assertEquals("application/vnd.pgrst.object+json;nulls=stripped", client.lastGetHeaders["Accept"])
-    }
+    @Test
+    fun test_rpc_singleUsesObjectAcceptHeader() =
+        runTest {
+            val client = FakeSupabaseClient()
+            val sut = DatabaseClientImpl(client)
+
+            runSuspend {
+                sut.rpc(function = "get_one", single = true)
+            }
+
+            assertEquals("application/vnd.pgrst.object+json", client.lastPostHeaders["Accept"])
+        }
+
+    @Test
+    fun test_rpc_maxAffectedAndRollbackSetPreferDirectives() =
+        runTest {
+            val client = FakeSupabaseClient()
+            val sut = DatabaseClientImpl(client)
+
+            runSuspend {
+                sut.rpc(function = "archive_messages", rollback = true, maxAffected = 2)
+            }
+
+            val prefer = client.lastPostHeaders["Prefer"].orEmpty()
+            assertTrue(prefer.contains("tx=rollback"))
+            assertTrue(prefer.contains("handling=strict"))
+            assertTrue(prefer.contains("max-affected=2"))
+        }
+
+    @Test
+    fun test_rpcGet_csvUsesTextCsvAcceptHeader() =
+        runTest {
+            val client = FakeSupabaseClient()
+            val sut = DatabaseClientImpl(client)
+
+            runSuspend {
+                sut.rpcGet(function = "get_many", csv = true)
+            }
+
+            assertEquals("text/csv", client.lastGetHeaders["Accept"])
+        }
+
+    @Test
+    fun test_rpcGet_retryEnabledByDefault() =
+        runTest {
+            val client = FakeSupabaseClient()
+            val sut = DatabaseClientImpl(client)
+
+            runSuspend {
+                sut.rpcGet(function = "get_many")
+            }
+
+            assertEquals("true", client.lastGetHeaders["X-Supabase-Kmp-Retry"])
+        }
+
+    @Test
+    fun test_rpcGet_stripNullsSingleUsesStrippedObjectAcceptHeader() =
+        runTest {
+            val client = FakeSupabaseClient()
+            val sut = DatabaseClientImpl(client)
+
+            runSuspend {
+                sut.rpcGet(function = "get_one", single = true, stripNulls = true)
+            }
+
+            assertEquals("application/vnd.pgrst.object+json;nulls=stripped", client.lastGetHeaders["Accept"])
+        }
 }
 
 private class FakeSupabaseClient(
@@ -467,6 +499,7 @@ private class FakeSupabaseClient(
         lastPostHeaders = headers
         return SupabaseResult.Success("{}")
     }
+
     override suspend fun put(
         endpoint: String,
         body: String?,

--- a/supabase-functions/src/commonMain/kotlin/io/github/androidpoet/supabase/functions/FunctionsClient.kt
+++ b/supabase-functions/src/commonMain/kotlin/io/github/androidpoet/supabase/functions/FunctionsClient.kt
@@ -2,27 +2,37 @@ package io.github.androidpoet.supabase.functions
 import io.github.androidpoet.supabase.core.result.SupabaseResult
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
+
 @Serializable
-public enum class FunctionRegion(public val value: String) {
+public enum class FunctionRegion(
+    public val value: String,
+) {
     @SerialName("us-east-1")
     US_EAST_1("us-east-1"),
+
     @SerialName("us-west-1")
     US_WEST_1("us-west-1"),
+
     @SerialName("eu-west-1")
     EU_WEST_1("eu-west-1"),
+
     @SerialName("ap-southeast-1")
     AP_SOUTHEAST_1("ap-southeast-1"),
+
     @SerialName("ap-northeast-1")
     AP_NORTHEAST_1("ap-northeast-1"),
 }
+
 public interface FunctionsClient {
     public fun setAuth(token: String)
+
     public suspend fun invoke(
         functionName: String,
         body: String? = null,
         headers: Map<String, String> = emptyMap(),
         region: FunctionRegion? = null,
     ): SupabaseResult<String>
+
     public suspend fun invokeWithBody(
         functionName: String,
         body: ByteArray,

--- a/supabase-functions/src/commonMain/kotlin/io/github/androidpoet/supabase/functions/FunctionsClientExt.kt
+++ b/supabase-functions/src/commonMain/kotlin/io/github/androidpoet/supabase/functions/FunctionsClientExt.kt
@@ -1,17 +1,20 @@
 package io.github.androidpoet.supabase.functions
 import io.github.androidpoet.supabase.client.defaultJson
 import io.github.androidpoet.supabase.core.result.SupabaseResult
+
 public suspend inline fun <reified T> FunctionsClient.invokeTyped(
     functionName: String,
     body: String? = null,
     headers: Map<String, String> = emptyMap(),
     region: FunctionRegion? = null,
-): SupabaseResult<T> = when (val result = invoke(functionName, body, headers, region)) {
-    is SupabaseResult.Success -> SupabaseResult.catching {
-        defaultJson.decodeFromString<T>(result.value)
+): SupabaseResult<T> =
+    when (val result = invoke(functionName, body, headers, region)) {
+        is SupabaseResult.Success ->
+            SupabaseResult.catching {
+                defaultJson.decodeFromString<T>(result.value)
+            }
+        is SupabaseResult.Failure -> result
     }
-    is SupabaseResult.Failure -> result
-}
 
 public suspend inline fun <reified Request : Any, reified Response> FunctionsClient.invokeTyped(
     functionName: String,
@@ -43,20 +46,23 @@ public suspend inline fun <reified T> FunctionsClient.invokeWithBodyTyped(
     contentType: String = "application/octet-stream",
     headers: Map<String, String> = emptyMap(),
     region: FunctionRegion? = null,
-): SupabaseResult<T> = when (
-    val result = invokeWithBody(
-        functionName = functionName,
-        body = body,
-        contentType = contentType,
-        headers = headers,
-        region = region,
-    )
-) {
-    is SupabaseResult.Success -> SupabaseResult.catching {
-        defaultJson.decodeFromString<T>(result.value)
+): SupabaseResult<T> =
+    when (
+        val result =
+            invokeWithBody(
+                functionName = functionName,
+                body = body,
+                contentType = contentType,
+                headers = headers,
+                region = region,
+            )
+    ) {
+        is SupabaseResult.Success ->
+            SupabaseResult.catching {
+                defaultJson.decodeFromString<T>(result.value)
+            }
+        is SupabaseResult.Failure -> result
     }
-    is SupabaseResult.Failure -> result
-}
 
 public suspend fun FunctionsClient.invokeWithBodyUnit(
     functionName: String,
@@ -66,13 +72,14 @@ public suspend fun FunctionsClient.invokeWithBodyUnit(
     region: FunctionRegion? = null,
 ): SupabaseResult<Unit> =
     when (
-        val result = invokeWithBody(
-            functionName = functionName,
-            body = body,
-            contentType = contentType,
-            headers = headers,
-            region = region,
-        )
+        val result =
+            invokeWithBody(
+                functionName = functionName,
+                body = body,
+                contentType = contentType,
+                headers = headers,
+                region = region,
+            )
     ) {
         is SupabaseResult.Success -> SupabaseResult.Success(Unit)
         is SupabaseResult.Failure -> result

--- a/supabase-functions/src/commonMain/kotlin/io/github/androidpoet/supabase/functions/FunctionsClientImpl.kt
+++ b/supabase-functions/src/commonMain/kotlin/io/github/androidpoet/supabase/functions/FunctionsClientImpl.kt
@@ -1,6 +1,7 @@
 package io.github.androidpoet.supabase.functions
 import io.github.androidpoet.supabase.client.SupabaseClient
 import io.github.androidpoet.supabase.core.result.SupabaseResult
+
 internal class FunctionsClientImpl(
     private val client: SupabaseClient,
 ) : FunctionsClient {
@@ -23,6 +24,7 @@ internal class FunctionsClientImpl(
             headers = merged,
         )
     }
+
     override suspend fun invokeWithBody(
         functionName: String,
         body: ByteArray,
@@ -40,16 +42,18 @@ internal class FunctionsClientImpl(
             headers = merged,
         )
     }
+
     private fun buildHeaders(
         extra: Map<String, String>,
         region: FunctionRegion?,
-    ): Map<String, String> = buildMap {
-        // Prefer an explicitly pinned token, otherwise fall back to the client's
-        // current session token so refreshes are picked up automatically.
-        (authToken ?: client.accessTokenOrNull)?.let { put("Authorization", "Bearer $it") }
-        if (region != null) {
-            put("x-region", region.value)
+    ): Map<String, String> =
+        buildMap {
+            // Prefer an explicitly pinned token, otherwise fall back to the client's
+            // current session token so refreshes are picked up automatically.
+            (authToken ?: client.accessTokenOrNull)?.let { put("Authorization", "Bearer $it") }
+            if (region != null) {
+                put("x-region", region.value)
+            }
+            putAll(extra)
         }
-        putAll(extra)
-    }
 }

--- a/supabase-functions/src/commonTest/kotlin/io/github/androidpoet/supabase/functions/FunctionsClientExtTest.kt
+++ b/supabase-functions/src/commonTest/kotlin/io/github/androidpoet/supabase/functions/FunctionsClientExtTest.kt
@@ -9,45 +9,54 @@ import kotlin.test.assertTrue
 
 class FunctionsClientExtTest {
     @Test
-    fun test_invokeTyped_requestEncodesAndDecodes() = runTest {
-        val client = FakeFunctionsClient()
+    fun test_invokeTyped_requestEncodesAndDecodes() =
+        runTest {
+            val client = FakeFunctionsClient()
 
-        val result = client.invokeTyped<Req, Res>(
-            functionName = "echo",
-            request = Req("hello"),
-        )
+            val result =
+                client.invokeTyped<Req, Res>(
+                    functionName = "echo",
+                    request = Req("hello"),
+                )
 
-        assertTrue(result is SupabaseResult.Success)
-        assertEquals("hello", result.value.value)
-        assertEquals("""{"value":"hello"}""", client.lastInvokeBody)
-    }
-
-    @Test
-    fun test_invokeWithBodyTyped_decodesResponse() = runTest {
-        val client = FakeFunctionsClient()
-
-        val result = client.invokeWithBodyTyped<Res>(
-            functionName = "bin",
-            body = byteArrayOf(1),
-        )
-
-        assertTrue(result is SupabaseResult.Success)
-        assertEquals("binary-ok", result.value.value)
-    }
+            assertTrue(result is SupabaseResult.Success)
+            assertEquals("hello", result.value.value)
+            assertEquals("""{"value":"hello"}""", client.lastInvokeBody)
+        }
 
     @Test
-    fun test_invokeUnit_mapsSuccessToUnit() = runTest {
-        val client = FakeFunctionsClient()
-        val result = client.invokeUnit(functionName = "ping")
-        assertTrue(result is SupabaseResult.Success)
-    }
+    fun test_invokeWithBodyTyped_decodesResponse() =
+        runTest {
+            val client = FakeFunctionsClient()
+
+            val result =
+                client.invokeWithBodyTyped<Res>(
+                    functionName = "bin",
+                    body = byteArrayOf(1),
+                )
+
+            assertTrue(result is SupabaseResult.Success)
+            assertEquals("binary-ok", result.value.value)
+        }
+
+    @Test
+    fun test_invokeUnit_mapsSuccessToUnit() =
+        runTest {
+            val client = FakeFunctionsClient()
+            val result = client.invokeUnit(functionName = "ping")
+            assertTrue(result is SupabaseResult.Success)
+        }
 }
 
 @Serializable
-private data class Req(val value: String)
+private data class Req(
+    val value: String,
+)
 
 @Serializable
-private data class Res(val value: String)
+private data class Res(
+    val value: String,
+)
 
 private class FakeFunctionsClient : FunctionsClient {
     var lastInvokeBody: String? = null

--- a/supabase-functions/src/commonTest/kotlin/io/github/androidpoet/supabase/functions/FunctionsClientImplTest.kt
+++ b/supabase-functions/src/commonTest/kotlin/io/github/androidpoet/supabase/functions/FunctionsClientImplTest.kt
@@ -9,64 +9,71 @@ import kotlin.test.assertTrue
 
 class FunctionsClientImplTest {
     @Test
-    fun test_invoke_withRegion_setsRegionHeader() = runTest {
-        val fake = FakeSupabaseClient()
-        val sut = FunctionsClientImpl(fake)
+    fun test_invoke_withRegion_setsRegionHeader() =
+        runTest {
+            val fake = FakeSupabaseClient()
+            val sut = FunctionsClientImpl(fake)
 
-        val result = sut.invoke(
-            functionName = "hello",
-            body = """{"a":1}""",
-            region = FunctionRegion.AP_SOUTHEAST_1,
-        )
+            val result =
+                sut.invoke(
+                    functionName = "hello",
+                    body = """{"a":1}""",
+                    region = FunctionRegion.AP_SOUTHEAST_1,
+                )
 
-        assertTrue(result is SupabaseResult.Success)
-        assertEquals("/functions/v1/hello", fake.lastPostEndpoint)
-        assertEquals("ap-southeast-1", fake.lastPostHeaders["x-region"])
-    }
-
-    @Test
-    fun test_invokeWithBody_usesRelativeFunctionsPath() = runTest {
-        val fake = FakeSupabaseClient()
-        val sut = FunctionsClientImpl(fake)
-
-        val result = sut.invokeWithBody(
-            functionName = "upload",
-            body = byteArrayOf(1, 2, 3),
-            contentType = "application/octet-stream",
-        )
-
-        assertTrue(result is SupabaseResult.Success)
-        // postRaw receives a relative path; SupabaseClientImpl.postRaw prepends
-        // projectUrl exactly once. Passing an absolute URL here would duplicate it.
-        assertEquals("/functions/v1/upload", fake.lastPostRawUrl)
-    }
+            assertTrue(result is SupabaseResult.Success)
+            assertEquals("/functions/v1/hello", fake.lastPostEndpoint)
+            assertEquals("ap-southeast-1", fake.lastPostHeaders["x-region"])
+        }
 
     @Test
-    fun test_setAuth_setsAuthorizationHeaderForInvoke() = runTest {
-        val fake = FakeSupabaseClient()
-        val sut = FunctionsClientImpl(fake)
+    fun test_invokeWithBody_usesRelativeFunctionsPath() =
+        runTest {
+            val fake = FakeSupabaseClient()
+            val sut = FunctionsClientImpl(fake)
 
-        sut.setAuth("jwt-1")
-        val result = sut.invoke(functionName = "hello")
+            val result =
+                sut.invokeWithBody(
+                    functionName = "upload",
+                    body = byteArrayOf(1, 2, 3),
+                    contentType = "application/octet-stream",
+                )
 
-        assertTrue(result is SupabaseResult.Success)
-        assertEquals("Bearer jwt-1", fake.lastPostHeaders["Authorization"])
-    }
+            assertTrue(result is SupabaseResult.Success)
+            // postRaw receives a relative path; SupabaseClientImpl.postRaw prepends
+            // projectUrl exactly once. Passing an absolute URL here would duplicate it.
+            assertEquals("/functions/v1/upload", fake.lastPostRawUrl)
+        }
 
     @Test
-    fun test_invokeHeaderOverridesSetAuthAuthorization() = runTest {
-        val fake = FakeSupabaseClient()
-        val sut = FunctionsClientImpl(fake)
+    fun test_setAuth_setsAuthorizationHeaderForInvoke() =
+        runTest {
+            val fake = FakeSupabaseClient()
+            val sut = FunctionsClientImpl(fake)
 
-        sut.setAuth("jwt-1")
-        val result = sut.invoke(
-            functionName = "hello",
-            headers = mapOf("Authorization" to "Bearer invoke-jwt"),
-        )
+            sut.setAuth("jwt-1")
+            val result = sut.invoke(functionName = "hello")
 
-        assertTrue(result is SupabaseResult.Success)
-        assertEquals("Bearer invoke-jwt", fake.lastPostHeaders["Authorization"])
-    }
+            assertTrue(result is SupabaseResult.Success)
+            assertEquals("Bearer jwt-1", fake.lastPostHeaders["Authorization"])
+        }
+
+    @Test
+    fun test_invokeHeaderOverridesSetAuthAuthorization() =
+        runTest {
+            val fake = FakeSupabaseClient()
+            val sut = FunctionsClientImpl(fake)
+
+            sut.setAuth("jwt-1")
+            val result =
+                sut.invoke(
+                    functionName = "hello",
+                    headers = mapOf("Authorization" to "Bearer invoke-jwt"),
+                )
+
+            assertTrue(result is SupabaseResult.Success)
+            assertEquals("Bearer invoke-jwt", fake.lastPostHeaders["Authorization"])
+        }
 }
 
 private class FakeSupabaseClient : SupabaseClient {
@@ -86,6 +93,7 @@ private class FakeSupabaseClient : SupabaseClient {
         lastPostHeaders = headers
         return SupabaseResult.Success("""{"ok":true}""")
     }
+
     override suspend fun put(endpoint: String, body: String?, headers: Map<String, String>): SupabaseResult<String> =
         SupabaseResult.Success("{}")
 
@@ -104,6 +112,8 @@ private class FakeSupabaseClient : SupabaseClient {
         SupabaseResult.Success("{}")
 
     override fun setAccessToken(token: String) = Unit
+
     override fun clearAccessToken() = Unit
+
     override fun close() = Unit
 }

--- a/supabase-realtime/src/commonMain/kotlin/io/github/androidpoet/supabase/realtime/ConnectionState.kt
+++ b/supabase-realtime/src/commonMain/kotlin/io/github/androidpoet/supabase/realtime/ConnectionState.kt
@@ -1,13 +1,19 @@
 package io.github.androidpoet.supabase.realtime
+
 public sealed interface ConnectionState {
     public data object Disconnected : ConnectionState
+
     public data object Connecting : ConnectionState
+
     public data object Connected : ConnectionState
+
     public data object Disconnecting : ConnectionState
+
     public data class Reconnecting(
         public val attempt: Int,
         public val nextRetryMs: Long,
     ) : ConnectionState
+
     public data class Failed(
         public val reason: String,
         public val attempts: Int,

--- a/supabase-realtime/src/commonMain/kotlin/io/github/androidpoet/supabase/realtime/RealtimeChannelBuilder.kt
+++ b/supabase-realtime/src/commonMain/kotlin/io/github/androidpoet/supabase/realtime/RealtimeChannelBuilder.kt
@@ -2,6 +2,7 @@ package io.github.androidpoet.supabase.realtime
 import io.github.androidpoet.supabase.realtime.models.PostgresChangeEvent
 import io.github.androidpoet.supabase.realtime.models.PresenceState
 import kotlinx.serialization.json.JsonObject
+
 public class RealtimeChannelBuilder internal constructor(
     internal val channelName: String,
     internal val client: RealtimeClientImpl,
@@ -15,21 +16,24 @@ public class RealtimeChannelBuilder internal constructor(
     internal var privateChannel: Boolean = false
     internal var replaySinceMs: Long? = null
     internal var replayLimit: Int? = null
+
     public fun onPostgresChange(
         schema: String = "public",
         table: String? = null,
         filter: String? = null,
         event: PostgresChangeEvent = PostgresChangeEvent.ALL,
         callback: suspend (JsonObject) -> Unit,
-    ): RealtimeChannelBuilder = apply {
-        postgresCallbacks += PostgresCallbackConfig.Simple(
-            schema = schema,
-            table = table,
-            filter = filter,
-            event = event,
-            callback = callback,
-        )
-    }
+    ): RealtimeChannelBuilder =
+        apply {
+            postgresCallbacks +=
+                PostgresCallbackConfig.Simple(
+                    schema = schema,
+                    table = table,
+                    filter = filter,
+                    event = event,
+                    callback = callback,
+                )
+        }
 
     public fun onPostgresChange(
         schema: String = "public",
@@ -37,53 +41,69 @@ public class RealtimeChannelBuilder internal constructor(
         filter: String? = null,
         event: PostgresChangeEvent = PostgresChangeEvent.ALL,
         callback: suspend (PostgresChangeEvent, JsonObject) -> Unit,
-    ): RealtimeChannelBuilder = apply {
-        postgresCallbacks += PostgresCallbackConfig.Typed(
-            schema = schema,
-            table = table,
-            filter = filter,
-            event = event,
-            callback = callback,
-        )
-    }
+    ): RealtimeChannelBuilder =
+        apply {
+            postgresCallbacks +=
+                PostgresCallbackConfig.Typed(
+                    schema = schema,
+                    table = table,
+                    filter = filter,
+                    event = event,
+                    callback = callback,
+                )
+        }
+
     public fun onBroadcast(
         event: String,
         callback: suspend (JsonObject) -> Unit,
-    ): RealtimeChannelBuilder = apply {
-        broadcastCallbacks[event] = callback
-    }
+    ): RealtimeChannelBuilder =
+        apply {
+            broadcastCallbacks[event] = callback
+        }
+
     public fun onPresence(
         callback: suspend (PresenceState) -> Unit,
-    ): RealtimeChannelBuilder = apply {
-        presenceCallback = callback
-    }
+    ): RealtimeChannelBuilder =
+        apply {
+            presenceCallback = callback
+        }
+
     public fun configureBroadcast(
         receiveOwnBroadcasts: Boolean = false,
         acknowledgeBroadcasts: Boolean = false,
-    ): RealtimeChannelBuilder = apply {
-        this.receiveOwnBroadcasts = receiveOwnBroadcasts
-        this.acknowledgeBroadcasts = acknowledgeBroadcasts
-    }
+    ): RealtimeChannelBuilder =
+        apply {
+            this.receiveOwnBroadcasts = receiveOwnBroadcasts
+            this.acknowledgeBroadcasts = acknowledgeBroadcasts
+        }
+
     public fun configureBroadcastReplay(
         sinceMs: Long,
         limit: Int? = null,
-    ): RealtimeChannelBuilder = apply {
-        replaySinceMs = sinceMs
-        replayLimit = limit
-    }
+    ): RealtimeChannelBuilder =
+        apply {
+            replaySinceMs = sinceMs
+            replayLimit = limit
+        }
+
     public fun configurePresence(
         key: String = "",
-    ): RealtimeChannelBuilder = apply {
-        presenceKey = key
-    }
+    ): RealtimeChannelBuilder =
+        apply {
+            presenceKey = key
+        }
+
     public fun setPrivate(
         enabled: Boolean = true,
-    ): RealtimeChannelBuilder = apply {
-        privateChannel = enabled
-    }
+    ): RealtimeChannelBuilder =
+        apply {
+            privateChannel = enabled
+        }
+
     public suspend fun subscribe(): RealtimeSubscription =
         client.subscribe(this)
 }
+
 internal sealed class PostgresCallbackConfig {
     abstract val schema: String
     abstract val table: String?

--- a/supabase-realtime/src/commonMain/kotlin/io/github/androidpoet/supabase/realtime/RealtimeClient.kt
+++ b/supabase-realtime/src/commonMain/kotlin/io/github/androidpoet/supabase/realtime/RealtimeClient.kt
@@ -3,6 +3,7 @@ import io.github.androidpoet.supabase.realtime.models.RealtimeChannel
 import io.github.androidpoet.supabase.realtime.models.RealtimeMessage
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.StateFlow
+
 public interface RealtimeClient {
     public val connectionState: StateFlow<ConnectionState>
     public val debugState: StateFlow<RealtimeDebugState>
@@ -10,23 +11,40 @@ public interface RealtimeClient {
     public val isConnected: Boolean
     public val isConnecting: Boolean
     public val isDisconnecting: Boolean
+
     public fun channel(name: String): RealtimeChannelBuilder
+
     public fun getSubscription(name: String): RealtimeSubscription?
+
     public fun getSubscriptionByTopic(topic: String): RealtimeSubscription?
+
     public fun getSubscriptions(): Set<RealtimeSubscription>
+
     public fun activeChannels(): Set<String>
+
     public fun activeChannelDetails(): Set<RealtimeChannel>
+
     public suspend fun removeSubscription(subscription: RealtimeSubscription)
+
     public suspend fun removeSubscriptions(subscriptions: List<RealtimeSubscription>)
+
     @Deprecated("Use removeSubscription instead", ReplaceWith("removeSubscription(subscription)"))
     public suspend fun removeChannel(subscription: RealtimeSubscription)
+
     public suspend fun removeSubscriptionByTopic(topic: String)
+
     public suspend fun removeChannelsByTopic(topics: List<String>)
+
     public suspend fun removeChannel(name: String)
+
     public suspend fun removeAllChannels()
+
     public suspend fun setAuth(token: String? = null)
+
     public suspend fun sendHeartbeat()
+
     public suspend fun connect()
+
     public suspend fun disconnect()
 
     /**
@@ -48,8 +66,19 @@ public data class RealtimeDebugState(
 )
 
 public sealed interface RealtimeDebugEvent {
-    public data class OutboundMessage(public val message: RealtimeMessage) : RealtimeDebugEvent
-    public data class InboundMessage(public val message: RealtimeMessage) : RealtimeDebugEvent
-    public data class HeartbeatSent(public val ref: String) : RealtimeDebugEvent
-    public data class HeartbeatReceived(public val ref: String?) : RealtimeDebugEvent
+    public data class OutboundMessage(
+        public val message: RealtimeMessage,
+    ) : RealtimeDebugEvent
+
+    public data class InboundMessage(
+        public val message: RealtimeMessage,
+    ) : RealtimeDebugEvent
+
+    public data class HeartbeatSent(
+        public val ref: String,
+    ) : RealtimeDebugEvent
+
+    public data class HeartbeatReceived(
+        public val ref: String?,
+    ) : RealtimeDebugEvent
 }

--- a/supabase-realtime/src/commonMain/kotlin/io/github/androidpoet/supabase/realtime/RealtimeClientImpl.kt
+++ b/supabase-realtime/src/commonMain/kotlin/io/github/androidpoet/supabase/realtime/RealtimeClientImpl.kt
@@ -11,8 +11,11 @@ import io.ktor.websocket.Frame
 import io.ktor.websocket.WebSocketSession
 import io.ktor.websocket.close
 import io.ktor.websocket.readText
-import kotlinx.coroutines.CoroutineScope
+import kotlinx.atomicfu.atomic
+import kotlinx.atomicfu.locks.SynchronizedObject
+import kotlinx.atomicfu.locks.synchronized
 import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
@@ -23,25 +26,21 @@ import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.withTimeout
-import kotlinx.coroutines.withTimeoutOrNull
-import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
-import kotlinx.atomicfu.locks.SynchronizedObject
-import kotlinx.atomicfu.locks.synchronized
+import kotlinx.coroutines.withTimeout
+import kotlinx.coroutines.withTimeoutOrNull
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.buildJsonObject
-import kotlinx.serialization.json.jsonArray
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
 import kotlinx.serialization.json.put
-import kotlinx.atomicfu.atomic
 import kotlin.concurrent.Volatile
 import kotlin.math.min
 import kotlin.math.pow
@@ -53,9 +52,11 @@ internal class RealtimeClientImpl(
     private val config: RealtimeConfig = RealtimeConfig(),
 ) : RealtimeClient {
     private val json = Json { ignoreUnknownKeys = true }
-    private val httpClient = HttpClient {
-        install(WebSockets)
-    }
+    private val httpClient =
+        HttpClient {
+            install(WebSockets)
+        }
+
     @Volatile
     private var session: WebSocketSession? = null
 
@@ -104,54 +105,70 @@ internal class RealtimeClientImpl(
     override val isConnected: Boolean get() = _connectionState.value is ConnectionState.Connected
     override val isConnecting: Boolean get() = _connectionState.value is ConnectionState.Connecting
     override val isDisconnecting: Boolean get() = _connectionState.value is ConnectionState.Disconnecting
+
     // activeSubscriptions is read from non-suspend getters on arbitrary threads
     // and mutated from coroutines; guard every access with this lock. Callers must
     // snapshot under the lock and release it before invoking suspend functions.
     private val subscriptionsLock = SynchronizedObject()
     private val activeSubscriptions = mutableMapOf<String, ChannelSubscriptionImpl>()
+
     internal fun nextRef(): String = refCounter.incrementAndGet().toString()
+
     override fun channel(name: String): RealtimeChannelBuilder =
         RealtimeChannelBuilder(channelName = name, client = this)
+
     override fun getSubscription(name: String): RealtimeSubscription? =
         synchronized(subscriptionsLock) { activeSubscriptions["realtime:$name"] }
+
     override fun getSubscriptionByTopic(topic: String): RealtimeSubscription? =
         synchronized(subscriptionsLock) { activeSubscriptions[topic] }
+
     override fun getSubscriptions(): Set<RealtimeSubscription> =
         synchronized(subscriptionsLock) { activeSubscriptions.values.toSet() }
+
     override fun activeChannels(): Set<String> =
         synchronized(subscriptionsLock) { activeSubscriptions.values.mapTo(mutableSetOf()) { it.channel } }
+
     override fun activeChannelDetails(): Set<RealtimeChannel> =
         synchronized(subscriptionsLock) {
             activeSubscriptions.values.mapTo(mutableSetOf()) { RealtimeChannel(name = it.channel, topic = it.topic) }
         }
+
     override suspend fun removeSubscription(subscription: RealtimeSubscription) {
         subscription.unsubscribe()
     }
+
     override suspend fun removeSubscriptions(subscriptions: List<RealtimeSubscription>) {
         subscriptions.forEach { subscription ->
             subscription.unsubscribe()
         }
     }
+
     @Deprecated("Use removeSubscription instead", ReplaceWith("removeSubscription(subscription)"))
     override suspend fun removeChannel(subscription: RealtimeSubscription) {
         removeSubscription(subscription)
     }
+
     override suspend fun removeSubscriptionByTopic(topic: String) {
         synchronized(subscriptionsLock) { activeSubscriptions[topic] }?.unsubscribe()
     }
+
     override suspend fun removeChannelsByTopic(topics: List<String>) {
         topics.forEach { topic ->
             synchronized(subscriptionsLock) { activeSubscriptions[topic] }?.unsubscribe()
         }
     }
+
     override suspend fun removeChannel(name: String) {
         val topic = "realtime:$name"
         synchronized(subscriptionsLock) { activeSubscriptions[topic] }?.unsubscribe()
     }
+
     override suspend fun removeAllChannels() {
         synchronized(subscriptionsLock) { activeSubscriptions.values.toList() }
             .forEach { it.unsubscribe() }
     }
+
     override suspend fun setAuth(token: String?) {
         authTokenOverride = token
         val subscriptions = synchronized(subscriptionsLock) { activeSubscriptions.values.toList() }
@@ -169,9 +186,11 @@ internal class RealtimeClientImpl(
             )
         }
     }
+
     override suspend fun sendHeartbeat() {
         sendHeartbeatMessage()
     }
+
     override suspend fun connect() {
         if (session != null) return
         intentionalDisconnect = false
@@ -186,24 +205,27 @@ internal class RealtimeClientImpl(
             if (config.autoReconnect && !intentionalDisconnect) {
                 scheduleReconnect()
             } else {
-                _connectionState.value = ConnectionState.Failed(
-                    reason = e.message ?: "Connection failed",
-                    attempts = reconnectAttempt,
-                )
+                _connectionState.value =
+                    ConnectionState.Failed(
+                        reason = e.message ?: "Connection failed",
+                        attempts = reconnectAttempt,
+                    )
             }
         }
     }
+
     override suspend fun disconnect() {
         intentionalDisconnect = true
         _connectionState.value = ConnectionState.Disconnecting
         reconnectJob?.cancel()
         reconnectJob = null
         reconnectAttempt = 0
-        val toUnsubscribe = synchronized(subscriptionsLock) {
-            val snapshot = activeSubscriptions.values.toList()
-            activeSubscriptions.clear()
-            snapshot
-        }
+        val toUnsubscribe =
+            synchronized(subscriptionsLock) {
+                val snapshot = activeSubscriptions.values.toList()
+                activeSubscriptions.clear()
+                snapshot
+            }
         toUnsubscribe.forEach { it.unsubscribe() }
         heartbeatJob?.cancel()
         heartbeatJob = null
@@ -213,32 +235,36 @@ internal class RealtimeClientImpl(
         scope = null
         _connectionState.value = ConnectionState.Disconnected
     }
+
     override suspend fun close() {
         disconnect()
         // Release the Ktor engine (connection pool / background threads). The
         // client is single-use after this; constructing a new one is cheap.
         httpClient.close()
     }
+
     internal suspend fun subscribe(builder: RealtimeChannelBuilder): RealtimeSubscription {
         val topic = "realtime:${builder.channelName}"
-        val subscription = ChannelSubscriptionImpl(
-            channel = builder.channelName,
-            topic = topic,
-            client = this,
-            postgresCallbacks = builder.postgresCallbacks.toList(),
-            broadcastCallbacks = builder.broadcastCallbacks.toMap(),
-            presenceCallback = builder.presenceCallback,
-            receiveOwnBroadcasts = builder.receiveOwnBroadcasts,
-            acknowledgeBroadcasts = builder.acknowledgeBroadcasts,
-            presenceKey = builder.presenceKey,
-            privateChannel = builder.privateChannel,
-            replaySinceMs = builder.replaySinceMs,
-            replayLimit = builder.replayLimit,
-        )
+        val subscription =
+            ChannelSubscriptionImpl(
+                channel = builder.channelName,
+                topic = topic,
+                client = this,
+                postgresCallbacks = builder.postgresCallbacks.toList(),
+                broadcastCallbacks = builder.broadcastCallbacks.toMap(),
+                presenceCallback = builder.presenceCallback,
+                receiveOwnBroadcasts = builder.receiveOwnBroadcasts,
+                acknowledgeBroadcasts = builder.acknowledgeBroadcasts,
+                presenceKey = builder.presenceKey,
+                privateChannel = builder.privateChannel,
+                replaySinceMs = builder.replaySinceMs,
+                replayLimit = builder.replayLimit,
+            )
         synchronized(subscriptionsLock) { activeSubscriptions[topic] = subscription }
         sendJoinMessage(subscription)
         return subscription
     }
+
     internal suspend fun leaveChannel(topic: String) {
         val subscription = synchronized(subscriptionsLock) { activeSubscriptions.remove(topic) }
         sendMessage(
@@ -251,6 +277,7 @@ internal class RealtimeClientImpl(
             ),
         )
     }
+
     internal suspend fun sendMessage(message: RealtimeMessage) {
         recordOutboundMessage(message)
         val current = session
@@ -268,22 +295,25 @@ internal class RealtimeClientImpl(
     }
 
     private suspend fun flushOutboundBuffer() {
-        val pending = outboundBufferLock.withLock {
-            val copy = outboundBuffer.toList()
-            outboundBuffer.clear()
-            copy
-        }
+        val pending =
+            outboundBufferLock.withLock {
+                val copy = outboundBuffer.toList()
+                outboundBuffer.clear()
+                copy
+            }
         val current = session ?: return
         for (message in pending) {
             current.send(Frame.Text(json.encodeToString(message)))
         }
     }
+
     private suspend fun establishConnection() {
         val isHttps = supabaseClient.projectUrl.startsWith("https://")
-        val host = supabaseClient.projectUrl
-            .removePrefix("https://")
-            .removePrefix("http://")
-            .trimEnd('/')
+        val host =
+            supabaseClient.projectUrl
+                .removePrefix("https://")
+                .removePrefix("http://")
+                .trimEnd('/')
         val wsScheme = if (isHttps) "wss" else "ws"
         val url = "$wsScheme://$host/realtime/v1/websocket?apikey=${supabaseClient.apiKey}&vsn=1.0.0"
         val newScope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
@@ -312,21 +342,23 @@ internal class RealtimeClientImpl(
                 }
             }
         }
-        heartbeatJob = newScope.launch {
-            while (isActive) {
-                delay(config.heartbeatIntervalMs)
-                if (pendingHeartbeatRef != null) {
-                    // Previous heartbeat was never acknowledged → server is gone.
-                    // Closing the socket wakes the incoming loop, whose finally
-                    // block runs the reconnect path.
-                    pendingHeartbeatRef = null
-                    session?.close()
-                    break
+        heartbeatJob =
+            newScope.launch {
+                while (isActive) {
+                    delay(config.heartbeatIntervalMs)
+                    if (pendingHeartbeatRef != null) {
+                        // Previous heartbeat was never acknowledged → server is gone.
+                        // Closing the socket wakes the incoming loop, whose finally
+                        // block runs the reconnect path.
+                        pendingHeartbeatRef = null
+                        session?.close()
+                        break
+                    }
+                    sendHeartbeatMessage()
                 }
-                sendHeartbeatMessage()
             }
-        }
     }
+
     private suspend fun sendHeartbeatMessage() {
         val ref = nextRef()
         pendingHeartbeatRef = ref
@@ -339,29 +371,34 @@ internal class RealtimeClientImpl(
             ),
         )
     }
+
     private fun recordOutboundMessage(message: RealtimeMessage) {
-        _debugState.value = _debugState.value.copy(
-            outboundMessageCount = _debugState.value.outboundMessageCount + 1,
-            heartbeatSentCount = _debugState.value.heartbeatSentCount + if (message.isHeartbeatRequest()) 1 else 0,
-            lastOutboundRef = message.ref,
-        )
+        _debugState.value =
+            _debugState.value.copy(
+                outboundMessageCount = _debugState.value.outboundMessageCount + 1,
+                heartbeatSentCount = _debugState.value.heartbeatSentCount + if (message.isHeartbeatRequest()) 1 else 0,
+                lastOutboundRef = message.ref,
+            )
         _debugEvents.tryEmit(RealtimeDebugEvent.OutboundMessage(message))
         if (message.isHeartbeatRequest()) {
             _debugEvents.tryEmit(RealtimeDebugEvent.HeartbeatSent(message.ref ?: ""))
         }
     }
+
     private fun recordInboundMessage(message: RealtimeMessage) {
-        _debugState.value = _debugState.value.copy(
-            inboundMessageCount = _debugState.value.inboundMessageCount + 1,
-            heartbeatReceivedCount = _debugState.value.heartbeatReceivedCount + if (message.isHeartbeatReply()) 1 else 0,
-            lastInboundRef = message.ref,
-        )
+        _debugState.value =
+            _debugState.value.copy(
+                inboundMessageCount = _debugState.value.inboundMessageCount + 1,
+                heartbeatReceivedCount = _debugState.value.heartbeatReceivedCount + if (message.isHeartbeatReply()) 1 else 0,
+                lastInboundRef = message.ref,
+            )
         _debugEvents.tryEmit(RealtimeDebugEvent.InboundMessage(message))
         if (message.isHeartbeatReply()) {
             pendingHeartbeatRef = null
             _debugEvents.tryEmit(RealtimeDebugEvent.HeartbeatReceived(message.ref))
         }
     }
+
     private fun handleUnexpectedDisconnect() {
         if (!config.autoReconnect || intentionalDisconnect) return
         heartbeatJob?.cancel()
@@ -370,6 +407,7 @@ internal class RealtimeClientImpl(
         scope = null
         scheduleReconnect()
     }
+
     private fun scheduleReconnect() {
         // Cancel any in-flight reconnect so overlapping triggers (e.g. a connect
         // failure racing an unexpected disconnect) don't spawn parallel loops.
@@ -377,24 +415,28 @@ internal class RealtimeClientImpl(
         reconnectJob = null
         val maxAttempts = config.maxReconnectAttempts
         if (maxAttempts > 0 && reconnectAttempt >= maxAttempts) {
-            _connectionState.value = ConnectionState.Failed(
-                reason = "Maximum reconnect attempts ($maxAttempts) exhausted",
-                attempts = reconnectAttempt,
-            )
+            _connectionState.value =
+                ConnectionState.Failed(
+                    reason = "Maximum reconnect attempts ($maxAttempts) exhausted",
+                    attempts = reconnectAttempt,
+                )
             return
         }
         val delayMs = calculateBackoffDelay(reconnectAttempt)
-        _connectionState.value = ConnectionState.Reconnecting(
-            attempt = reconnectAttempt + 1,
-            nextRetryMs = delayMs,
-        )
+        _connectionState.value =
+            ConnectionState.Reconnecting(
+                attempt = reconnectAttempt + 1,
+                nextRetryMs = delayMs,
+            )
         val reconnectScope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
-        reconnectJob = reconnectScope.launch {
-            delay(delayMs)
-            reconnectAttempt++
-            attemptReconnect()
-        }
+        reconnectJob =
+            reconnectScope.launch {
+                delay(delayMs)
+                reconnectAttempt++
+                attemptReconnect()
+            }
     }
+
     private suspend fun attemptReconnect() {
         _connectionState.value = ConnectionState.Connecting
         try {
@@ -411,12 +453,14 @@ internal class RealtimeClientImpl(
             scheduleReconnect()
         }
     }
+
     private suspend fun rejoinActiveChannels() {
         val subscriptions = synchronized(subscriptionsLock) { activeSubscriptions.values.toList() }
         for (subscription in subscriptions) {
             sendJoinMessage(subscription)
         }
     }
+
     private suspend fun sendJoinMessage(
         subscription: ChannelSubscriptionImpl,
     ) {
@@ -428,37 +472,51 @@ internal class RealtimeClientImpl(
         val privateChannel = subscription.privateChannel
         val replaySinceMs = subscription.replaySinceMs
         val replayLimit = subscription.replayLimit
-        val postgresConfigs = postgresCallbacks.map { config ->
-            buildJsonObject {
-                put("event", config.event.toWireValue())
-                put("schema", config.schema)
-                config.table?.let { put("table", it) }
-                config.filter?.let { put("filter", it) }
-            }
-        }
-        val joinPayload = buildJsonObject {
-            put("config", buildJsonObject {
-                put("broadcast", buildJsonObject {
-                    put("self", JsonPrimitive(receiveOwnBroadcasts))
-                    put("ack", JsonPrimitive(acknowledgeBroadcasts))
-                    if (replaySinceMs != null) {
-                        put("replay", buildJsonObject {
-                            put("since", JsonPrimitive(replaySinceMs))
-                            replayLimit?.let { put("limit", JsonPrimitive(it)) }
-                        })
-                    }
-                })
-                put("presence", buildJsonObject {
-                    put("enabled", JsonPrimitive(presenceKey.isNotEmpty() || subscription.hasPresenceTracking))
-                    put("key", JsonPrimitive(presenceKey))
-                })
-                if (postgresConfigs.isNotEmpty()) {
-                    put("postgres_changes", kotlinx.serialization.json.JsonArray(postgresConfigs))
+        val postgresConfigs =
+            postgresCallbacks.map { config ->
+                buildJsonObject {
+                    put("event", config.event.toWireValue())
+                    put("schema", config.schema)
+                    config.table?.let { put("table", it) }
+                    config.filter?.let { put("filter", it) }
                 }
-                put("private", JsonPrimitive(privateChannel))
-            })
-            put("access_token", JsonPrimitive(currentAccessToken()))
-        }
+            }
+        val joinPayload =
+            buildJsonObject {
+                put(
+                    "config",
+                    buildJsonObject {
+                        put(
+                            "broadcast",
+                            buildJsonObject {
+                                put("self", JsonPrimitive(receiveOwnBroadcasts))
+                                put("ack", JsonPrimitive(acknowledgeBroadcasts))
+                                if (replaySinceMs != null) {
+                                    put(
+                                        "replay",
+                                        buildJsonObject {
+                                            put("since", JsonPrimitive(replaySinceMs))
+                                            replayLimit?.let { put("limit", JsonPrimitive(it)) }
+                                        },
+                                    )
+                                }
+                            },
+                        )
+                        put(
+                            "presence",
+                            buildJsonObject {
+                                put("enabled", JsonPrimitive(presenceKey.isNotEmpty() || subscription.hasPresenceTracking))
+                                put("key", JsonPrimitive(presenceKey))
+                            },
+                        )
+                        if (postgresConfigs.isNotEmpty()) {
+                            put("postgres_changes", kotlinx.serialization.json.JsonArray(postgresConfigs))
+                        }
+                        put("private", JsonPrimitive(privateChannel))
+                    },
+                )
+                put("access_token", JsonPrimitive(currentAccessToken()))
+            }
         val joinRef = nextRef()
         subscription.joinRef = joinRef
         sendMessage(
@@ -473,17 +531,21 @@ internal class RealtimeClientImpl(
         // phx_join is fire-and-forget; without a watchdog a missing phx_reply
         // leaves the subscription stuck in SUBSCRIBING forever. Fail it on timeout.
         scope?.launch {
-            val resolved = withTimeoutOrNull(config.connectionTimeoutMs) {
-                subscription.status.first { it != RealtimeSubscription.Status.SUBSCRIBING }
-            }
+            val resolved =
+                withTimeoutOrNull(config.connectionTimeoutMs) {
+                    subscription.status.first { it != RealtimeSubscription.Status.SUBSCRIBING }
+                }
             if (resolved == null) subscription.markJoinTimedOut()
         }
     }
+
     private fun calculateBackoffDelay(attempt: Int): Long {
-        val delay = config.initialReconnectDelayMs *
-            config.backoffMultiplier.pow(attempt.toDouble())
+        val delay =
+            config.initialReconnectDelayMs *
+                config.backoffMultiplier.pow(attempt.toDouble())
         return min(delay.toLong(), config.maxReconnectDelayMs)
     }
+
     private suspend fun dispatchToSubscription(message: RealtimeMessage) {
         val subscription = synchronized(subscriptionsLock) { activeSubscriptions[message.topic] } ?: return
         try {
@@ -500,6 +562,7 @@ internal class RealtimeClientImpl(
     private fun currentAccessToken(): String =
         authTokenOverride ?: supabaseClient.accessTokenOrNull ?: supabaseClient.apiKey
 }
+
 internal class ChannelSubscriptionImpl(
     override val channel: String,
     internal val topic: String,
@@ -516,48 +579,58 @@ internal class ChannelSubscriptionImpl(
 ) : RealtimeSubscription {
     private val eventFlow = MutableSharedFlow<RealtimeEvent>(extraBufferCapacity = 64)
     private val _status = MutableStateFlow(RealtimeSubscription.Status.SUBSCRIBING)
+
     // Cumulative presence state, mutated only on the single inbound dispatch loop.
     private val presenceState = mutableMapOf<String, JsonObject>()
     internal var joinRef: String? = null
     internal val hasPresenceTracking: Boolean = presenceCallback != null
     override val status: StateFlow<RealtimeSubscription.Status> = _status.asStateFlow()
+
     override fun asFlow(): Flow<RealtimeEvent> = eventFlow
+
     internal fun markJoinTimedOut() {
         if (_status.value == RealtimeSubscription.Status.SUBSCRIBING) {
             _status.value = RealtimeSubscription.Status.ERROR
         }
     }
+
     override suspend fun unsubscribe() {
         _status.value = RealtimeSubscription.Status.UNSUBSCRIBING
         client.leaveChannel(topic)
         _status.value = RealtimeSubscription.Status.UNSUBSCRIBED
     }
+
     override suspend fun send(type: RealtimeSubscription.SendType, event: String, payload: JsonObject?) {
         client.sendMessage(
             RealtimeMessage(
                 topic = topic,
                 event = type.wireValue,
-                payload = buildJsonObject {
-                    put("type", type.wireValue)
-                    put("event", event)
-                    if (payload != null) {
-                        put("payload", payload)
-                    }
-                },
+                payload =
+                    buildJsonObject {
+                        put("type", type.wireValue)
+                        put("event", event)
+                        if (payload != null) {
+                            put("payload", payload)
+                        }
+                    },
                 joinRef = joinRef,
                 ref = client.nextRef(),
             ),
         )
     }
+
     override suspend fun broadcast(event: String, payload: JsonObject) {
         send(RealtimeSubscription.SendType.BROADCAST, event, payload)
     }
+
     override suspend fun track(state: JsonObject) {
         send(RealtimeSubscription.SendType.PRESENCE, "track", state)
     }
+
     override suspend fun untrack() {
         send(RealtimeSubscription.SendType.PRESENCE, "untrack")
     }
+
     internal suspend fun handleMessage(message: RealtimeMessage) {
         when (message.event) {
             "postgres_changes" -> handlePostgresChange(message.payload)
@@ -567,35 +640,38 @@ internal class ChannelSubscriptionImpl(
             "phx_reply" -> handleSystemReply(message.payload)
             "phx_error" -> {
                 _status.value = RealtimeSubscription.Status.ERROR
-                val event = RealtimeEvent.SystemEvent(
-                    status = "error",
-                    message = message.payload.toString(),
-                )
+                val event =
+                    RealtimeEvent.SystemEvent(
+                        status = "error",
+                        message = message.payload.toString(),
+                    )
                 eventFlow.emit(event)
             }
-            else -> {  }
+            else -> { }
         }
     }
+
     private suspend fun handlePostgresChange(payload: JsonObject) {
         val data = payload["data"]?.jsonObject ?: return
         val type = data["type"]?.jsonPrimitive?.content ?: return
         val record = data["record"]?.jsonObject
         val oldRecord = data["old_record"]?.jsonObject
-        val event = when (type) {
-            "INSERT" -> {
-                record ?: return
-                RealtimeEvent.PostgresInsert(record = record, oldRecord = oldRecord)
+        val event =
+            when (type) {
+                "INSERT" -> {
+                    record ?: return
+                    RealtimeEvent.PostgresInsert(record = record, oldRecord = oldRecord)
+                }
+                "UPDATE" -> {
+                    record ?: return
+                    RealtimeEvent.PostgresUpdate(record = record, oldRecord = oldRecord)
+                }
+                "DELETE" -> {
+                    val old = oldRecord ?: return
+                    RealtimeEvent.PostgresDelete(oldRecord = old)
+                }
+                else -> return
             }
-            "UPDATE" -> {
-                record ?: return
-                RealtimeEvent.PostgresUpdate(record = record, oldRecord = oldRecord)
-            }
-            "DELETE" -> {
-                val old = oldRecord ?: return
-                RealtimeEvent.PostgresDelete(oldRecord = old)
-            }
-            else -> return
-        }
         eventFlow.emit(event)
         for (config in postgresCallbacks) {
             if (config.event == PostgresChangeEvent.ALL || config.event.toWireValue() == type) {
@@ -603,17 +679,19 @@ internal class ChannelSubscriptionImpl(
                 when (config) {
                     is PostgresCallbackConfig.Simple -> config.callback(callbackPayload)
                     is PostgresCallbackConfig.Typed -> {
-                        val changeEvent = try {
-                            PostgresChangeEvent.valueOf(type)
-                        } catch (_: IllegalArgumentException) {
-                            PostgresChangeEvent.ALL
-                        }
+                        val changeEvent =
+                            try {
+                                PostgresChangeEvent.valueOf(type)
+                            } catch (_: IllegalArgumentException) {
+                                PostgresChangeEvent.ALL
+                            }
                         config.callback(changeEvent, callbackPayload)
                     }
                 }
             }
         }
     }
+
     private suspend fun handleBroadcast(payload: JsonObject) {
         val eventName = payload["event"]?.jsonPrimitive?.content ?: return
         val broadcastPayload = payload["payload"]?.jsonObject ?: buildJsonObject {}
@@ -621,6 +699,7 @@ internal class ChannelSubscriptionImpl(
         eventFlow.emit(event)
         broadcastCallbacks[eventName]?.invoke(broadcastPayload)
     }
+
     private suspend fun handlePresenceDiff(payload: JsonObject) {
         val joins = payload["joins"]?.jsonObject
         val leaves = payload["leaves"]?.jsonObject
@@ -638,6 +717,7 @@ internal class ChannelSubscriptionImpl(
         // members in this diff — so callers always see who is currently present.
         presenceCallback?.invoke(presenceState.toMap())
     }
+
     private suspend fun handlePresenceState(payload: JsonObject) {
         presenceState.clear()
         payload.forEach { (key, value) -> presenceState[key] = value.jsonObject }
@@ -645,27 +725,32 @@ internal class ChannelSubscriptionImpl(
         eventFlow.emit(RealtimeEvent.PresenceSync(state = state))
         presenceCallback?.invoke(state)
     }
+
     private suspend fun handleSystemReply(payload: JsonObject) {
         val status = payload["status"]?.jsonPrimitive?.content ?: "ok"
-        _status.value = if (status == "ok") {
-            RealtimeSubscription.Status.SUBSCRIBED
-        } else {
-            RealtimeSubscription.Status.ERROR
-        }
+        _status.value =
+            if (status == "ok") {
+                RealtimeSubscription.Status.SUBSCRIBED
+            } else {
+                RealtimeSubscription.Status.ERROR
+            }
         val response = payload["response"]
-        val event = RealtimeEvent.SystemEvent(
-            status = status,
-            message = response?.toString(),
-        )
+        val event =
+            RealtimeEvent.SystemEvent(
+                status = status,
+                message = response?.toString(),
+            )
         eventFlow.emit(event)
     }
 }
-internal fun PostgresChangeEvent.toWireValue(): String = when (this) {
-    PostgresChangeEvent.INSERT -> "INSERT"
-    PostgresChangeEvent.UPDATE -> "UPDATE"
-    PostgresChangeEvent.DELETE -> "DELETE"
-    PostgresChangeEvent.ALL -> "*"
-}
+
+internal fun PostgresChangeEvent.toWireValue(): String =
+    when (this) {
+        PostgresChangeEvent.INSERT -> "INSERT"
+        PostgresChangeEvent.UPDATE -> "UPDATE"
+        PostgresChangeEvent.DELETE -> "DELETE"
+        PostgresChangeEvent.ALL -> "*"
+    }
 
 // Control frames that are regenerated on reconnect and must not be replayed
 // from the outbound buffer (they would carry stale refs / duplicate joins).

--- a/supabase-realtime/src/commonMain/kotlin/io/github/androidpoet/supabase/realtime/RealtimeConfig.kt
+++ b/supabase-realtime/src/commonMain/kotlin/io/github/androidpoet/supabase/realtime/RealtimeConfig.kt
@@ -1,4 +1,5 @@
 package io.github.androidpoet.supabase.realtime
+
 public data class RealtimeConfig(
     public val autoReconnect: Boolean = true,
     public val initialReconnectDelayMs: Long = 1_000L,

--- a/supabase-realtime/src/commonMain/kotlin/io/github/androidpoet/supabase/realtime/RealtimeEvent.kt
+++ b/supabase-realtime/src/commonMain/kotlin/io/github/androidpoet/supabase/realtime/RealtimeEvent.kt
@@ -1,33 +1,41 @@
 package io.github.androidpoet.supabase.realtime
 import io.github.androidpoet.supabase.realtime.models.PresenceState
 import kotlinx.serialization.json.JsonObject
+
 public sealed interface RealtimeEvent {
     public data class PostgresInsert(
         public val record: JsonObject,
         public val oldRecord: JsonObject? = null,
     ) : RealtimeEvent
+
     public data class PostgresUpdate(
         public val record: JsonObject,
         public val oldRecord: JsonObject? = null,
     ) : RealtimeEvent
+
     public data class PostgresDelete(
         public val oldRecord: JsonObject,
     ) : RealtimeEvent
+
     public data class Broadcast(
         public val event: String,
         public val payload: JsonObject,
     ) : RealtimeEvent
+
     public data class PresenceSync(
         public val state: PresenceState,
     ) : RealtimeEvent
+
     public data class PresenceJoin(
         public val key: String,
         public val newPresence: JsonObject,
     ) : RealtimeEvent
+
     public data class PresenceLeave(
         public val key: String,
         public val leftPresence: JsonObject,
     ) : RealtimeEvent
+
     public data class SystemEvent(
         public val status: String,
         public val message: String? = null,

--- a/supabase-realtime/src/commonMain/kotlin/io/github/androidpoet/supabase/realtime/RealtimeExt.kt
+++ b/supabase-realtime/src/commonMain/kotlin/io/github/androidpoet/supabase/realtime/RealtimeExt.kt
@@ -4,8 +4,8 @@ import io.github.androidpoet.supabase.realtime.models.PresenceState
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.filter
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.withTimeout
 import kotlinx.serialization.decodeFromString

--- a/supabase-realtime/src/commonMain/kotlin/io/github/androidpoet/supabase/realtime/RealtimeSubscription.kt
+++ b/supabase-realtime/src/commonMain/kotlin/io/github/androidpoet/supabase/realtime/RealtimeSubscription.kt
@@ -2,6 +2,7 @@ package io.github.androidpoet.supabase.realtime
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.serialization.json.JsonObject
+
 public interface RealtimeSubscription {
     public enum class Status {
         SUBSCRIBING,
@@ -11,7 +12,9 @@ public interface RealtimeSubscription {
         ERROR,
     }
 
-    public enum class SendType(public val wireValue: String) {
+    public enum class SendType(
+        public val wireValue: String,
+    ) {
         BROADCAST("broadcast"),
         PRESENCE("presence"),
         POSTGRES_CHANGES("postgres_changes"),
@@ -19,10 +22,16 @@ public interface RealtimeSubscription {
 
     public val channel: String
     public val status: StateFlow<Status>
+
     public fun asFlow(): Flow<RealtimeEvent>
+
     public suspend fun unsubscribe()
+
     public suspend fun send(type: SendType, event: String, payload: JsonObject? = null)
+
     public suspend fun broadcast(event: String, payload: JsonObject)
+
     public suspend fun track(state: JsonObject)
+
     public suspend fun untrack()
 }

--- a/supabase-realtime/src/commonMain/kotlin/io/github/androidpoet/supabase/realtime/models/RealtimeModels.kt
+++ b/supabase-realtime/src/commonMain/kotlin/io/github/androidpoet/supabase/realtime/models/RealtimeModels.kt
@@ -2,6 +2,7 @@ package io.github.androidpoet.supabase.realtime.models
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.JsonObject
+
 @Serializable
 public data class RealtimeMessage(
     public val topic: String,
@@ -11,6 +12,7 @@ public data class RealtimeMessage(
     public val joinRef: String? = null,
     public val ref: String? = null,
 )
+
 @Serializable
 public data class PostgresChange(
     public val schema: String = "public",
@@ -18,22 +20,28 @@ public data class PostgresChange(
     public val filter: String? = null,
     public val event: PostgresChangeEvent = PostgresChangeEvent.ALL,
 )
+
 @Serializable
 public enum class PostgresChangeEvent {
     @SerialName("INSERT")
     INSERT,
+
     @SerialName("UPDATE")
     UPDATE,
+
     @SerialName("DELETE")
     DELETE,
+
     @SerialName("*")
     ALL,
 }
 public typealias PresenceState = Map<String, JsonObject>
+
 public data class RealtimeChannel(
     public val name: String,
     public val topic: String,
 )
+
 @Serializable
 public data class BroadcastPayload(
     public val event: String,

--- a/supabase-realtime/src/commonTest/kotlin/io/github/androidpoet/supabase/realtime/RealtimeChannelBuilderConfigTest.kt
+++ b/supabase-realtime/src/commonTest/kotlin/io/github/androidpoet/supabase/realtime/RealtimeChannelBuilderConfigTest.kt
@@ -4,136 +4,146 @@ import io.github.androidpoet.supabase.client.SupabaseClient
 import io.github.androidpoet.supabase.core.result.SupabaseError
 import io.github.androidpoet.supabase.core.result.SupabaseResult
 import io.github.androidpoet.supabase.realtime.models.RealtimeChannel
+import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
-import kotlinx.coroutines.test.runTest
 
 class RealtimeChannelBuilderConfigTest {
     @Test
-    fun test_builder_configValuesPropagateToSubscription() = runTest {
-        val client = FakeSupabaseClient()
-        val realtime = RealtimeClientImpl(client, RealtimeConfig(autoReconnect = false))
+    fun test_builder_configValuesPropagateToSubscription() =
+        runTest {
+            val client = FakeSupabaseClient()
+            val realtime = RealtimeClientImpl(client, RealtimeConfig(autoReconnect = false))
 
-        val subscription = realtime
-            .channel("room-1")
-            .configureBroadcast(receiveOwnBroadcasts = true, acknowledgeBroadcasts = true)
-            .configureBroadcastReplay(sinceMs = 1234L, limit = 10)
-            .configurePresence(key = "user-123")
-            .setPrivate(true)
-            .subscribe()
+            val subscription =
+                realtime
+                    .channel("room-1")
+                    .configureBroadcast(receiveOwnBroadcasts = true, acknowledgeBroadcasts = true)
+                    .configureBroadcastReplay(sinceMs = 1234L, limit = 10)
+                    .configurePresence(key = "user-123")
+                    .setPrivate(true)
+                    .subscribe()
 
-        val internal = subscription as ChannelSubscriptionImpl
-        assertEquals(true, internal.receiveOwnBroadcasts)
-        assertEquals(true, internal.acknowledgeBroadcasts)
-        assertEquals("user-123", internal.presenceKey)
-        assertEquals(true, internal.privateChannel)
-        assertEquals(1234L, internal.replaySinceMs)
-        assertEquals(10, internal.replayLimit)
-    }
-
-    @Test
-    fun test_removeSubscription_unsubscribesChannel() = runTest {
-        val client = FakeSupabaseClient()
-        val realtime = RealtimeClientImpl(client, RealtimeConfig(autoReconnect = false))
-        val subscription = realtime.channel("room-2").subscribe()
-
-        realtime.removeSubscription(subscription)
-
-        assertTrue(subscription.status.value == RealtimeSubscription.Status.UNSUBSCRIBED)
-    }
+            val internal = subscription as ChannelSubscriptionImpl
+            assertEquals(true, internal.receiveOwnBroadcasts)
+            assertEquals(true, internal.acknowledgeBroadcasts)
+            assertEquals("user-123", internal.presenceKey)
+            assertEquals(true, internal.privateChannel)
+            assertEquals(1234L, internal.replaySinceMs)
+            assertEquals(10, internal.replayLimit)
+        }
 
     @Test
-    fun test_removeChannel_subscription_unsubscribesChannel() = runTest {
-        val client = FakeSupabaseClient()
-        val realtime = RealtimeClientImpl(client, RealtimeConfig(autoReconnect = false))
-        val subscription = realtime.channel("room-2b").subscribe()
+    fun test_removeSubscription_unsubscribesChannel() =
+        runTest {
+            val client = FakeSupabaseClient()
+            val realtime = RealtimeClientImpl(client, RealtimeConfig(autoReconnect = false))
+            val subscription = realtime.channel("room-2").subscribe()
 
-        realtime.removeSubscription(subscription)
+            realtime.removeSubscription(subscription)
 
-        assertTrue(subscription.status.value == RealtimeSubscription.Status.UNSUBSCRIBED)
-    }
-
-    @Test
-    fun test_removeSubscriptions_unsubscribesAllChannels() = runTest {
-        val client = FakeSupabaseClient()
-        val realtime = RealtimeClientImpl(client, RealtimeConfig(autoReconnect = false))
-        val first = realtime.channel("room-2c-1").subscribe()
-        val second = realtime.channel("room-2c-2").subscribe()
-
-        realtime.removeSubscriptions(listOf(first, second))
-
-        assertTrue(first.status.value == RealtimeSubscription.Status.UNSUBSCRIBED)
-        assertTrue(second.status.value == RealtimeSubscription.Status.UNSUBSCRIBED)
-    }
+            assertTrue(subscription.status.value == RealtimeSubscription.Status.UNSUBSCRIBED)
+        }
 
     @Test
-    fun test_activeChannelDetails_returnsNameAndTopic() = runTest {
-        val client = FakeSupabaseClient()
-        val realtime = RealtimeClientImpl(client, RealtimeConfig(autoReconnect = false))
-        realtime.channel("room-3").subscribe()
+    fun test_removeChannel_subscription_unsubscribesChannel() =
+        runTest {
+            val client = FakeSupabaseClient()
+            val realtime = RealtimeClientImpl(client, RealtimeConfig(autoReconnect = false))
+            val subscription = realtime.channel("room-2b").subscribe()
 
-        assertEquals(
-            setOf(RealtimeChannel(name = "room-3", topic = "realtime:room-3")),
-            realtime.activeChannelDetails(),
-        )
-    }
+            realtime.removeSubscription(subscription)
 
-    @Test
-    fun test_getSubscription_returnsSubscriptionForChannel() = runTest {
-        val client = FakeSupabaseClient()
-        val realtime = RealtimeClientImpl(client, RealtimeConfig(autoReconnect = false))
-        val subscription = realtime.channel("room-4").subscribe()
-
-        assertTrue(realtime.getSubscription("room-4") === subscription)
-    }
+            assertTrue(subscription.status.value == RealtimeSubscription.Status.UNSUBSCRIBED)
+        }
 
     @Test
-    fun test_getSubscriptionByTopic_returnsSubscription() = runTest {
-        val client = FakeSupabaseClient()
-        val realtime = RealtimeClientImpl(client, RealtimeConfig(autoReconnect = false))
-        val subscription = realtime.channel("room-5").subscribe()
+    fun test_removeSubscriptions_unsubscribesAllChannels() =
+        runTest {
+            val client = FakeSupabaseClient()
+            val realtime = RealtimeClientImpl(client, RealtimeConfig(autoReconnect = false))
+            val first = realtime.channel("room-2c-1").subscribe()
+            val second = realtime.channel("room-2c-2").subscribe()
 
-        assertTrue(realtime.getSubscriptionByTopic("realtime:room-5") === subscription)
-    }
+            realtime.removeSubscriptions(listOf(first, second))
 
-    @Test
-    fun test_removeSubscriptionByTopic_unsubscribesChannel() = runTest {
-        val client = FakeSupabaseClient()
-        val realtime = RealtimeClientImpl(client, RealtimeConfig(autoReconnect = false))
-        val subscription = realtime.channel("room-topic").subscribe()
-
-        realtime.removeSubscriptionByTopic("realtime:room-topic")
-
-        assertTrue(subscription.status.value == RealtimeSubscription.Status.UNSUBSCRIBED)
-    }
+            assertTrue(first.status.value == RealtimeSubscription.Status.UNSUBSCRIBED)
+            assertTrue(second.status.value == RealtimeSubscription.Status.UNSUBSCRIBED)
+        }
 
     @Test
-    fun test_removeChannelsByTopic_unsubscribesAllMatchingChannels() = runTest {
-        val client = FakeSupabaseClient()
-        val realtime = RealtimeClientImpl(client, RealtimeConfig(autoReconnect = false))
-        val first = realtime.channel("room-t1").subscribe()
-        val second = realtime.channel("room-t2").subscribe()
+    fun test_activeChannelDetails_returnsNameAndTopic() =
+        runTest {
+            val client = FakeSupabaseClient()
+            val realtime = RealtimeClientImpl(client, RealtimeConfig(autoReconnect = false))
+            realtime.channel("room-3").subscribe()
 
-        realtime.removeChannelsByTopic(listOf("realtime:room-t1", "realtime:room-t2"))
-
-        assertTrue(first.status.value == RealtimeSubscription.Status.UNSUBSCRIBED)
-        assertTrue(second.status.value == RealtimeSubscription.Status.UNSUBSCRIBED)
-    }
+            assertEquals(
+                setOf(RealtimeChannel(name = "room-3", topic = "realtime:room-3")),
+                realtime.activeChannelDetails(),
+            )
+        }
 
     @Test
-    fun test_getSubscriptions_returnsAllActiveSubscriptions() = runTest {
-        val client = FakeSupabaseClient()
-        val realtime = RealtimeClientImpl(client, RealtimeConfig(autoReconnect = false))
-        val first = realtime.channel("room-a").subscribe()
-        val second = realtime.channel("room-b").subscribe()
+    fun test_getSubscription_returnsSubscriptionForChannel() =
+        runTest {
+            val client = FakeSupabaseClient()
+            val realtime = RealtimeClientImpl(client, RealtimeConfig(autoReconnect = false))
+            val subscription = realtime.channel("room-4").subscribe()
 
-        val subscriptions = realtime.getSubscriptions()
-        assertEquals(2, subscriptions.size)
-        assertTrue(subscriptions.contains(first))
-        assertTrue(subscriptions.contains(second))
-    }
+            assertTrue(realtime.getSubscription("room-4") === subscription)
+        }
 
+    @Test
+    fun test_getSubscriptionByTopic_returnsSubscription() =
+        runTest {
+            val client = FakeSupabaseClient()
+            val realtime = RealtimeClientImpl(client, RealtimeConfig(autoReconnect = false))
+            val subscription = realtime.channel("room-5").subscribe()
+
+            assertTrue(realtime.getSubscriptionByTopic("realtime:room-5") === subscription)
+        }
+
+    @Test
+    fun test_removeSubscriptionByTopic_unsubscribesChannel() =
+        runTest {
+            val client = FakeSupabaseClient()
+            val realtime = RealtimeClientImpl(client, RealtimeConfig(autoReconnect = false))
+            val subscription = realtime.channel("room-topic").subscribe()
+
+            realtime.removeSubscriptionByTopic("realtime:room-topic")
+
+            assertTrue(subscription.status.value == RealtimeSubscription.Status.UNSUBSCRIBED)
+        }
+
+    @Test
+    fun test_removeChannelsByTopic_unsubscribesAllMatchingChannels() =
+        runTest {
+            val client = FakeSupabaseClient()
+            val realtime = RealtimeClientImpl(client, RealtimeConfig(autoReconnect = false))
+            val first = realtime.channel("room-t1").subscribe()
+            val second = realtime.channel("room-t2").subscribe()
+
+            realtime.removeChannelsByTopic(listOf("realtime:room-t1", "realtime:room-t2"))
+
+            assertTrue(first.status.value == RealtimeSubscription.Status.UNSUBSCRIBED)
+            assertTrue(second.status.value == RealtimeSubscription.Status.UNSUBSCRIBED)
+        }
+
+    @Test
+    fun test_getSubscriptions_returnsAllActiveSubscriptions() =
+        runTest {
+            val client = FakeSupabaseClient()
+            val realtime = RealtimeClientImpl(client, RealtimeConfig(autoReconnect = false))
+            val first = realtime.channel("room-a").subscribe()
+            val second = realtime.channel("room-b").subscribe()
+
+            val subscriptions = realtime.getSubscriptions()
+            assertEquals(2, subscriptions.size)
+            assertTrue(subscriptions.contains(first))
+            assertTrue(subscriptions.contains(second))
+        }
 }
 
 private class FakeSupabaseClient : SupabaseClient {
@@ -152,6 +162,7 @@ private class FakeSupabaseClient : SupabaseClient {
         body: String?,
         headers: Map<String, String>,
     ): SupabaseResult<String> = SupabaseResult.Failure(SupabaseError("not used"))
+
     override suspend fun put(
         endpoint: String,
         body: String?,

--- a/supabase-realtime/src/commonTest/kotlin/io/github/androidpoet/supabase/realtime/RealtimeClientExtTest.kt
+++ b/supabase-realtime/src/commonTest/kotlin/io/github/androidpoet/supabase/realtime/RealtimeClientExtTest.kt
@@ -4,12 +4,10 @@ import io.github.androidpoet.supabase.client.SupabaseClient
 import io.github.androidpoet.supabase.core.result.SupabaseError
 import io.github.androidpoet.supabase.core.result.SupabaseResult
 import io.github.androidpoet.supabase.realtime.models.PostgresChangeEvent
-import io.github.androidpoet.supabase.realtime.models.RealtimeChannel
 import io.github.androidpoet.supabase.realtime.models.PresenceState
-import kotlinx.serialization.json.JsonObject
+import io.github.androidpoet.supabase.realtime.models.RealtimeChannel
 import kotlinx.coroutines.async
 import kotlinx.coroutines.delay
-import kotlinx.coroutines.yield
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -17,6 +15,8 @@ import kotlinx.coroutines.flow.emptyFlow
 import kotlinx.coroutines.flow.filterIsInstance
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.yield
+import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.jsonPrimitive
 import kotlinx.serialization.json.put
@@ -26,181 +26,205 @@ import kotlin.test.assertTrue
 
 class RealtimeClientExtTest {
     @Test
-    fun test_awaitConnected_returnsWhenStateBecomesConnected() = runTest {
-        val realtime = AwaitFakeRealtimeClient()
+    fun test_awaitConnected_returnsWhenStateBecomesConnected() =
+        runTest {
+            val realtime = AwaitFakeRealtimeClient()
 
-        val waiter = async { realtime.awaitConnected() }
-        delay(20)
-        realtime.emit(ConnectionState.Connected)
+            val waiter = async { realtime.awaitConnected() }
+            delay(20)
+            realtime.emit(ConnectionState.Connected)
 
-        val state = waiter.await()
-        assertEquals(ConnectionState.Connected, state)
-    }
-
-    @Test
-    fun test_awaitDisconnected_returnsWhenStateBecomesDisconnected() = runTest {
-        val realtime = AwaitFakeRealtimeClient(initial = ConnectionState.Connected)
-
-        val waiter = async { realtime.awaitDisconnected() }
-        delay(20)
-        realtime.emit(ConnectionState.Disconnected)
-
-        val state = waiter.await()
-        assertEquals(ConnectionState.Disconnected, state)
-    }
-
-    @Test
-    fun test_connectionStateBooleans_reflectCurrentState() = runTest {
-        val realtime = AwaitFakeRealtimeClient()
-
-        assertEquals(false, realtime.isConnected)
-        assertEquals(false, realtime.isConnecting)
-        assertEquals(false, realtime.isDisconnecting)
-
-        realtime.emit(ConnectionState.Connecting)
-        assertEquals(true, realtime.isConnecting)
-
-        realtime.emit(ConnectionState.Connected)
-        assertEquals(true, realtime.isConnected)
-
-        realtime.emit(ConnectionState.Disconnecting)
-        assertEquals(true, realtime.isDisconnecting)
-    }
-
-    @Test
-    fun test_subscribe_appliesConfigureBlock() = runTest {
-        val realtime = RealtimeClientImpl(ExtFakeSupabaseClient(), RealtimeConfig(autoReconnect = false))
-
-        val subscription = realtime.subscribe("room-x") {
-            setPrivate(true)
-            configurePresence("user-1")
-        } as ChannelSubscriptionImpl
-
-        assertEquals("room-x", subscription.channel)
-        assertTrue(subscription.privateChannel)
-        assertEquals("user-1", subscription.presenceKey)
-    }
-
-    @Test
-    fun test_subscribeToPostgresChanges_registersCallback() = runTest {
-        val realtime = RealtimeClientImpl(ExtFakeSupabaseClient(), RealtimeConfig(autoReconnect = false))
-
-        val subscription = realtime.subscribeToPostgresChanges(
-            channel = "room-pg",
-            schema = "public",
-            table = "messages",
-            event = PostgresChangeEvent.INSERT,
-            callback = {},
-        ) as ChannelSubscriptionImpl
-
-        assertEquals(1, subscription.postgresCallbacks.size)
-        assertEquals("messages", subscription.postgresCallbacks.first().table)
-    }
-
-    @Test
-    fun test_subscribeToPostgresChanges_typedCallback_receivesEventType() = runTest {
-        val realtime = RealtimeClientImpl(ExtFakeSupabaseClient(), RealtimeConfig(autoReconnect = false))
-        var capturedEvent: PostgresChangeEvent? = null
-        var capturedPayload: JsonObject? = null
-
-        val subscription = realtime.subscribeToPostgresChanges(
-            channel = "room-pg-typed",
-            table = "messages",
-            event = PostgresChangeEvent.ALL,
-        ) { event, payload ->
-            capturedEvent = event
-            capturedPayload = payload
-        } as ChannelSubscriptionImpl
-
-        assertEquals(1, subscription.postgresCallbacks.size)
-        assertTrue(subscription.postgresCallbacks.first() is PostgresCallbackConfig.Typed)
-
-        subscription.handleMessage(
-            io.github.androidpoet.supabase.realtime.models.RealtimeMessage(
-                topic = "realtime:room-pg-typed",
-                event = "postgres_changes",
-                payload = buildJsonObject {
-                    put("data", buildJsonObject {
-                        put("type", "INSERT")
-                        put("record", buildJsonObject { put("id", "1") })
-                        put("old_record", buildJsonObject {})
-                    })
-                },
-                ref = "1",
-            ),
-        )
-
-        assertEquals(PostgresChangeEvent.INSERT, capturedEvent)
-        assertEquals("1", capturedPayload?.get("id")?.jsonPrimitive?.content)
-    }
-
-    @Test
-    fun test_subscribeToBroadcast_registersEventCallback() = runTest {
-        val realtime = RealtimeClientImpl(ExtFakeSupabaseClient(), RealtimeConfig(autoReconnect = false))
-        var called = false
-
-        val subscription = realtime.subscribeToBroadcast(
-            channel = "room-b",
-            event = "message",
-            callback = { called = true },
-        ) as ChannelSubscriptionImpl
-
-        subscription.handleMessage(
-            io.github.androidpoet.supabase.realtime.models.RealtimeMessage(
-                topic = "realtime:room-b",
-                event = "broadcast",
-                payload = buildJsonObject {
-                    put("event", "message")
-                    put("payload", buildJsonObject { put("v", 1) })
-                },
-                ref = "1",
-            ),
-        )
-
-        assertTrue(called)
-    }
-
-    @Test
-    fun test_subscribeToPresence_registersPresenceHandler() = runTest {
-        val realtime = RealtimeClientImpl(ExtFakeSupabaseClient(), RealtimeConfig(autoReconnect = false))
-        var stateSize = -1
-
-        val subscription = realtime.subscribeToPresence(
-            channel = "room-presence",
-            callback = { state: PresenceState -> stateSize = state.size },
-        ) as ChannelSubscriptionImpl
-
-        subscription.handleMessage(
-            io.github.androidpoet.supabase.realtime.models.RealtimeMessage(
-                topic = "realtime:room-presence",
-                event = "presence_state",
-                payload = buildJsonObject {
-                    put("user-1", buildJsonObject {
-                        put("metas", kotlinx.serialization.json.buildJsonArray {})
-                    })
-                },
-                ref = "1",
-            ),
-        )
-
-        assertEquals(1, stateSize)
-    }
-
-    @Test
-    fun test_sendHeartbeat_recordsDebugEventAndState() = runTest {
-        val realtime = RealtimeClientImpl(ExtFakeSupabaseClient(), RealtimeConfig(autoReconnect = false))
-
-        val heartbeat = async {
-            realtime.debugEvents.filterIsInstance<RealtimeDebugEvent.HeartbeatSent>().first()
+            val state = waiter.await()
+            assertEquals(ConnectionState.Connected, state)
         }
-        yield()
-        realtime.sendHeartbeat()
 
-        assertEquals("1", heartbeat.await().ref)
-        assertEquals(1, realtime.debugState.value.outboundMessageCount)
-        assertEquals(1, realtime.debugState.value.heartbeatSentCount)
-        assertEquals("1", realtime.debugState.value.lastOutboundRef)
-    }
+    @Test
+    fun test_awaitDisconnected_returnsWhenStateBecomesDisconnected() =
+        runTest {
+            val realtime = AwaitFakeRealtimeClient(initial = ConnectionState.Connected)
+
+            val waiter = async { realtime.awaitDisconnected() }
+            delay(20)
+            realtime.emit(ConnectionState.Disconnected)
+
+            val state = waiter.await()
+            assertEquals(ConnectionState.Disconnected, state)
+        }
+
+    @Test
+    fun test_connectionStateBooleans_reflectCurrentState() =
+        runTest {
+            val realtime = AwaitFakeRealtimeClient()
+
+            assertEquals(false, realtime.isConnected)
+            assertEquals(false, realtime.isConnecting)
+            assertEquals(false, realtime.isDisconnecting)
+
+            realtime.emit(ConnectionState.Connecting)
+            assertEquals(true, realtime.isConnecting)
+
+            realtime.emit(ConnectionState.Connected)
+            assertEquals(true, realtime.isConnected)
+
+            realtime.emit(ConnectionState.Disconnecting)
+            assertEquals(true, realtime.isDisconnecting)
+        }
+
+    @Test
+    fun test_subscribe_appliesConfigureBlock() =
+        runTest {
+            val realtime = RealtimeClientImpl(ExtFakeSupabaseClient(), RealtimeConfig(autoReconnect = false))
+
+            val subscription =
+                realtime.subscribe("room-x") {
+                    setPrivate(true)
+                    configurePresence("user-1")
+                } as ChannelSubscriptionImpl
+
+            assertEquals("room-x", subscription.channel)
+            assertTrue(subscription.privateChannel)
+            assertEquals("user-1", subscription.presenceKey)
+        }
+
+    @Test
+    fun test_subscribeToPostgresChanges_registersCallback() =
+        runTest {
+            val realtime = RealtimeClientImpl(ExtFakeSupabaseClient(), RealtimeConfig(autoReconnect = false))
+
+            val subscription =
+                realtime.subscribeToPostgresChanges(
+                    channel = "room-pg",
+                    schema = "public",
+                    table = "messages",
+                    event = PostgresChangeEvent.INSERT,
+                    callback = {},
+                ) as ChannelSubscriptionImpl
+
+            assertEquals(1, subscription.postgresCallbacks.size)
+            assertEquals("messages", subscription.postgresCallbacks.first().table)
+        }
+
+    @Test
+    fun test_subscribeToPostgresChanges_typedCallback_receivesEventType() =
+        runTest {
+            val realtime = RealtimeClientImpl(ExtFakeSupabaseClient(), RealtimeConfig(autoReconnect = false))
+            var capturedEvent: PostgresChangeEvent? = null
+            var capturedPayload: JsonObject? = null
+
+            val subscription =
+                realtime.subscribeToPostgresChanges(
+                    channel = "room-pg-typed",
+                    table = "messages",
+                    event = PostgresChangeEvent.ALL,
+                ) { event, payload ->
+                    capturedEvent = event
+                    capturedPayload = payload
+                } as ChannelSubscriptionImpl
+
+            assertEquals(1, subscription.postgresCallbacks.size)
+            assertTrue(subscription.postgresCallbacks.first() is PostgresCallbackConfig.Typed)
+
+            subscription.handleMessage(
+                io.github.androidpoet.supabase.realtime.models.RealtimeMessage(
+                    topic = "realtime:room-pg-typed",
+                    event = "postgres_changes",
+                    payload =
+                        buildJsonObject {
+                            put(
+                                "data",
+                                buildJsonObject {
+                                    put("type", "INSERT")
+                                    put("record", buildJsonObject { put("id", "1") })
+                                    put("old_record", buildJsonObject {})
+                                },
+                            )
+                        },
+                    ref = "1",
+                ),
+            )
+
+            assertEquals(PostgresChangeEvent.INSERT, capturedEvent)
+            assertEquals("1", capturedPayload?.get("id")?.jsonPrimitive?.content)
+        }
+
+    @Test
+    fun test_subscribeToBroadcast_registersEventCallback() =
+        runTest {
+            val realtime = RealtimeClientImpl(ExtFakeSupabaseClient(), RealtimeConfig(autoReconnect = false))
+            var called = false
+
+            val subscription =
+                realtime.subscribeToBroadcast(
+                    channel = "room-b",
+                    event = "message",
+                    callback = { called = true },
+                ) as ChannelSubscriptionImpl
+
+            subscription.handleMessage(
+                io.github.androidpoet.supabase.realtime.models.RealtimeMessage(
+                    topic = "realtime:room-b",
+                    event = "broadcast",
+                    payload =
+                        buildJsonObject {
+                            put("event", "message")
+                            put("payload", buildJsonObject { put("v", 1) })
+                        },
+                    ref = "1",
+                ),
+            )
+
+            assertTrue(called)
+        }
+
+    @Test
+    fun test_subscribeToPresence_registersPresenceHandler() =
+        runTest {
+            val realtime = RealtimeClientImpl(ExtFakeSupabaseClient(), RealtimeConfig(autoReconnect = false))
+            var stateSize = -1
+
+            val subscription =
+                realtime.subscribeToPresence(
+                    channel = "room-presence",
+                    callback = { state: PresenceState -> stateSize = state.size },
+                ) as ChannelSubscriptionImpl
+
+            subscription.handleMessage(
+                io.github.androidpoet.supabase.realtime.models.RealtimeMessage(
+                    topic = "realtime:room-presence",
+                    event = "presence_state",
+                    payload =
+                        buildJsonObject {
+                            put(
+                                "user-1",
+                                buildJsonObject {
+                                    put("metas", kotlinx.serialization.json.buildJsonArray {})
+                                },
+                            )
+                        },
+                    ref = "1",
+                ),
+            )
+
+            assertEquals(1, stateSize)
+        }
+
+    @Test
+    fun test_sendHeartbeat_recordsDebugEventAndState() =
+        runTest {
+            val realtime = RealtimeClientImpl(ExtFakeSupabaseClient(), RealtimeConfig(autoReconnect = false))
+
+            val heartbeat =
+                async {
+                    realtime.debugEvents.filterIsInstance<RealtimeDebugEvent.HeartbeatSent>().first()
+                }
+            yield()
+            realtime.sendHeartbeat()
+
+            assertEquals("1", heartbeat.await().ref)
+            assertEquals(1, realtime.debugState.value.outboundMessageCount)
+            assertEquals(1, realtime.debugState.value.heartbeatSentCount)
+            assertEquals("1", realtime.debugState.value.lastOutboundRef)
+        }
 }
 
 private class ExtFakeSupabaseClient : SupabaseClient {
@@ -253,7 +277,9 @@ private class ExtFakeSupabaseClient : SupabaseClient {
     ): SupabaseResult<String> = SupabaseResult.Failure(SupabaseError("not used"))
 
     override fun setAccessToken(token: String) = Unit
+
     override fun clearAccessToken() = Unit
+
     override fun close() = Unit
 }
 
@@ -272,24 +298,41 @@ private class AwaitFakeRealtimeClient(
         get() = state.value is ConnectionState.Disconnecting
 
     override fun channel(name: String): RealtimeChannelBuilder = error("not used")
+
     override fun getSubscription(name: String): RealtimeSubscription? = null
+
     override fun getSubscriptionByTopic(topic: String): RealtimeSubscription? = null
+
     override fun getSubscriptions(): Set<RealtimeSubscription> = emptySet()
+
     override fun activeChannels(): Set<String> = emptySet()
+
     override fun activeChannelDetails(): Set<RealtimeChannel> = emptySet()
+
     override suspend fun removeSubscription(subscription: RealtimeSubscription) = Unit
+
     override suspend fun removeSubscriptions(subscriptions: List<RealtimeSubscription>) = Unit
+
     @Suppress("DEPRECATION")
     @Deprecated("Test override", ReplaceWith(""), level = DeprecationLevel.HIDDEN)
     override suspend fun removeChannel(subscription: RealtimeSubscription) = Unit
+
     override suspend fun removeSubscriptionByTopic(topic: String) = Unit
+
     override suspend fun removeChannelsByTopic(topics: List<String>) = Unit
+
     override suspend fun removeChannel(name: String) = Unit
+
     override suspend fun removeAllChannels() = Unit
+
     override suspend fun setAuth(token: String?) = Unit
+
     override suspend fun sendHeartbeat() = Unit
+
     override suspend fun connect() = Unit
+
     override suspend fun disconnect() = Unit
+
     override suspend fun close() = Unit
 
     fun emit(value: ConnectionState) {

--- a/supabase-realtime/src/commonTest/kotlin/io/github/androidpoet/supabase/realtime/RealtimeExtTest.kt
+++ b/supabase-realtime/src/commonTest/kotlin/io/github/androidpoet/supabase/realtime/RealtimeExtTest.kt
@@ -16,73 +16,82 @@ import kotlin.test.assertEquals
 
 class RealtimeExtTest {
     @Test
-    fun test_broadcastFlow_filtersByEvent() = runTest {
-        val sub = FakeSubscription()
-        val expectedPayload = buildJsonObject { put("v", 1) }
+    fun test_broadcastFlow_filtersByEvent() =
+        runTest {
+            val sub = FakeSubscription()
+            val expectedPayload = buildJsonObject { put("v", 1) }
 
-        sub.emit(RealtimeEvent.Broadcast("other", buildJsonObject { put("v", 0) }))
-        sub.emit(RealtimeEvent.Broadcast("message", expectedPayload))
+            sub.emit(RealtimeEvent.Broadcast("other", buildJsonObject { put("v", 0) }))
+            sub.emit(RealtimeEvent.Broadcast("message", expectedPayload))
 
-        assertEquals(expectedPayload, sub.broadcastFlow("message").first())
-    }
-
-    @Test
-    fun test_presenceSyncFlow_emitsState() = runTest {
-        val sub = FakeSubscription()
-        val expected: PresenceState = mapOf("user1" to buildJsonObject { put("online", true) })
-
-        sub.emit(RealtimeEvent.PresenceSync(expected))
-
-        assertEquals(expected, sub.presenceSyncFlow().first())
-    }
-
-    @Test
-    fun test_postgresInsertsFlow_emitsInsertRecord() = runTest {
-        val sub = FakeSubscription()
-        val expected = buildJsonObject { put("id", "1") }
-
-        sub.emit(RealtimeEvent.PostgresInsert(expected))
-
-        assertEquals(expected, sub.postgresInsertsFlow().first())
-    }
-
-    @Test
-    fun test_presenceDataFlow_decodesTypedPayloads() = runTest {
-        val sub = FakeSubscription()
-        val expected = listOf(PresenceUser("u1"), PresenceUser("u2"))
-        val syncState: PresenceState = mapOf(
-            "u1" to buildJsonObject { put("id", "u1") },
-            "u2" to buildJsonObject { put("id", "u2") },
-        )
-
-        sub.emit(RealtimeEvent.PresenceSync(syncState))
-
-        assertEquals(expected, sub.presenceDataFlow<PresenceUser>().first())
-    }
-
-    @Test
-    fun test_systemEventFlow_filtersByStatus() = runTest {
-        val sub = FakeSubscription()
-
-        sub.emit(RealtimeEvent.SystemEvent(status = "ok", message = "joined"))
-
-        val event = sub.systemEventFlow(status = "ok").first()
-        assertEquals("joined", event.message)
-    }
-
-    @Test
-    fun test_awaitSubscribed_returnsSubscribedStatus() = runTest {
-        val sub = FakeSubscription()
-        launch {
-            sub.updateStatus(RealtimeSubscription.Status.SUBSCRIBED)
+            assertEquals(expectedPayload, sub.broadcastFlow("message").first())
         }
 
-        assertEquals(RealtimeSubscription.Status.SUBSCRIBED, sub.awaitSubscribed(timeoutMs = 1_000))
-    }
+    @Test
+    fun test_presenceSyncFlow_emitsState() =
+        runTest {
+            val sub = FakeSubscription()
+            val expected: PresenceState = mapOf("user1" to buildJsonObject { put("online", true) })
+
+            sub.emit(RealtimeEvent.PresenceSync(expected))
+
+            assertEquals(expected, sub.presenceSyncFlow().first())
+        }
+
+    @Test
+    fun test_postgresInsertsFlow_emitsInsertRecord() =
+        runTest {
+            val sub = FakeSubscription()
+            val expected = buildJsonObject { put("id", "1") }
+
+            sub.emit(RealtimeEvent.PostgresInsert(expected))
+
+            assertEquals(expected, sub.postgresInsertsFlow().first())
+        }
+
+    @Test
+    fun test_presenceDataFlow_decodesTypedPayloads() =
+        runTest {
+            val sub = FakeSubscription()
+            val expected = listOf(PresenceUser("u1"), PresenceUser("u2"))
+            val syncState: PresenceState =
+                mapOf(
+                    "u1" to buildJsonObject { put("id", "u1") },
+                    "u2" to buildJsonObject { put("id", "u2") },
+                )
+
+            sub.emit(RealtimeEvent.PresenceSync(syncState))
+
+            assertEquals(expected, sub.presenceDataFlow<PresenceUser>().first())
+        }
+
+    @Test
+    fun test_systemEventFlow_filtersByStatus() =
+        runTest {
+            val sub = FakeSubscription()
+
+            sub.emit(RealtimeEvent.SystemEvent(status = "ok", message = "joined"))
+
+            val event = sub.systemEventFlow(status = "ok").first()
+            assertEquals("joined", event.message)
+        }
+
+    @Test
+    fun test_awaitSubscribed_returnsSubscribedStatus() =
+        runTest {
+            val sub = FakeSubscription()
+            launch {
+                sub.updateStatus(RealtimeSubscription.Status.SUBSCRIBED)
+            }
+
+            assertEquals(RealtimeSubscription.Status.SUBSCRIBED, sub.awaitSubscribed(timeoutMs = 1_000))
+        }
 }
 
 @Serializable
-private data class PresenceUser(val id: String)
+private data class PresenceUser(
+    val id: String,
+)
 
 private class FakeSubscription : RealtimeSubscription {
     private val flow = MutableSharedFlow<RealtimeEvent>(replay = 8, extraBufferCapacity = 8)

--- a/supabase-storage/src/commonMain/kotlin/io/github/androidpoet/supabase/storage/StorageClient.kt
+++ b/supabase-storage/src/commonMain/kotlin/io/github/androidpoet/supabase/storage/StorageClient.kt
@@ -29,100 +29,126 @@ import io.github.androidpoet.supabase.storage.models.VectorMetadataConfiguration
 import io.github.androidpoet.supabase.storage.models.VectorObject
 import io.github.androidpoet.supabase.storage.models.VectorQueryResponse
 import kotlinx.serialization.json.JsonObject
+
 public interface AnalyticsCatalogClient {
     public suspend fun loadConfig(): SupabaseResult<JsonObject>
+
     public suspend fun loadConfigTyped(): SupabaseResult<IcebergCatalogConfig>
+
     public suspend fun listNamespaces(
         parent: List<String>? = null,
         pageToken: String? = null,
         pageSize: Int? = null,
     ): SupabaseResult<JsonObject>
+
     public suspend fun listNamespacesTyped(
         parent: List<String>? = null,
         pageToken: String? = null,
         pageSize: Int? = null,
     ): SupabaseResult<IcebergNamespaceListResponse>
+
     public suspend fun createNamespace(
         namespace: List<String>,
         properties: Map<String, String> = emptyMap(),
     ): SupabaseResult<JsonObject>
+
     public suspend fun createNamespaceTyped(
         request: IcebergCreateNamespaceRequest,
     ): SupabaseResult<IcebergNamespaceMetadata>
+
     public suspend fun dropNamespace(namespace: List<String>): SupabaseResult<Unit>
+
     public suspend fun loadNamespaceMetadata(namespace: List<String>): SupabaseResult<JsonObject>
+
     public suspend fun loadNamespaceMetadataTyped(namespace: List<String>): SupabaseResult<IcebergNamespaceMetadata>
+
     public suspend fun updateNamespaceProperties(
         namespace: List<String>,
         removals: List<String>? = null,
         updates: Map<String, String>? = null,
     ): SupabaseResult<JsonObject>
+
     public suspend fun updateNamespacePropertiesTyped(
         namespace: List<String>,
         request: IcebergUpdateNamespacePropertiesRequest,
     ): SupabaseResult<IcebergUpdateNamespacePropertiesResponse>
+
     public suspend fun listTables(
         namespace: List<String>,
         pageToken: String? = null,
         pageSize: Int? = null,
     ): SupabaseResult<JsonObject>
+
     public suspend fun listTablesTyped(
         namespace: List<String>,
         pageToken: String? = null,
         pageSize: Int? = null,
     ): SupabaseResult<IcebergTableListResponse>
+
     public suspend fun createTable(
         namespace: List<String>,
         request: JsonObject,
     ): SupabaseResult<JsonObject>
+
     public suspend fun createTableTyped(
         namespace: List<String>,
         request: IcebergTableCreateRequest,
     ): SupabaseResult<IcebergTableMetadataResponse>
+
     public suspend fun updateTable(
         namespace: List<String>,
         name: String,
         request: JsonObject,
     ): SupabaseResult<JsonObject>
+
     public suspend fun commitTableTyped(
         namespace: List<String>,
         name: String,
         request: IcebergTableCommitRequest,
     ): SupabaseResult<IcebergTableMetadataResponse>
+
     public suspend fun commitTable(
         namespace: List<String>,
         name: String,
         request: JsonObject,
     ): SupabaseResult<JsonObject>
+
     public suspend fun dropTable(
         namespace: List<String>,
         name: String,
         purge: Boolean = false,
     ): SupabaseResult<Unit>
+
     public suspend fun loadTable(
         namespace: List<String>,
         name: String,
         snapshots: String? = null,
     ): SupabaseResult<JsonObject>
+
     public suspend fun loadTableTyped(
         namespace: List<String>,
         name: String,
         snapshots: String? = null,
     ): SupabaseResult<IcebergTableMetadataResponse>
+
     public suspend fun registerTable(
         namespace: List<String>,
         request: JsonObject,
     ): SupabaseResult<JsonObject>
+
     public suspend fun registerTableTyped(
         namespace: List<String>,
         request: IcebergTableRegisterRequest,
     ): SupabaseResult<IcebergTableMetadataResponse>
+
     public suspend fun renameTable(request: JsonObject): SupabaseResult<Unit>
+
     public suspend fun renameTableTyped(
         source: IcebergTableIdentifier,
         destination: IcebergTableIdentifier,
     ): SupabaseResult<Unit>
 }
+
 public interface StorageClient {
     public suspend fun listBuckets(
         limit: Int? = null,
@@ -131,7 +157,9 @@ public interface StorageClient {
         sortOrder: SortOrder? = null,
         search: String? = null,
     ): SupabaseResult<List<Bucket>>
+
     public suspend fun getBucket(id: String): SupabaseResult<Bucket>
+
     public suspend fun createBucket(
         id: String,
         name: String,
@@ -139,6 +167,7 @@ public interface StorageClient {
         fileSizeLimit: Long? = null,
         allowedMimeTypes: List<String>? = null,
     ): SupabaseResult<Bucket>
+
     public suspend fun updateBucket(
         id: String,
         name: String? = null,
@@ -146,8 +175,11 @@ public interface StorageClient {
         fileSizeLimit: Long? = null,
         allowedMimeTypes: List<String>? = null,
     ): SupabaseResult<Bucket>
+
     public suspend fun deleteBucket(id: String): SupabaseResult<Unit>
+
     public suspend fun emptyBucket(id: String): SupabaseResult<Unit>
+
     public suspend fun upload(
         bucket: String,
         path: String,
@@ -156,6 +188,7 @@ public interface StorageClient {
         upsert: Boolean = false,
         cacheControl: Int? = null,
     ): SupabaseResult<String>
+
     public suspend fun update(
         bucket: String,
         path: String,
@@ -164,24 +197,33 @@ public interface StorageClient {
         upsert: Boolean = false,
         cacheControl: Int? = null,
     ): SupabaseResult<String>
+
     public suspend fun download(bucket: String, path: String): SupabaseResult<String>
+
     public suspend fun downloadPublic(bucket: String, path: String): SupabaseResult<String>
+
     public suspend fun download(
         bucket: String,
         path: String,
         download: Boolean = true,
         fileName: String? = null,
     ): SupabaseResult<String>
+
     public suspend fun downloadPublic(
         bucket: String,
         path: String,
         download: Boolean = true,
         fileName: String? = null,
     ): SupabaseResult<String>
+
     public suspend fun info(bucket: String, path: String): SupabaseResult<FileObject>
+
     public suspend fun infoPublic(bucket: String, path: String): SupabaseResult<FileObject>
+
     public suspend fun exists(bucket: String, path: String): SupabaseResult<Boolean>
+
     public suspend fun existsPublic(bucket: String, path: String): SupabaseResult<Boolean>
+
     public suspend fun list(
         bucket: String,
         prefix: String = "",
@@ -191,6 +233,7 @@ public interface StorageClient {
         sortOrder: SortOrder = SortOrder.ASC,
         search: String? = null,
     ): SupabaseResult<List<FileObject>>
+
     public suspend fun listV2(
         bucket: String,
         prefix: String? = null,
@@ -200,16 +243,19 @@ public interface StorageClient {
         sortBy: String? = null,
         sortOrder: SortOrder = SortOrder.ASC,
     ): SupabaseResult<ObjectListV2Result>
+
     public suspend fun move(
         bucket: String,
         fromPath: String,
         toPath: String,
         destinationBucket: String? = null,
     ): SupabaseResult<Unit>
+
     public suspend fun deleteObject(
         bucket: String,
         path: String,
     ): SupabaseResult<Unit>
+
     public suspend fun copy(
         bucket: String,
         fromPath: String,
@@ -217,8 +263,11 @@ public interface StorageClient {
         destinationBucket: String? = null,
         copyMetadata: Boolean? = null,
     ): SupabaseResult<Unit>
+
     public suspend fun remove(bucket: String, paths: List<String>): SupabaseResult<Unit>
+
     public suspend fun removeWithResult(bucket: String, paths: List<String>): SupabaseResult<List<FileObject>>
+
     public suspend fun createSignedUrl(
         bucket: String,
         path: String,
@@ -227,6 +276,7 @@ public interface StorageClient {
         fileName: String? = null,
         transform: ImageTransformOptions? = null,
     ): SupabaseResult<String>
+
     public suspend fun createSignedUrls(
         bucket: String,
         paths: List<String>,
@@ -234,16 +284,19 @@ public interface StorageClient {
         download: Boolean = false,
         fileName: String? = null,
     ): SupabaseResult<List<String>>
+
     public suspend fun createUploadSignedUrl(
         bucket: String,
         path: String,
         upsert: Boolean = false,
     ): SupabaseResult<String>
+
     public suspend fun createUploadSignedUrlWithPath(
         bucket: String,
         path: String,
         upsert: Boolean = false,
     ): SupabaseResult<UploadSignedUrl>
+
     public fun getSignedDownloadUrl(
         bucket: String,
         path: String,
@@ -251,6 +304,7 @@ public interface StorageClient {
         download: Boolean = false,
         fileName: String? = null,
     ): String
+
     public suspend fun uploadToSignedUrl(
         bucket: String,
         path: String,
@@ -260,16 +314,19 @@ public interface StorageClient {
         upsert: Boolean = false,
         cacheControl: Int? = null,
     ): SupabaseResult<String>
+
     public fun getPublicUrl(
         bucket: String,
         path: String,
         transform: ImageTransformOptions? = null,
     ): String
+
     public fun getAuthenticatedUrl(
         bucket: String,
         path: String,
         transform: ImageTransformOptions? = null,
     ): String
+
     public fun getPublicUrl(
         bucket: String,
         path: String,
@@ -277,6 +334,7 @@ public interface StorageClient {
         fileName: String? = null,
         transform: ImageTransformOptions? = null,
     ): String
+
     public fun getAuthenticatedUrl(
         bucket: String,
         path: String,
@@ -284,17 +342,21 @@ public interface StorageClient {
         fileName: String? = null,
         transform: ImageTransformOptions? = null,
     ): String
+
     public fun getPublicRenderUrl(
         bucket: String,
         path: String,
         transform: ImageTransformOptions? = null,
     ): String
+
     public fun getAuthenticatedRenderUrl(
         bucket: String,
         path: String,
         transform: ImageTransformOptions? = null,
     ): String
+
     public suspend fun createAnalyticsBucket(name: String): SupabaseResult<AnalyticsBucket>
+
     public suspend fun listAnalyticsBuckets(
         limit: Int? = null,
         offset: Int? = null,
@@ -302,16 +364,23 @@ public interface StorageClient {
         sortOrder: SortOrder? = null,
         search: String? = null,
     ): SupabaseResult<List<AnalyticsBucket>>
+
     public suspend fun deleteAnalyticsBucket(name: String): SupabaseResult<Unit>
+
     public fun analyticsCatalog(bucketName: String): AnalyticsCatalogClient
+
     public suspend fun createVectorBucket(vectorBucketName: String): SupabaseResult<Unit>
+
     public suspend fun getVectorBucket(vectorBucketName: String): SupabaseResult<VectorBucket>
+
     public suspend fun listVectorBuckets(
         prefix: String? = null,
         maxResults: Int? = null,
         nextToken: String? = null,
     ): SupabaseResult<VectorBucketListResponse>
+
     public suspend fun deleteVectorBucket(vectorBucketName: String): SupabaseResult<Unit>
+
     public suspend fun createVectorIndex(
         vectorBucketName: String,
         indexName: String,
@@ -320,25 +389,30 @@ public interface StorageClient {
         distanceMetric: VectorDistanceMetric,
         metadataConfiguration: VectorMetadataConfiguration? = null,
     ): SupabaseResult<Unit>
+
     public suspend fun getVectorIndex(
         vectorBucketName: String,
         indexName: String,
     ): SupabaseResult<VectorIndex>
+
     public suspend fun listVectorIndexes(
         vectorBucketName: String,
         prefix: String? = null,
         maxResults: Int? = null,
         nextToken: String? = null,
     ): SupabaseResult<VectorIndexListResponse>
+
     public suspend fun deleteVectorIndex(
         vectorBucketName: String,
         indexName: String,
     ): SupabaseResult<Unit>
+
     public suspend fun putVectors(
         vectorBucketName: String,
         indexName: String,
         vectors: List<VectorObject>,
     ): SupabaseResult<Unit>
+
     public suspend fun getVectors(
         vectorBucketName: String,
         indexName: String,
@@ -346,6 +420,7 @@ public interface StorageClient {
         returnData: Boolean? = null,
         returnMetadata: Boolean? = null,
     ): SupabaseResult<List<VectorMatch>>
+
     public suspend fun listVectors(
         vectorBucketName: String,
         indexName: String,
@@ -356,6 +431,7 @@ public interface StorageClient {
         segmentCount: Int? = null,
         segmentIndex: Int? = null,
     ): SupabaseResult<VectorListResponse>
+
     public suspend fun queryVectors(
         vectorBucketName: String,
         indexName: String,
@@ -365,6 +441,7 @@ public interface StorageClient {
         returnDistance: Boolean? = null,
         returnMetadata: Boolean? = null,
     ): SupabaseResult<VectorQueryResponse>
+
     public suspend fun deleteVectors(
         vectorBucketName: String,
         indexName: String,

--- a/supabase-storage/src/commonMain/kotlin/io/github/androidpoet/supabase/storage/StorageClientExt.kt
+++ b/supabase-storage/src/commonMain/kotlin/io/github/androidpoet/supabase/storage/StorageClientExt.kt
@@ -95,13 +95,14 @@ public suspend fun StorageClient.createSignedRenderUrls(
     val urls = ArrayList<String>(paths.size)
     for (path in paths) {
         when (
-            val signed = createSignedUrl(
-                bucket = bucket,
-                path = path,
-                expiresIn = expiresIn,
-                download = false,
-                transform = transform,
-            )
+            val signed =
+                createSignedUrl(
+                    bucket = bucket,
+                    path = path,
+                    expiresIn = expiresIn,
+                    download = false,
+                    transform = transform,
+                )
         ) {
             is SupabaseResult.Failure -> return signed
             is SupabaseResult.Success -> urls += signed.value
@@ -130,12 +131,13 @@ public suspend fun StorageClient.createSignedDownloadUrlsByPath(
     fileName: String? = null,
 ): SupabaseResult<Map<String, String>> =
     when (
-        val result = createSignedDownloadUrls(
-            bucket = bucket,
-            paths = paths,
-            expiresIn = expiresIn,
-            fileName = fileName,
-        )
+        val result =
+            createSignedDownloadUrls(
+                bucket = bucket,
+                paths = paths,
+                expiresIn = expiresIn,
+                fileName = fileName,
+            )
     ) {
         is SupabaseResult.Failure -> result
         is SupabaseResult.Success -> SupabaseResult.Success(paths.zip(result.value).toMap())
@@ -173,12 +175,13 @@ public suspend fun StorageClient.createSignedRenderUrlsByPath(
     transform: ImageTransformOptions,
 ): SupabaseResult<Map<String, String>> =
     when (
-        val result = createSignedRenderUrls(
-            bucket = bucket,
-            paths = paths,
-            expiresIn = expiresIn,
-            transform = transform,
-        )
+        val result =
+            createSignedRenderUrls(
+                bucket = bucket,
+                paths = paths,
+                expiresIn = expiresIn,
+                transform = transform,
+            )
     ) {
         is SupabaseResult.Failure -> result
         is SupabaseResult.Success -> SupabaseResult.Success(paths.zip(result.value).toMap())
@@ -237,13 +240,14 @@ public fun StorageClient.getPublicUrls(
     fileName: String? = null,
     transform: ImageTransformOptions? = null,
     vararg paths: String,
-): List<String> = getPublicUrls(
-    bucket = bucket,
-    paths = paths.toList(),
-    download = download,
-    fileName = fileName,
-    transform = transform,
-)
+): List<String> =
+    getPublicUrls(
+        bucket = bucket,
+        paths = paths.toList(),
+        download = download,
+        fileName = fileName,
+        transform = transform,
+    )
 
 public fun StorageClient.getPublicUrlsByPath(
     bucket: String,
@@ -251,15 +255,16 @@ public fun StorageClient.getPublicUrlsByPath(
     download: Boolean = false,
     fileName: String? = null,
     transform: ImageTransformOptions? = null,
-): Map<String, String> = paths.associateWith { path ->
-    getPublicUrl(
-        bucket = bucket,
-        path = path,
-        download = download,
-        fileName = fileName,
-        transform = transform,
-    )
-}
+): Map<String, String> =
+    paths.associateWith { path ->
+        getPublicUrl(
+            bucket = bucket,
+            path = path,
+            download = download,
+            fileName = fileName,
+            transform = transform,
+        )
+    }
 
 public fun StorageClient.getPublicUrlsByPath(
     bucket: String,
@@ -272,13 +277,14 @@ public fun StorageClient.getPublicUrlsByPath(
     fileName: String? = null,
     transform: ImageTransformOptions? = null,
     vararg paths: String,
-): Map<String, String> = getPublicUrlsByPath(
-    bucket = bucket,
-    paths = paths.toList(),
-    download = download,
-    fileName = fileName,
-    transform = transform,
-)
+): Map<String, String> =
+    getPublicUrlsByPath(
+        bucket = bucket,
+        paths = paths.toList(),
+        download = download,
+        fileName = fileName,
+        transform = transform,
+    )
 
 public fun StorageClient.getAuthenticatedUrls(
     bucket: String,
@@ -308,13 +314,14 @@ public fun StorageClient.getAuthenticatedUrls(
     fileName: String? = null,
     transform: ImageTransformOptions? = null,
     vararg paths: String,
-): List<String> = getAuthenticatedUrls(
-    bucket = bucket,
-    paths = paths.toList(),
-    download = download,
-    fileName = fileName,
-    transform = transform,
-)
+): List<String> =
+    getAuthenticatedUrls(
+        bucket = bucket,
+        paths = paths.toList(),
+        download = download,
+        fileName = fileName,
+        transform = transform,
+    )
 
 public fun StorageClient.getAuthenticatedUrlsByPath(
     bucket: String,
@@ -322,15 +329,16 @@ public fun StorageClient.getAuthenticatedUrlsByPath(
     download: Boolean = false,
     fileName: String? = null,
     transform: ImageTransformOptions? = null,
-): Map<String, String> = paths.associateWith { path ->
-    getAuthenticatedUrl(
-        bucket = bucket,
-        path = path,
-        download = download,
-        fileName = fileName,
-        transform = transform,
-    )
-}
+): Map<String, String> =
+    paths.associateWith { path ->
+        getAuthenticatedUrl(
+            bucket = bucket,
+            path = path,
+            download = download,
+            fileName = fileName,
+            transform = transform,
+        )
+    }
 
 public fun StorageClient.getAuthenticatedUrlsByPath(
     bucket: String,
@@ -343,21 +351,23 @@ public fun StorageClient.getAuthenticatedUrlsByPath(
     fileName: String? = null,
     transform: ImageTransformOptions? = null,
     vararg paths: String,
-): Map<String, String> = getAuthenticatedUrlsByPath(
-    bucket = bucket,
-    paths = paths.toList(),
-    download = download,
-    fileName = fileName,
-    transform = transform,
-)
+): Map<String, String> =
+    getAuthenticatedUrlsByPath(
+        bucket = bucket,
+        paths = paths.toList(),
+        download = download,
+        fileName = fileName,
+        transform = transform,
+    )
 
 public fun StorageClient.getPublicRenderUrls(
     bucket: String,
     paths: List<String>,
     transform: ImageTransformOptions? = null,
-): List<String> = paths.map { path ->
-    getPublicRenderUrl(bucket = bucket, path = path, transform = transform)
-}
+): List<String> =
+    paths.map { path ->
+        getPublicRenderUrl(bucket = bucket, path = path, transform = transform)
+    }
 
 public fun StorageClient.getPublicRenderUrls(
     bucket: String,
@@ -369,9 +379,10 @@ public fun StorageClient.getPublicRenderUrlsByPath(
     bucket: String,
     paths: List<String>,
     transform: ImageTransformOptions? = null,
-): Map<String, String> = paths.associateWith { path ->
-    getPublicRenderUrl(bucket = bucket, path = path, transform = transform)
-}
+): Map<String, String> =
+    paths.associateWith { path ->
+        getPublicRenderUrl(bucket = bucket, path = path, transform = transform)
+    }
 
 public fun StorageClient.getPublicRenderUrlsByPath(
     bucket: String,
@@ -383,9 +394,10 @@ public fun StorageClient.getAuthenticatedRenderUrls(
     bucket: String,
     paths: List<String>,
     transform: ImageTransformOptions? = null,
-): List<String> = paths.map { path ->
-    getAuthenticatedRenderUrl(bucket = bucket, path = path, transform = transform)
-}
+): List<String> =
+    paths.map { path ->
+        getAuthenticatedRenderUrl(bucket = bucket, path = path, transform = transform)
+    }
 
 public fun StorageClient.getAuthenticatedRenderUrls(
     bucket: String,
@@ -397,9 +409,10 @@ public fun StorageClient.getAuthenticatedRenderUrlsByPath(
     bucket: String,
     paths: List<String>,
     transform: ImageTransformOptions? = null,
-): Map<String, String> = paths.associateWith { path ->
-    getAuthenticatedRenderUrl(bucket = bucket, path = path, transform = transform)
-}
+): Map<String, String> =
+    paths.associateWith { path ->
+        getAuthenticatedRenderUrl(bucket = bucket, path = path, transform = transform)
+    }
 
 public fun StorageClient.getAuthenticatedRenderUrlsByPath(
     bucket: String,

--- a/supabase-storage/src/commonMain/kotlin/io/github/androidpoet/supabase/storage/StorageClientImpl.kt
+++ b/supabase-storage/src/commonMain/kotlin/io/github/androidpoet/supabase/storage/StorageClientImpl.kt
@@ -2,8 +2,8 @@ package io.github.androidpoet.supabase.storage
 import io.github.androidpoet.supabase.client.SupabaseClient
 import io.github.androidpoet.supabase.client.defaultJson
 import io.github.androidpoet.supabase.client.deserialize
-import io.github.androidpoet.supabase.core.result.SupabaseResult
 import io.github.androidpoet.supabase.core.result.SupabaseErrorCategory
+import io.github.androidpoet.supabase.core.result.SupabaseResult
 import io.github.androidpoet.supabase.core.result.category
 import io.github.androidpoet.supabase.core.result.map
 import io.github.androidpoet.supabase.storage.models.AnalyticsBucket
@@ -29,11 +29,11 @@ import io.github.androidpoet.supabase.storage.models.ObjectListRequest
 import io.github.androidpoet.supabase.storage.models.ObjectListV2Request
 import io.github.androidpoet.supabase.storage.models.ObjectListV2Result
 import io.github.androidpoet.supabase.storage.models.ObjectSortByRequest
-import io.github.androidpoet.supabase.storage.models.SignedUrlRequest
 import io.github.androidpoet.supabase.storage.models.SignedUrlItemResponse
-import io.github.androidpoet.supabase.storage.models.SignedUrlsRequest
-import io.github.androidpoet.supabase.storage.models.SignedUrlTransformRequest
+import io.github.androidpoet.supabase.storage.models.SignedUrlRequest
 import io.github.androidpoet.supabase.storage.models.SignedUrlResponse
+import io.github.androidpoet.supabase.storage.models.SignedUrlTransformRequest
+import io.github.androidpoet.supabase.storage.models.SignedUrlsRequest
 import io.github.androidpoet.supabase.storage.models.UpdateBucketRequest
 import io.github.androidpoet.supabase.storage.models.UploadSignedUrlResponse
 import io.github.androidpoet.supabase.storage.models.VectorBucket
@@ -61,8 +61,8 @@ import io.github.androidpoet.supabase.storage.models.VectorObject
 import io.github.androidpoet.supabase.storage.models.VectorPutRequest
 import io.github.androidpoet.supabase.storage.models.VectorQueryRequest
 import io.github.androidpoet.supabase.storage.models.VectorQueryResponse
-import kotlinx.serialization.encodeToString
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.buildJsonObject
@@ -71,6 +71,7 @@ import kotlinx.serialization.json.jsonPrimitive
 import kotlinx.serialization.json.put
 import kotlinx.serialization.json.putJsonArray
 import kotlinx.serialization.json.putJsonObject
+
 internal class StorageClientImpl(
     private val client: SupabaseClient,
 ) : StorageClient {
@@ -81,17 +82,20 @@ internal class StorageClientImpl(
         sortOrder: SortOrder?,
         search: String?,
     ): SupabaseResult<List<Bucket>> {
-        val query = buildList {
-            limit?.let { add("limit" to it.toString()) }
-            offset?.let { add("offset" to it.toString()) }
-            sortColumn?.let { add("sortColumn" to it) }
-            sortOrder?.let { add("sortOrder" to it.name.lowercase()) }
-            search?.let { add("search" to it) }
-        }
+        val query =
+            buildList {
+                limit?.let { add("limit" to it.toString()) }
+                offset?.let { add("offset" to it.toString()) }
+                sortColumn?.let { add("sortColumn" to it) }
+                sortOrder?.let { add("sortOrder" to it.name.lowercase()) }
+                search?.let { add("search" to it) }
+            }
         return client.get("/storage/v1/bucket", queryParams = query).deserialize()
     }
+
     override suspend fun getBucket(id: String): SupabaseResult<Bucket> =
         client.get("/storage/v1/bucket/$id").deserialize()
+
     override suspend fun createBucket(
         id: String,
         name: String,
@@ -99,17 +103,19 @@ internal class StorageClientImpl(
         fileSizeLimit: Long?,
         allowedMimeTypes: List<String>?,
     ): SupabaseResult<Bucket> {
-        val body = defaultJson.encodeToString(
-            CreateBucketRequest(
-                id = id,
-                name = name,
-                public = public,
-                fileSizeLimit = fileSizeLimit,
-                allowedMimeTypes = allowedMimeTypes,
-            ),
-        )
+        val body =
+            defaultJson.encodeToString(
+                CreateBucketRequest(
+                    id = id,
+                    name = name,
+                    public = public,
+                    fileSizeLimit = fileSizeLimit,
+                    allowedMimeTypes = allowedMimeTypes,
+                ),
+            )
         return client.post("/storage/v1/bucket", body = body).deserialize()
     }
+
     override suspend fun updateBucket(
         id: String,
         name: String?,
@@ -117,20 +123,24 @@ internal class StorageClientImpl(
         fileSizeLimit: Long?,
         allowedMimeTypes: List<String>?,
     ): SupabaseResult<Bucket> {
-        val body = defaultJson.encodeToString(
-            UpdateBucketRequest(
-                name = name,
-                public = public,
-                fileSizeLimit = fileSizeLimit,
-                allowedMimeTypes = allowedMimeTypes,
-            ),
-        )
+        val body =
+            defaultJson.encodeToString(
+                UpdateBucketRequest(
+                    name = name,
+                    public = public,
+                    fileSizeLimit = fileSizeLimit,
+                    allowedMimeTypes = allowedMimeTypes,
+                ),
+            )
         return client.put("/storage/v1/bucket/$id", body = body).deserialize()
     }
+
     override suspend fun deleteBucket(id: String): SupabaseResult<Unit> =
         client.delete("/storage/v1/bucket/$id").map { }
+
     override suspend fun emptyBucket(id: String): SupabaseResult<Unit> =
         client.post("/storage/v1/bucket/$id/empty").map { }
+
     override suspend fun upload(
         bucket: String,
         path: String,
@@ -139,9 +149,10 @@ internal class StorageClientImpl(
         upsert: Boolean,
         cacheControl: Int?,
     ): SupabaseResult<String> {
-        val headers = buildMap {
-            if (upsert) put("x-upsert", "true")
-        }
+        val headers =
+            buildMap {
+                if (upsert) put("x-upsert", "true")
+            }
         val endpoint = withCacheControl("/storage/v1/object/${objectRef(bucket, path)}", cacheControl)
         return client.postRaw(
             url = endpoint,
@@ -150,6 +161,7 @@ internal class StorageClientImpl(
             headers = headers,
         )
     }
+
     override suspend fun update(
         bucket: String,
         path: String,
@@ -158,9 +170,10 @@ internal class StorageClientImpl(
         upsert: Boolean,
         cacheControl: Int?,
     ): SupabaseResult<String> {
-        val headers = buildMap {
-            if (upsert) put("x-upsert", "true")
-        }
+        val headers =
+            buildMap {
+                if (upsert) put("x-upsert", "true")
+            }
         val endpoint = withCacheControl("/storage/v1/object/${objectRef(bucket, path)}", cacheControl)
         return client.putRaw(
             url = endpoint,
@@ -169,10 +182,13 @@ internal class StorageClientImpl(
             headers = headers,
         )
     }
+
     override suspend fun download(bucket: String, path: String): SupabaseResult<String> =
         client.get("/storage/v1/object/authenticated/${objectRef(bucket, path)}")
+
     override suspend fun downloadPublic(bucket: String, path: String): SupabaseResult<String> =
         client.get("/storage/v1/object/public/${objectRef(bucket, path)}")
+
     override suspend fun download(
         bucket: String,
         path: String,
@@ -180,6 +196,7 @@ internal class StorageClientImpl(
         fileName: String?,
     ): SupabaseResult<String> =
         client.get("/storage/v1/object/authenticated/${objectRef(bucket, path)}${buildDownloadQuery(download, fileName)}")
+
     override suspend fun downloadPublic(
         bucket: String,
         path: String,
@@ -187,10 +204,13 @@ internal class StorageClientImpl(
         fileName: String?,
     ): SupabaseResult<String> =
         client.get("/storage/v1/object/public/${objectRef(bucket, path)}${buildDownloadQuery(download, fileName)}")
+
     override suspend fun info(bucket: String, path: String): SupabaseResult<FileObject> =
         client.get("/storage/v1/object/info/${objectRef(bucket, path)}").deserialize()
+
     override suspend fun infoPublic(bucket: String, path: String): SupabaseResult<FileObject> =
         client.get("/storage/v1/object/info/public/${objectRef(bucket, path)}").deserialize()
+
     override suspend fun exists(bucket: String, path: String): SupabaseResult<Boolean> =
         when (val result = info(bucket, path)) {
             is SupabaseResult.Success -> SupabaseResult.Success(true)
@@ -201,6 +221,7 @@ internal class StorageClientImpl(
                     result
                 }
         }
+
     override suspend fun existsPublic(bucket: String, path: String): SupabaseResult<Boolean> =
         when (val result = infoPublic(bucket, path)) {
             is SupabaseResult.Success -> SupabaseResult.Success(true)
@@ -211,6 +232,7 @@ internal class StorageClientImpl(
                     result
                 }
         }
+
     override suspend fun list(
         bucket: String,
         prefix: String,
@@ -220,19 +242,22 @@ internal class StorageClientImpl(
         sortOrder: SortOrder,
         search: String?,
     ): SupabaseResult<List<FileObject>> {
-        val body = defaultJson.encodeToString(
-            ObjectListRequest(
-                prefix = prefix,
-                limit = limit,
-                offset = offset,
-                sortBy = sortBy?.let {
-                    ObjectSortByRequest(column = it, order = sortOrder.name.lowercase())
-                },
-                search = search,
-            ),
-        )
+        val body =
+            defaultJson.encodeToString(
+                ObjectListRequest(
+                    prefix = prefix,
+                    limit = limit,
+                    offset = offset,
+                    sortBy =
+                        sortBy?.let {
+                            ObjectSortByRequest(column = it, order = sortOrder.name.lowercase())
+                        },
+                    search = search,
+                ),
+            )
         return client.post("/storage/v1/object/list/$bucket", body = body).deserialize()
     }
+
     override suspend fun listV2(
         bucket: String,
         prefix: String?,
@@ -242,40 +267,46 @@ internal class StorageClientImpl(
         sortBy: String?,
         sortOrder: SortOrder,
     ): SupabaseResult<ObjectListV2Result> {
-        val body = defaultJson.encodeToString(
-            ObjectListV2Request(
-                prefix = prefix,
-                cursor = cursor,
-                limit = limit,
-                withDelimiter = withDelimiter,
-                sortBy = sortBy?.let {
-                    ObjectSortByRequest(column = it, order = sortOrder.name.lowercase())
-                },
-            ),
-        )
+        val body =
+            defaultJson.encodeToString(
+                ObjectListV2Request(
+                    prefix = prefix,
+                    cursor = cursor,
+                    limit = limit,
+                    withDelimiter = withDelimiter,
+                    sortBy =
+                        sortBy?.let {
+                            ObjectSortByRequest(column = it, order = sortOrder.name.lowercase())
+                        },
+                ),
+            )
         return client.post("/storage/v1/object/list-v2/$bucket", body = body).deserialize()
     }
+
     override suspend fun move(
         bucket: String,
         fromPath: String,
         toPath: String,
         destinationBucket: String?,
     ): SupabaseResult<Unit> {
-        val body = defaultJson.encodeToString(
-            MoveRequest(
-                bucketId = bucket,
-                sourceKey = fromPath,
-                destinationKey = toPath,
-                destinationBucketId = destinationBucket,
-            ),
-        )
+        val body =
+            defaultJson.encodeToString(
+                MoveRequest(
+                    bucketId = bucket,
+                    sourceKey = fromPath,
+                    destinationKey = toPath,
+                    destinationBucketId = destinationBucket,
+                ),
+            )
         return client.post("/storage/v1/object/move", body = body).map { }
     }
+
     override suspend fun deleteObject(
         bucket: String,
         path: String,
     ): SupabaseResult<Unit> =
         client.delete("/storage/v1/object/${objectRef(bucket, path)}").map { }
+
     override suspend fun copy(
         bucket: String,
         fromPath: String,
@@ -283,31 +314,33 @@ internal class StorageClientImpl(
         destinationBucket: String?,
         copyMetadata: Boolean?,
     ): SupabaseResult<Unit> {
-        val body = defaultJson.encodeToString(
-            MoveRequest(
-                bucketId = bucket,
-                sourceKey = fromPath,
-                destinationKey = toPath,
-                destinationBucketId = destinationBucket,
-                copyMetadata = copyMetadata,
-            ),
-        )
+        val body =
+            defaultJson.encodeToString(
+                MoveRequest(
+                    bucketId = bucket,
+                    sourceKey = fromPath,
+                    destinationKey = toPath,
+                    destinationBucketId = destinationBucket,
+                    copyMetadata = copyMetadata,
+                ),
+            )
         return client.post("/storage/v1/object/copy", body = body).map { }
     }
-    override suspend fun remove(bucket: String, paths: List<String>): SupabaseResult<Unit> {
-        return removeWithResult(bucket, paths).map { }
-    }
+
+    override suspend fun remove(bucket: String, paths: List<String>): SupabaseResult<Unit> = removeWithResult(bucket, paths).map { }
 
     override suspend fun removeWithResult(
         bucket: String,
         paths: List<String>,
     ): SupabaseResult<List<FileObject>> {
         val body = defaultJson.encodeToString(mapOf("prefixes" to paths))
-        return client.post(
-            endpoint = "/storage/v1/object/remove/$bucket",
-            body = body,
-        ).deserialize()
+        return client
+            .post(
+                endpoint = "/storage/v1/object/remove/$bucket",
+                body = body,
+            ).deserialize()
     }
+
     override suspend fun createSignedUrl(
         bucket: String,
         path: String,
@@ -316,13 +349,15 @@ internal class StorageClientImpl(
         fileName: String?,
         transform: ImageTransformOptions?,
     ): SupabaseResult<String> {
-        val body = defaultJson.encodeToString(
-            SignedUrlRequest(
-                expiresIn = expiresIn,
-                transform = transform?.toRequest(),
-            ),
-        )
-        return client.post("/storage/v1/object/sign/${objectRef(bucket, path)}", body = body)
+        val body =
+            defaultJson.encodeToString(
+                SignedUrlRequest(
+                    expiresIn = expiresIn,
+                    transform = transform?.toRequest(),
+                ),
+            )
+        return client
+            .post("/storage/v1/object/sign/${objectRef(bucket, path)}", body = body)
             .deserialize<SignedUrlResponse>()
             .map { appendDownloadQuery(resolveStorageUrl(it.signedUrl), download, fileName) }
     }
@@ -335,10 +370,12 @@ internal class StorageClientImpl(
         fileName: String?,
     ): SupabaseResult<List<String>> {
         val body = defaultJson.encodeToString(SignedUrlsRequest(paths = paths, expiresIn = expiresIn))
-        return client.post("/storage/v1/object/sign/$bucket", body = body)
+        return client
+            .post("/storage/v1/object/sign/$bucket", body = body)
             .deserialize<List<SignedUrlItemResponse>>()
             .map { list -> list.map { appendDownloadQuery(resolveStorageUrl(it.signedUrl), download, fileName) } }
     }
+
     override suspend fun createUploadSignedUrl(
         bucket: String,
         path: String,
@@ -346,16 +383,17 @@ internal class StorageClientImpl(
     ): SupabaseResult<String> =
         createUploadSignedUrlWithPath(bucket, path, upsert)
             .map { it.token }
+
     override suspend fun createUploadSignedUrlWithPath(
         bucket: String,
         path: String,
         upsert: Boolean,
     ): SupabaseResult<UploadSignedUrl> =
-        client.post(
-            endpoint = "/storage/v1/object/upload/sign/${objectRef(bucket, path)}",
-            headers = if (upsert) mapOf("x-upsert" to "true") else emptyMap(),
-        )
-            .deserialize<UploadSignedUrlResponse>()
+        client
+            .post(
+                endpoint = "/storage/v1/object/upload/sign/${objectRef(bucket, path)}",
+                headers = if (upsert) mapOf("x-upsert" to "true") else emptyMap(),
+            ).deserialize<UploadSignedUrlResponse>()
             .map { UploadSignedUrl(url = resolveStorageUrl(it.url), token = it.token) }
 
     override suspend fun uploadToSignedUrl(
@@ -367,13 +405,15 @@ internal class StorageClientImpl(
         upsert: Boolean,
         cacheControl: Int?,
     ): SupabaseResult<String> {
-        val headers = buildMap {
-            if (upsert) put("x-upsert", "true")
-        }
-        val qs = buildList {
-            add("token=${encodeQueryComponent(token)}")
-            cacheControl?.let { add("cacheControl=$it") }
-        }.joinToString("&")
+        val headers =
+            buildMap {
+                if (upsert) put("x-upsert", "true")
+            }
+        val qs =
+            buildList {
+                add("token=${encodeQueryComponent(token)}")
+                cacheControl?.let { add("cacheControl=$it") }
+            }.joinToString("&")
         return client.postRaw(
             url = "/storage/v1/object/upload/sign/${objectRef(bucket, path)}?$qs",
             body = data,
@@ -381,6 +421,7 @@ internal class StorageClientImpl(
             headers = headers,
         )
     }
+
     override fun getSignedDownloadUrl(
         bucket: String,
         path: String,
@@ -491,18 +532,20 @@ internal class StorageClientImpl(
         sortOrder: SortOrder?,
         search: String?,
     ): SupabaseResult<List<AnalyticsBucket>> {
-        val query = buildList {
-            limit?.let { add("limit" to it.toString()) }
-            offset?.let { add("offset" to it.toString()) }
-            sortColumn?.let { add("sortColumn" to it) }
-            sortOrder?.let { add("sortOrder" to it.name.lowercase()) }
-            search?.let { add("search" to it) }
-        }
-        val endpoint = if (query.isEmpty()) {
-            "/storage/v1/iceberg/bucket"
-        } else {
-            "/storage/v1/iceberg/bucket?${query.joinToString("&") { (k, v) -> "${encodeQueryComponent(k)}=${encodeQueryComponent(v)}" }}"
-        }
+        val query =
+            buildList {
+                limit?.let { add("limit" to it.toString()) }
+                offset?.let { add("offset" to it.toString()) }
+                sortColumn?.let { add("sortColumn" to it) }
+                sortOrder?.let { add("sortOrder" to it.name.lowercase()) }
+                search?.let { add("search" to it) }
+            }
+        val endpoint =
+            if (query.isEmpty()) {
+                "/storage/v1/iceberg/bucket"
+            } else {
+                "/storage/v1/iceberg/bucket?${query.joinToString("&") { (k, v) -> "${encodeQueryComponent(k)}=${encodeQueryComponent(v)}" }}"
+            }
         return client.get(endpoint).deserialize()
     }
 
@@ -521,7 +564,8 @@ internal class StorageClientImpl(
 
     override suspend fun getVectorBucket(vectorBucketName: String): SupabaseResult<VectorBucket> {
         val body = defaultJson.encodeToString(VectorBucketRequest(vectorBucketName = vectorBucketName))
-        return client.post("/storage/v1/vector/GetVectorBucket", body = body)
+        return client
+            .post("/storage/v1/vector/GetVectorBucket", body = body)
             .deserialize<VectorBucketResponse>()
             .map { it.vectorBucket }
     }
@@ -531,13 +575,14 @@ internal class StorageClientImpl(
         maxResults: Int?,
         nextToken: String?,
     ): SupabaseResult<VectorBucketListResponse> {
-        val body = defaultJson.encodeToString(
-            VectorBucketListRequest(
-                prefix = prefix,
-                maxResults = maxResults,
-                nextToken = nextToken,
-            ),
-        )
+        val body =
+            defaultJson.encodeToString(
+                VectorBucketListRequest(
+                    prefix = prefix,
+                    maxResults = maxResults,
+                    nextToken = nextToken,
+                ),
+            )
         return client.post("/storage/v1/vector/ListVectorBuckets", body = body).deserialize()
     }
 
@@ -554,16 +599,17 @@ internal class StorageClientImpl(
         distanceMetric: VectorDistanceMetric,
         metadataConfiguration: VectorMetadataConfiguration?,
     ): SupabaseResult<Unit> {
-        val body = defaultJson.encodeToString(
-            VectorIndexCreateRequest(
-                vectorBucketName = vectorBucketName,
-                indexName = indexName,
-                dataType = dataType,
-                dimension = dimension,
-                distanceMetric = distanceMetric,
-                metadataConfiguration = metadataConfiguration,
-            ),
-        )
+        val body =
+            defaultJson.encodeToString(
+                VectorIndexCreateRequest(
+                    vectorBucketName = vectorBucketName,
+                    indexName = indexName,
+                    dataType = dataType,
+                    dimension = dimension,
+                    distanceMetric = distanceMetric,
+                    metadataConfiguration = metadataConfiguration,
+                ),
+            )
         return client.post("/storage/v1/vector/CreateIndex", body = body).map { }
     }
 
@@ -571,10 +617,12 @@ internal class StorageClientImpl(
         vectorBucketName: String,
         indexName: String,
     ): SupabaseResult<VectorIndex> {
-        val body = defaultJson.encodeToString(
-            VectorIndexRequest(vectorBucketName = vectorBucketName, indexName = indexName),
-        )
-        return client.post("/storage/v1/vector/GetIndex", body = body)
+        val body =
+            defaultJson.encodeToString(
+                VectorIndexRequest(vectorBucketName = vectorBucketName, indexName = indexName),
+            )
+        return client
+            .post("/storage/v1/vector/GetIndex", body = body)
             .deserialize<VectorIndexResponse>()
             .map { it.index }
     }
@@ -585,14 +633,15 @@ internal class StorageClientImpl(
         maxResults: Int?,
         nextToken: String?,
     ): SupabaseResult<VectorIndexListResponse> {
-        val body = defaultJson.encodeToString(
-            VectorIndexListRequest(
-                vectorBucketName = vectorBucketName,
-                prefix = prefix,
-                maxResults = maxResults,
-                nextToken = nextToken,
-            ),
-        )
+        val body =
+            defaultJson.encodeToString(
+                VectorIndexListRequest(
+                    vectorBucketName = vectorBucketName,
+                    prefix = prefix,
+                    maxResults = maxResults,
+                    nextToken = nextToken,
+                ),
+            )
         return client.post("/storage/v1/vector/ListIndexes", body = body).deserialize()
     }
 
@@ -600,9 +649,10 @@ internal class StorageClientImpl(
         vectorBucketName: String,
         indexName: String,
     ): SupabaseResult<Unit> {
-        val body = defaultJson.encodeToString(
-            VectorIndexRequest(vectorBucketName = vectorBucketName, indexName = indexName),
-        )
+        val body =
+            defaultJson.encodeToString(
+                VectorIndexRequest(vectorBucketName = vectorBucketName, indexName = indexName),
+            )
         return client.post("/storage/v1/vector/DeleteIndex", body = body).map { }
     }
 
@@ -612,9 +662,10 @@ internal class StorageClientImpl(
         vectors: List<VectorObject>,
     ): SupabaseResult<Unit> {
         require(vectors.size in 1..500) { "Vector batch size must be between 1 and 500 items" }
-        val body = defaultJson.encodeToString(
-            VectorPutRequest(vectorBucketName = vectorBucketName, indexName = indexName, vectors = vectors),
-        )
+        val body =
+            defaultJson.encodeToString(
+                VectorPutRequest(vectorBucketName = vectorBucketName, indexName = indexName, vectors = vectors),
+            )
         return client.post("/storage/v1/vector/PutVectors", body = body).map { }
     }
 
@@ -625,16 +676,18 @@ internal class StorageClientImpl(
         returnData: Boolean?,
         returnMetadata: Boolean?,
     ): SupabaseResult<List<VectorMatch>> {
-        val body = defaultJson.encodeToString(
-            VectorGetRequest(
-                vectorBucketName = vectorBucketName,
-                indexName = indexName,
-                keys = keys,
-                returnData = returnData,
-                returnMetadata = returnMetadata,
-            ),
-        )
-        return client.post("/storage/v1/vector/GetVectors", body = body)
+        val body =
+            defaultJson.encodeToString(
+                VectorGetRequest(
+                    vectorBucketName = vectorBucketName,
+                    indexName = indexName,
+                    keys = keys,
+                    returnData = returnData,
+                    returnMetadata = returnMetadata,
+                ),
+            )
+        return client
+            .post("/storage/v1/vector/GetVectors", body = body)
             .deserialize<VectorMatchesResponse>()
             .map { it.vectors }
     }
@@ -657,18 +710,19 @@ internal class StorageClientImpl(
                 }
             }
         }
-        val body = defaultJson.encodeToString(
-            VectorListRequest(
-                vectorBucketName = vectorBucketName,
-                indexName = indexName,
-                maxResults = maxResults,
-                nextToken = nextToken,
-                returnData = returnData,
-                returnMetadata = returnMetadata,
-                segmentCount = segmentCount,
-                segmentIndex = segmentIndex,
-            ),
-        )
+        val body =
+            defaultJson.encodeToString(
+                VectorListRequest(
+                    vectorBucketName = vectorBucketName,
+                    indexName = indexName,
+                    maxResults = maxResults,
+                    nextToken = nextToken,
+                    returnData = returnData,
+                    returnMetadata = returnMetadata,
+                    segmentCount = segmentCount,
+                    segmentIndex = segmentIndex,
+                ),
+            )
         return client.post("/storage/v1/vector/ListVectors", body = body).deserialize()
     }
 
@@ -681,17 +735,18 @@ internal class StorageClientImpl(
         returnDistance: Boolean?,
         returnMetadata: Boolean?,
     ): SupabaseResult<VectorQueryResponse> {
-        val body = defaultJson.encodeToString(
-            VectorQueryRequest(
-                vectorBucketName = vectorBucketName,
-                indexName = indexName,
-                queryVector = queryVector,
-                topK = topK,
-                filter = filter,
-                returnDistance = returnDistance,
-                returnMetadata = returnMetadata,
-            ),
-        )
+        val body =
+            defaultJson.encodeToString(
+                VectorQueryRequest(
+                    vectorBucketName = vectorBucketName,
+                    indexName = indexName,
+                    queryVector = queryVector,
+                    topK = topK,
+                    filter = filter,
+                    returnDistance = returnDistance,
+                    returnMetadata = returnMetadata,
+                ),
+            )
         return client.post("/storage/v1/vector/QueryVectors", body = body).deserialize()
     }
 
@@ -701,9 +756,10 @@ internal class StorageClientImpl(
         keys: List<String>,
     ): SupabaseResult<Unit> {
         require(keys.size in 1..500) { "Keys batch size must be between 1 and 500 items" }
-        val body = defaultJson.encodeToString(
-            VectorDeleteRequest(vectorBucketName = vectorBucketName, indexName = indexName, keys = keys),
-        )
+        val body =
+            defaultJson.encodeToString(
+                VectorDeleteRequest(vectorBucketName = vectorBucketName, indexName = indexName, keys = keys),
+            )
         return client.post("/storage/v1/vector/DeleteVectors", body = body).map { }
     }
 
@@ -724,13 +780,14 @@ internal class StorageClientImpl(
         )
 
     private fun ImageTransformOptions.toQueryString(): String {
-        val params = buildList {
-            width?.let { add("width" to it.toString()) }
-            height?.let { add("height" to it.toString()) }
-            resize?.let { add("resize" to it.name.lowercase()) }
-            format?.let { add("format" to it) }
-            quality?.let { add("quality" to it.toString()) }
-        }
+        val params =
+            buildList {
+                width?.let { add("width" to it.toString()) }
+                height?.let { add("height" to it.toString()) }
+                resize?.let { add("resize" to it.name.lowercase()) }
+                format?.let { add("format" to it) }
+                quality?.let { add("quality" to it.toString()) }
+            }
         return params.joinToString("&") { (k, v) ->
             "${encodeQueryComponent(k)}=${encodeQueryComponent(v)}"
         }
@@ -793,16 +850,18 @@ internal class AnalyticsCatalogClientImpl(
     private var resolvedPrefix: String? = null
 
     override suspend fun loadConfig(): SupabaseResult<JsonObject> =
-        client.get(
-            endpoint = "/storage/v1/iceberg/v1/config",
-            queryParams = listOf("warehouse" to bucketName),
-        ).toJsonObject()
+        client
+            .get(
+                endpoint = "/storage/v1/iceberg/v1/config",
+                queryParams = listOf("warehouse" to bucketName),
+            ).toJsonObject()
 
     override suspend fun loadConfigTyped(): SupabaseResult<IcebergCatalogConfig> =
-        client.get(
-            endpoint = "/storage/v1/iceberg/v1/config",
-            queryParams = listOf("warehouse" to bucketName),
-        ).deserialize()
+        client
+            .get(
+                endpoint = "/storage/v1/iceberg/v1/config",
+                queryParams = listOf("warehouse" to bucketName),
+            ).deserialize()
 
     override suspend fun listNamespaces(
         parent: List<String>?,
@@ -810,11 +869,12 @@ internal class AnalyticsCatalogClientImpl(
         pageSize: Int?,
     ): SupabaseResult<JsonObject> {
         val prefix = resolvePrefix()
-        val query = buildList {
-            parent?.let { add("parent" to it.joinToString("\u001F")) }
-            pageToken?.let { add("pageToken" to it) }
-            pageSize?.let { add("pageSize" to it.toString()) }
-        }
+        val query =
+            buildList {
+                parent?.let { add("parent" to it.joinToString("\u001F")) }
+                pageToken?.let { add("pageToken" to it) }
+                pageSize?.let { add("pageSize" to it.toString()) }
+            }
         return client.get(appendQuery("$prefix/namespaces", query)).toJsonObject()
     }
 
@@ -824,11 +884,12 @@ internal class AnalyticsCatalogClientImpl(
         pageSize: Int?,
     ): SupabaseResult<IcebergNamespaceListResponse> {
         val prefix = resolvePrefix()
-        val query = buildList {
-            parent?.let { add("parent" to it.joinToString("\u001F")) }
-            pageToken?.let { add("pageToken" to it) }
-            pageSize?.let { add("pageSize" to it.toString()) }
-        }
+        val query =
+            buildList {
+                parent?.let { add("parent" to it.joinToString("\u001F")) }
+                pageToken?.let { add("pageToken" to it) }
+                pageSize?.let { add("pageSize" to it.toString()) }
+            }
         return client.get(appendQuery("$prefix/namespaces", query)).deserialize()
     }
 
@@ -837,28 +898,30 @@ internal class AnalyticsCatalogClientImpl(
         properties: Map<String, String>,
     ): SupabaseResult<JsonObject> {
         val prefix = resolvePrefix()
-        val body = defaultJson.encodeToString(
-            buildJsonObject {
-                putJsonArray("namespace") {
-                    namespace.forEach { add(JsonPrimitive(it)) }
-                }
-                if (properties.isNotEmpty()) {
-                    putJsonObject("properties") {
-                        properties.forEach { (key, value) -> put(key, value) }
+        val body =
+            defaultJson.encodeToString(
+                buildJsonObject {
+                    putJsonArray("namespace") {
+                        namespace.forEach { add(JsonPrimitive(it)) }
                     }
-                }
-            },
-        )
+                    if (properties.isNotEmpty()) {
+                        putJsonObject("properties") {
+                            properties.forEach { (key, value) -> put(key, value) }
+                        }
+                    }
+                },
+            )
         return client.post("$prefix/namespaces", body = body).toJsonObject()
     }
 
     override suspend fun createNamespaceTyped(
         request: IcebergCreateNamespaceRequest,
     ): SupabaseResult<IcebergNamespaceMetadata> =
-        client.post(
-            endpoint = "${resolvePrefix()}/namespaces",
-            body = defaultJson.encodeToString(request),
-        ).deserialize()
+        client
+            .post(
+                endpoint = "${resolvePrefix()}/namespaces",
+                body = defaultJson.encodeToString(request),
+            ).deserialize()
 
     override suspend fun dropNamespace(namespace: List<String>): SupabaseResult<Unit> =
         client.delete("${resolvePrefix()}/namespaces/${namespace.toIcebergPath()}").map { }
@@ -874,47 +937,52 @@ internal class AnalyticsCatalogClientImpl(
         removals: List<String>?,
         updates: Map<String, String>?,
     ): SupabaseResult<JsonObject> {
-        val body = defaultJson.encodeToString(
-            buildJsonObject {
-                removals?.let {
-                    putJsonArray("removals") {
-                        it.forEach { value -> add(JsonPrimitive(value)) }
+        val body =
+            defaultJson.encodeToString(
+                buildJsonObject {
+                    removals?.let {
+                        putJsonArray("removals") {
+                            it.forEach { value -> add(JsonPrimitive(value)) }
+                        }
                     }
-                }
-                updates?.let {
-                    putJsonObject("updates") {
-                        it.forEach { (key, value) -> put(key, value) }
+                    updates?.let {
+                        putJsonObject("updates") {
+                            it.forEach { (key, value) -> put(key, value) }
+                        }
                     }
-                }
-            },
-        )
-        return client.post(
-            endpoint = "${resolvePrefix()}/namespaces/${namespace.toIcebergPath()}/properties",
-            body = body,
-        ).toJsonObject()
+                },
+            )
+        return client
+            .post(
+                endpoint = "${resolvePrefix()}/namespaces/${namespace.toIcebergPath()}/properties",
+                body = body,
+            ).toJsonObject()
     }
 
     override suspend fun updateNamespacePropertiesTyped(
         namespace: List<String>,
         request: IcebergUpdateNamespacePropertiesRequest,
     ): SupabaseResult<IcebergUpdateNamespacePropertiesResponse> =
-        client.post(
-            endpoint = "${resolvePrefix()}/namespaces/${namespace.toIcebergPath()}/properties",
-            body = defaultJson.encodeToString(request),
-        ).deserialize()
+        client
+            .post(
+                endpoint = "${resolvePrefix()}/namespaces/${namespace.toIcebergPath()}/properties",
+                body = defaultJson.encodeToString(request),
+            ).deserialize()
 
     override suspend fun listTables(
         namespace: List<String>,
         pageToken: String?,
         pageSize: Int?,
     ): SupabaseResult<JsonObject> {
-        val query = buildList {
-            pageToken?.let { add("pageToken" to it) }
-            pageSize?.let { add("pageSize" to it.toString()) }
-        }
-        return client.get(
-            endpoint = appendQuery("${resolvePrefix()}/namespaces/${namespace.toIcebergPath()}/tables", query),
-        ).toJsonObject()
+        val query =
+            buildList {
+                pageToken?.let { add("pageToken" to it) }
+                pageSize?.let { add("pageSize" to it.toString()) }
+            }
+        return client
+            .get(
+                endpoint = appendQuery("${resolvePrefix()}/namespaces/${namespace.toIcebergPath()}/tables", query),
+            ).toJsonObject()
     }
 
     override suspend fun listTablesTyped(
@@ -922,39 +990,44 @@ internal class AnalyticsCatalogClientImpl(
         pageToken: String?,
         pageSize: Int?,
     ): SupabaseResult<IcebergTableListResponse> {
-        val query = buildList {
-            pageToken?.let { add("pageToken" to it) }
-            pageSize?.let { add("pageSize" to it.toString()) }
-        }
-        return client.get(
-            endpoint = appendQuery("${resolvePrefix()}/namespaces/${namespace.toIcebergPath()}/tables", query),
-        ).deserialize()
+        val query =
+            buildList {
+                pageToken?.let { add("pageToken" to it) }
+                pageSize?.let { add("pageSize" to it.toString()) }
+            }
+        return client
+            .get(
+                endpoint = appendQuery("${resolvePrefix()}/namespaces/${namespace.toIcebergPath()}/tables", query),
+            ).deserialize()
     }
 
     override suspend fun createTable(namespace: List<String>, request: JsonObject): SupabaseResult<JsonObject> =
-        client.post(
-            endpoint = "${resolvePrefix()}/namespaces/${namespace.toIcebergPath()}/tables",
-            body = defaultJson.encodeToString(request),
-        ).toJsonObject()
+        client
+            .post(
+                endpoint = "${resolvePrefix()}/namespaces/${namespace.toIcebergPath()}/tables",
+                body = defaultJson.encodeToString(request),
+            ).toJsonObject()
 
     override suspend fun createTableTyped(
         namespace: List<String>,
         request: IcebergTableCreateRequest,
     ): SupabaseResult<IcebergTableMetadataResponse> =
-        client.post(
-            endpoint = "${resolvePrefix()}/namespaces/${namespace.toIcebergPath()}/tables",
-            body = defaultJson.encodeToString(request),
-        ).deserialize()
+        client
+            .post(
+                endpoint = "${resolvePrefix()}/namespaces/${namespace.toIcebergPath()}/tables",
+                body = defaultJson.encodeToString(request),
+            ).deserialize()
 
     override suspend fun updateTable(
         namespace: List<String>,
         name: String,
         request: JsonObject,
     ): SupabaseResult<JsonObject> =
-        client.post(
-            endpoint = "${resolvePrefix()}/namespaces/${namespace.toIcebergPath()}/tables/${encodePathSegment(name)}",
-            body = defaultJson.encodeToString(request),
-        ).toJsonObject()
+        client
+            .post(
+                endpoint = "${resolvePrefix()}/namespaces/${namespace.toIcebergPath()}/tables/${encodePathSegment(name)}",
+                body = defaultJson.encodeToString(request),
+            ).toJsonObject()
 
     override suspend fun commitTable(
         namespace: List<String>,
@@ -968,34 +1041,39 @@ internal class AnalyticsCatalogClientImpl(
         name: String,
         request: IcebergTableCommitRequest,
     ): SupabaseResult<IcebergTableMetadataResponse> =
-        client.post(
-            endpoint = "${resolvePrefix()}/namespaces/${namespace.toIcebergPath()}/tables/${encodePathSegment(name)}",
-            body = defaultJson.encodeToString(request),
-        ).deserialize()
+        client
+            .post(
+                endpoint = "${resolvePrefix()}/namespaces/${namespace.toIcebergPath()}/tables/${encodePathSegment(name)}",
+                body = defaultJson.encodeToString(request),
+            ).deserialize()
 
     override suspend fun dropTable(
         namespace: List<String>,
         name: String,
         purge: Boolean,
     ): SupabaseResult<Unit> =
-        client.delete(
-            endpoint = "${resolvePrefix()}/namespaces/${namespace.toIcebergPath()}/tables/${encodePathSegment(name)}?purgeRequested=$purge",
-        ).map { }
+        client
+            .delete(
+                endpoint = "${resolvePrefix()}/namespaces/${namespace.toIcebergPath()}/tables/${encodePathSegment(name)}?purgeRequested=$purge",
+            ).map { }
 
     override suspend fun loadTable(
         namespace: List<String>,
         name: String,
         snapshots: String?,
     ): SupabaseResult<JsonObject> {
-        val query = buildList {
-            snapshots?.let { add("snapshots" to it) }
-        }
-        return client.get(
-            endpoint = appendQuery(
-                "${resolvePrefix()}/namespaces/${namespace.toIcebergPath()}/tables/${encodePathSegment(name)}",
-                query,
-            ),
-        ).toJsonObject()
+        val query =
+            buildList {
+                snapshots?.let { add("snapshots" to it) }
+            }
+        return client
+            .get(
+                endpoint =
+                    appendQuery(
+                        "${resolvePrefix()}/namespaces/${namespace.toIcebergPath()}/tables/${encodePathSegment(name)}",
+                        query,
+                    ),
+            ).toJsonObject()
     }
 
     override suspend fun loadTableTyped(
@@ -1003,68 +1081,85 @@ internal class AnalyticsCatalogClientImpl(
         name: String,
         snapshots: String?,
     ): SupabaseResult<IcebergTableMetadataResponse> {
-        val query = buildList {
-            snapshots?.let { add("snapshots" to it) }
-        }
-        return client.get(
-            endpoint = appendQuery(
-                "${resolvePrefix()}/namespaces/${namespace.toIcebergPath()}/tables/${encodePathSegment(name)}",
-                query,
-            ),
-        ).deserialize()
+        val query =
+            buildList {
+                snapshots?.let { add("snapshots" to it) }
+            }
+        return client
+            .get(
+                endpoint =
+                    appendQuery(
+                        "${resolvePrefix()}/namespaces/${namespace.toIcebergPath()}/tables/${encodePathSegment(name)}",
+                        query,
+                    ),
+            ).deserialize()
     }
 
     override suspend fun registerTable(namespace: List<String>, request: JsonObject): SupabaseResult<JsonObject> =
-        client.post(
-            endpoint = "${resolvePrefix()}/namespaces/${namespace.toIcebergPath()}/register",
-            body = defaultJson.encodeToString(request),
-        ).toJsonObject()
+        client
+            .post(
+                endpoint = "${resolvePrefix()}/namespaces/${namespace.toIcebergPath()}/register",
+                body = defaultJson.encodeToString(request),
+            ).toJsonObject()
 
     override suspend fun registerTableTyped(
         namespace: List<String>,
         request: IcebergTableRegisterRequest,
     ): SupabaseResult<IcebergTableMetadataResponse> =
-        client.post(
-            endpoint = "${resolvePrefix()}/namespaces/${namespace.toIcebergPath()}/register",
-            body = defaultJson.encodeToString(request),
-        ).deserialize()
+        client
+            .post(
+                endpoint = "${resolvePrefix()}/namespaces/${namespace.toIcebergPath()}/register",
+                body = defaultJson.encodeToString(request),
+            ).deserialize()
 
     override suspend fun renameTable(request: JsonObject): SupabaseResult<Unit> =
-        client.post(
-            endpoint = "${resolvePrefix()}/tables/rename",
-            body = defaultJson.encodeToString(request),
-        ).map { }
+        client
+            .post(
+                endpoint = "${resolvePrefix()}/tables/rename",
+                body = defaultJson.encodeToString(request),
+            ).map { }
 
     override suspend fun renameTableTyped(
         source: IcebergTableIdentifier,
         destination: IcebergTableIdentifier,
     ): SupabaseResult<Unit> =
-        client.post(
-            endpoint = "${resolvePrefix()}/tables/rename",
-            body = defaultJson.encodeToString(IcebergTableRenameRequest(source = source, destination = destination)),
-        ).map { }
+        client
+            .post(
+                endpoint = "${resolvePrefix()}/tables/rename",
+                body = defaultJson.encodeToString(IcebergTableRenameRequest(source = source, destination = destination)),
+            ).map { }
 
     private suspend fun resolvePrefix(): String {
         resolvedPrefix?.let { return it }
-        val prefix = when (val config = loadConfig()) {
-            is SupabaseResult.Success -> config.value.extractIcebergPrefix()
-            is SupabaseResult.Failure -> null
-        } ?: bucketName
+        val prefix =
+            when (val config = loadConfig()) {
+                is SupabaseResult.Success -> config.value.extractIcebergPrefix()
+                is SupabaseResult.Failure -> null
+            } ?: bucketName
         return "/storage/v1/iceberg/v1/$prefix".also { resolvedPrefix = it }
     }
 
     private fun JsonObject.extractIcebergPrefix(): String? =
-        this["overrides"]?.jsonObject?.get("prefix")?.jsonPrimitive?.contentOrNull()
-            ?: this["defaults"]?.jsonObject?.get("prefix")?.jsonPrimitive?.contentOrNull()
+        this["overrides"]
+            ?.jsonObject
+            ?.get("prefix")
+            ?.jsonPrimitive
+            ?.contentOrNull()
+            ?: this["defaults"]
+                ?.jsonObject
+                ?.get("prefix")
+                ?.jsonPrimitive
+                ?.contentOrNull()
 
     private fun JsonPrimitive.contentOrNull(): String? =
         runCatching { content }.getOrNull()
 
     private fun appendQuery(endpoint: String, params: List<Pair<String, String>>): String {
         if (params.isEmpty()) return endpoint
-        val qs = params.joinToString("&") { (key, value) ->
-            "${encodePathSegment(key)}=${encodePathSegment(value)}"
-        }
+        val qs =
+            params.joinToString("&") { (key, value) ->
+                "${encodePathSegment(key)}=${encodePathSegment(value)}"
+            }
         return "$endpoint?$qs"
     }
 }

--- a/supabase-storage/src/commonMain/kotlin/io/github/androidpoet/supabase/storage/models/StorageModels.kt
+++ b/supabase-storage/src/commonMain/kotlin/io/github/androidpoet/supabase/storage/models/StorageModels.kt
@@ -293,14 +293,20 @@ public data class VectorBucketListResponse(
 
 @Serializable
 public enum class VectorDataType {
-    @SerialName("float32") FLOAT32,
+    @SerialName("float32")
+    FLOAT32,
 }
 
 @Serializable
 public enum class VectorDistanceMetric {
-    @SerialName("cosine") COSINE,
-    @SerialName("euclidean") EUCLIDEAN,
-    @SerialName("dotproduct") DOTPRODUCT,
+    @SerialName("cosine")
+    COSINE,
+
+    @SerialName("euclidean")
+    EUCLIDEAN,
+
+    @SerialName("dotproduct")
+    DOTPRODUCT,
 }
 
 @Serializable

--- a/supabase-storage/src/commonTest/kotlin/io/github/androidpoet/supabase/storage/StorageClientExtTest.kt
+++ b/supabase-storage/src/commonTest/kotlin/io/github/androidpoet/supabase/storage/StorageClientExtTest.kt
@@ -25,276 +25,304 @@ import kotlin.test.assertTrue
 
 class StorageClientExtTest {
     @Test
-    fun test_createSignedDownloadUrl_addsDownloadParam() = runTest {
-        val client = FakeStorageClient()
+    fun test_createSignedDownloadUrl_addsDownloadParam() =
+        runTest {
+            val client = FakeStorageClient()
 
-        val result = client.createSignedDownloadUrl(
-            bucket = "avatars",
-            path = "a.png",
-            expiresIn = 60,
-        )
+            val result =
+                client.createSignedDownloadUrl(
+                    bucket = "avatars",
+                    path = "a.png",
+                    expiresIn = 60,
+                )
 
-        assertTrue(result is SupabaseResult.Success)
-        assertEquals("https://example.supabase.co/storage/v1/object/sign/avatars/a.png?token=abc&download", result.value)
-    }
-
-    @Test
-    fun test_createSignedDownloadUrl_encodesFileName() = runTest {
-        val client = FakeStorageClient()
-
-        val result = client.createSignedDownloadUrl(
-            bucket = "avatars",
-            path = "a.png",
-            expiresIn = 60,
-            fileName = "my avatar.png",
-        )
-
-        assertTrue(result is SupabaseResult.Success)
-        assertEquals(
-            "https://example.supabase.co/storage/v1/object/sign/avatars/a.png?token=abc&download=my%20avatar.png",
-            result.value,
-        )
-    }
+            assertTrue(result is SupabaseResult.Success)
+            assertEquals("https://example.supabase.co/storage/v1/object/sign/avatars/a.png?token=abc&download", result.value)
+        }
 
     @Test
-    fun test_createSignedDownloadUrl_passesDownloadOptionsToCoreApi() = runTest {
-        val client = FakeStorageClient()
+    fun test_createSignedDownloadUrl_encodesFileName() =
+        runTest {
+            val client = FakeStorageClient()
 
-        client.createSignedDownloadUrl(
-            bucket = "avatars",
-            path = "a.png",
-            expiresIn = 60,
-            fileName = "avatar.png",
-        )
+            val result =
+                client.createSignedDownloadUrl(
+                    bucket = "avatars",
+                    path = "a.png",
+                    expiresIn = 60,
+                    fileName = "my avatar.png",
+                )
 
-        assertEquals(true, client.lastSignedDownload)
-        assertEquals("avatar.png", client.lastSignedFileName)
-    }
-
-    @Test
-    fun test_createSignedDownloadUrl_transformOverload_passesTransform() = runTest {
-        val client = FakeStorageClient()
-
-        client.createSignedDownloadUrl(
-            bucket = "avatars",
-            path = "a.png",
-            expiresIn = 60,
-            transform = ImageTransformOptions(width = 120),
-        )
-
-        assertEquals(120, client.lastSignedTransform?.width)
-    }
+            assertTrue(result is SupabaseResult.Success)
+            assertEquals(
+                "https://example.supabase.co/storage/v1/object/sign/avatars/a.png?token=abc&download=my%20avatar.png",
+                result.value,
+            )
+        }
 
     @Test
-    fun test_createSignedRenderUrl_setsDownloadFalseAndPassesTransform() = runTest {
-        val client = FakeStorageClient()
+    fun test_createSignedDownloadUrl_passesDownloadOptionsToCoreApi() =
+        runTest {
+            val client = FakeStorageClient()
 
-        client.createSignedRenderUrl(
-            bucket = "avatars",
-            path = "a.png",
-            expiresIn = 60,
-            transform = ImageTransformOptions(height = 240),
-        )
+            client.createSignedDownloadUrl(
+                bucket = "avatars",
+                path = "a.png",
+                expiresIn = 60,
+                fileName = "avatar.png",
+            )
 
-        assertEquals(false, client.lastSignedDownload)
-        assertEquals(240, client.lastSignedTransform?.height)
-    }
-
-    @Test
-    fun test_createSignedDownloadUrls_vararg_routesToListOverload() = runTest {
-        val client = FakeStorageClient()
-
-        val result = client.createSignedDownloadUrls(
-            bucket = "avatars",
-            expiresIn = 60,
-            "a.png",
-            "b.png",
-        )
-
-        assertTrue(result is SupabaseResult.Success)
-        assertEquals(listOf("a.png", "b.png"), client.lastSignedPaths)
-        assertEquals(true, client.lastSignedUrlsDownload)
-    }
+            assertEquals(true, client.lastSignedDownload)
+            assertEquals("avatar.png", client.lastSignedFileName)
+        }
 
     @Test
-    fun test_createSignedDownloadUrls_vararg_withFileName_routesToListOverload() = runTest {
-        val client = FakeStorageClient()
+    fun test_createSignedDownloadUrl_transformOverload_passesTransform() =
+        runTest {
+            val client = FakeStorageClient()
 
-        val result = client.createSignedDownloadUrls(
-            bucket = "avatars",
-            expiresIn = 60,
-            fileName = "avatar.png",
-            "a.png",
-            "b.png",
-        )
+            client.createSignedDownloadUrl(
+                bucket = "avatars",
+                path = "a.png",
+                expiresIn = 60,
+                transform = ImageTransformOptions(width = 120),
+            )
 
-        assertTrue(result is SupabaseResult.Success)
-        assertEquals(listOf("a.png", "b.png"), client.lastSignedPaths)
-        assertEquals(true, client.lastSignedUrlsDownload)
-        assertEquals("avatar.png", client.lastSignedUrlsFileName)
-    }
+            assertEquals(120, client.lastSignedTransform?.width)
+        }
 
     @Test
-    fun test_createSignedRenderUrls_list_appendsTransformQuery() = runTest {
-        val client = FakeStorageClient()
+    fun test_createSignedRenderUrl_setsDownloadFalseAndPassesTransform() =
+        runTest {
+            val client = FakeStorageClient()
 
-        val result = client.createSignedRenderUrls(
-            bucket = "avatars",
-            paths = listOf("a.png"),
-            expiresIn = 60,
-            transform = ImageTransformOptions(width = 200, resize = ResizeMode.COVER),
-        )
+            client.createSignedRenderUrl(
+                bucket = "avatars",
+                path = "a.png",
+                expiresIn = 60,
+                transform = ImageTransformOptions(height = 240),
+            )
 
-        assertTrue(result is SupabaseResult.Success)
-        assertEquals(
-            "https://example.supabase.co/storage/v1/object/sign/avatars/a.png?token=abc&width=200&resize=cover",
-            result.value.first(),
-        )
-    }
+            assertEquals(false, client.lastSignedDownload)
+            assertEquals(240, client.lastSignedTransform?.height)
+        }
 
     @Test
-    fun test_createSignedRenderUrls_vararg_routesAndAppendsTransform() = runTest {
-        val client = FakeStorageClient()
+    fun test_createSignedDownloadUrls_vararg_routesToListOverload() =
+        runTest {
+            val client = FakeStorageClient()
 
-        val result = client.createSignedRenderUrls(
-            bucket = "avatars",
-            expiresIn = 60,
-            transform = ImageTransformOptions(height = 120),
-            "a.png",
-            "b.png",
-        )
+            val result =
+                client.createSignedDownloadUrls(
+                    bucket = "avatars",
+                    expiresIn = 60,
+                    "a.png",
+                    "b.png",
+                )
 
-        assertTrue(result is SupabaseResult.Success)
-        assertEquals(
-            listOf(
-                "https://example.supabase.co/storage/v1/object/sign/avatars/a.png?token=abc&height=120",
-                "https://example.supabase.co/storage/v1/object/sign/avatars/b.png?token=abc&height=120",
-            ),
-            result.value,
-        )
-    }
+            assertTrue(result is SupabaseResult.Success)
+            assertEquals(listOf("a.png", "b.png"), client.lastSignedPaths)
+            assertEquals(true, client.lastSignedUrlsDownload)
+        }
 
     @Test
-    fun test_createSignedDownloadUrlsByPath_returnsPathUrlMap() = runTest {
-        val client = FakeStorageClient()
+    fun test_createSignedDownloadUrls_vararg_withFileName_routesToListOverload() =
+        runTest {
+            val client = FakeStorageClient()
 
-        val result = client.createSignedDownloadUrlsByPath(
-            bucket = "avatars",
-            paths = listOf("a.png", "b.png"),
-            expiresIn = 60,
-        )
+            val result =
+                client.createSignedDownloadUrls(
+                    bucket = "avatars",
+                    expiresIn = 60,
+                    fileName = "avatar.png",
+                    "a.png",
+                    "b.png",
+                )
 
-        assertTrue(result is SupabaseResult.Success)
-        assertEquals(
-            mapOf(
-                "a.png" to "https://example.supabase.co/storage/v1/object/sign/avatars/a.png?token=abc",
-                "b.png" to "https://example.supabase.co/storage/v1/object/sign/avatars/b.png?token=abc",
-            ),
-            result.value,
-        )
-    }
-
-    @Test
-    fun test_createSignedRenderUrlsByPath_returnsPathUrlMapWithTransformQuery() = runTest {
-        val client = FakeStorageClient()
-
-        val result = client.createSignedRenderUrlsByPath(
-            bucket = "avatars",
-            paths = listOf("a.png", "b.png"),
-            expiresIn = 60,
-            transform = ImageTransformOptions(width = 200),
-        )
-
-        assertTrue(result is SupabaseResult.Success)
-        assertEquals(
-            mapOf(
-                "a.png" to "https://example.supabase.co/storage/v1/object/sign/avatars/a.png?token=abc&width=200",
-                "b.png" to "https://example.supabase.co/storage/v1/object/sign/avatars/b.png?token=abc&width=200",
-            ),
-            result.value,
-        )
-    }
+            assertTrue(result is SupabaseResult.Success)
+            assertEquals(listOf("a.png", "b.png"), client.lastSignedPaths)
+            assertEquals(true, client.lastSignedUrlsDownload)
+            assertEquals("avatar.png", client.lastSignedUrlsFileName)
+        }
 
     @Test
-    fun test_createSignedDownloadUrlsByPath_vararg_routesToListOverload() = runTest {
-        val client = FakeStorageClient()
+    fun test_createSignedRenderUrls_list_appendsTransformQuery() =
+        runTest {
+            val client = FakeStorageClient()
 
-        val result = client.createSignedDownloadUrlsByPath(
-            bucket = "avatars",
-            expiresIn = 60,
-            "a.png",
-            "b.png",
-        )
+            val result =
+                client.createSignedRenderUrls(
+                    bucket = "avatars",
+                    paths = listOf("a.png"),
+                    expiresIn = 60,
+                    transform = ImageTransformOptions(width = 200, resize = ResizeMode.COVER),
+                )
 
-        assertTrue(result is SupabaseResult.Success)
-        assertEquals(
-            mapOf(
-                "a.png" to "https://example.supabase.co/storage/v1/object/sign/avatars/a.png?token=abc",
-                "b.png" to "https://example.supabase.co/storage/v1/object/sign/avatars/b.png?token=abc",
-            ),
-            result.value,
-        )
-    }
-
-    @Test
-    fun test_createSignedRenderUrlsByPath_vararg_routesToListOverload() = runTest {
-        val client = FakeStorageClient()
-
-        val result = client.createSignedRenderUrlsByPath(
-            bucket = "avatars",
-            expiresIn = 60,
-            transform = ImageTransformOptions(height = 100),
-            "a.png",
-            "b.png",
-        )
-
-        assertTrue(result is SupabaseResult.Success)
-        assertEquals(
-            mapOf(
-                "a.png" to "https://example.supabase.co/storage/v1/object/sign/avatars/a.png?token=abc&height=100",
-                "b.png" to "https://example.supabase.co/storage/v1/object/sign/avatars/b.png?token=abc&height=100",
-            ),
-            result.value,
-        )
-    }
+            assertTrue(result is SupabaseResult.Success)
+            assertEquals(
+                "https://example.supabase.co/storage/v1/object/sign/avatars/a.png?token=abc&width=200&resize=cover",
+                result.value.first(),
+            )
+        }
 
     @Test
-    fun test_remove_vararg_routesToListOverload() = runTest {
-        val client = FakeStorageClient()
+    fun test_createSignedRenderUrls_vararg_routesAndAppendsTransform() =
+        runTest {
+            val client = FakeStorageClient()
 
-        val result = client.remove(
-            bucket = "avatars",
-            "a.png",
-            "b.png",
-        )
+            val result =
+                client.createSignedRenderUrls(
+                    bucket = "avatars",
+                    expiresIn = 60,
+                    transform = ImageTransformOptions(height = 120),
+                    "a.png",
+                    "b.png",
+                )
 
-        assertTrue(result is SupabaseResult.Success)
-        assertEquals(listOf("a.png", "b.png"), client.lastRemovedPaths)
-    }
+            assertTrue(result is SupabaseResult.Success)
+            assertEquals(
+                listOf(
+                    "https://example.supabase.co/storage/v1/object/sign/avatars/a.png?token=abc&height=120",
+                    "https://example.supabase.co/storage/v1/object/sign/avatars/b.png?token=abc&height=120",
+                ),
+                result.value,
+            )
+        }
 
     @Test
-    fun test_removeWithResult_vararg_routesToListOverload() = runTest {
-        val client = FakeStorageClient()
+    fun test_createSignedDownloadUrlsByPath_returnsPathUrlMap() =
+        runTest {
+            val client = FakeStorageClient()
 
-        val result = client.removeWithResult(
-            bucket = "avatars",
-            "a.png",
-        )
+            val result =
+                client.createSignedDownloadUrlsByPath(
+                    bucket = "avatars",
+                    paths = listOf("a.png", "b.png"),
+                    expiresIn = 60,
+                )
 
-        assertTrue(result is SupabaseResult.Success)
-        assertEquals(listOf("a.png"), client.lastRemovedPaths)
-    }
+            assertTrue(result is SupabaseResult.Success)
+            assertEquals(
+                mapOf(
+                    "a.png" to "https://example.supabase.co/storage/v1/object/sign/avatars/a.png?token=abc",
+                    "b.png" to "https://example.supabase.co/storage/v1/object/sign/avatars/b.png?token=abc",
+                ),
+                result.value,
+            )
+        }
+
+    @Test
+    fun test_createSignedRenderUrlsByPath_returnsPathUrlMapWithTransformQuery() =
+        runTest {
+            val client = FakeStorageClient()
+
+            val result =
+                client.createSignedRenderUrlsByPath(
+                    bucket = "avatars",
+                    paths = listOf("a.png", "b.png"),
+                    expiresIn = 60,
+                    transform = ImageTransformOptions(width = 200),
+                )
+
+            assertTrue(result is SupabaseResult.Success)
+            assertEquals(
+                mapOf(
+                    "a.png" to "https://example.supabase.co/storage/v1/object/sign/avatars/a.png?token=abc&width=200",
+                    "b.png" to "https://example.supabase.co/storage/v1/object/sign/avatars/b.png?token=abc&width=200",
+                ),
+                result.value,
+            )
+        }
+
+    @Test
+    fun test_createSignedDownloadUrlsByPath_vararg_routesToListOverload() =
+        runTest {
+            val client = FakeStorageClient()
+
+            val result =
+                client.createSignedDownloadUrlsByPath(
+                    bucket = "avatars",
+                    expiresIn = 60,
+                    "a.png",
+                    "b.png",
+                )
+
+            assertTrue(result is SupabaseResult.Success)
+            assertEquals(
+                mapOf(
+                    "a.png" to "https://example.supabase.co/storage/v1/object/sign/avatars/a.png?token=abc",
+                    "b.png" to "https://example.supabase.co/storage/v1/object/sign/avatars/b.png?token=abc",
+                ),
+                result.value,
+            )
+        }
+
+    @Test
+    fun test_createSignedRenderUrlsByPath_vararg_routesToListOverload() =
+        runTest {
+            val client = FakeStorageClient()
+
+            val result =
+                client.createSignedRenderUrlsByPath(
+                    bucket = "avatars",
+                    expiresIn = 60,
+                    transform = ImageTransformOptions(height = 100),
+                    "a.png",
+                    "b.png",
+                )
+
+            assertTrue(result is SupabaseResult.Success)
+            assertEquals(
+                mapOf(
+                    "a.png" to "https://example.supabase.co/storage/v1/object/sign/avatars/a.png?token=abc&height=100",
+                    "b.png" to "https://example.supabase.co/storage/v1/object/sign/avatars/b.png?token=abc&height=100",
+                ),
+                result.value,
+            )
+        }
+
+    @Test
+    fun test_remove_vararg_routesToListOverload() =
+        runTest {
+            val client = FakeStorageClient()
+
+            val result =
+                client.remove(
+                    bucket = "avatars",
+                    "a.png",
+                    "b.png",
+                )
+
+            assertTrue(result is SupabaseResult.Success)
+            assertEquals(listOf("a.png", "b.png"), client.lastRemovedPaths)
+        }
+
+    @Test
+    fun test_removeWithResult_vararg_routesToListOverload() =
+        runTest {
+            val client = FakeStorageClient()
+
+            val result =
+                client.removeWithResult(
+                    bucket = "avatars",
+                    "a.png",
+                )
+
+            assertTrue(result is SupabaseResult.Success)
+            assertEquals(listOf("a.png"), client.lastRemovedPaths)
+        }
 
     @Test
     fun test_getPublicUrlsByPath_buildsMap() {
         val client = FakeStorageClient()
 
-        val urls = client.getPublicUrlsByPath(
-            bucket = "avatars",
-            paths = listOf("a.png", "b.png"),
-            download = true,
-            fileName = "avatar.png",
-        )
+        val urls =
+            client.getPublicUrlsByPath(
+                bucket = "avatars",
+                paths = listOf("a.png", "b.png"),
+                download = true,
+                fileName = "avatar.png",
+            )
 
         assertEquals(
             mapOf(
@@ -309,12 +337,13 @@ class StorageClientExtTest {
     fun test_getPublicUrls_vararg_withOptions_buildsList() {
         val client = FakeStorageClient()
 
-        val urls = client.getPublicUrls(
-            bucket = "avatars",
-            download = true,
-            fileName = "avatar.png",
-            paths = arrayOf("a.png", "b.png"),
-        )
+        val urls =
+            client.getPublicUrls(
+                bucket = "avatars",
+                download = true,
+                fileName = "avatar.png",
+                paths = arrayOf("a.png", "b.png"),
+            )
 
         assertEquals(
             listOf(
@@ -329,10 +358,11 @@ class StorageClientExtTest {
     fun test_getAuthenticatedUrls_buildsList() {
         val client = FakeStorageClient()
 
-        val urls = client.getAuthenticatedUrls(
-            bucket = "avatars",
-            paths = listOf("a.png", "b.png"),
-        )
+        val urls =
+            client.getAuthenticatedUrls(
+                bucket = "avatars",
+                paths = listOf("a.png", "b.png"),
+            )
 
         assertEquals(
             listOf(
@@ -347,11 +377,12 @@ class StorageClientExtTest {
     fun test_getPublicRenderUrlsByPath_buildsMap() {
         val client = FakeStorageClient()
 
-        val urls = client.getPublicRenderUrlsByPath(
-            bucket = "avatars",
-            paths = listOf("a.png"),
-            transform = ImageTransformOptions(width = 100),
-        )
+        val urls =
+            client.getPublicRenderUrlsByPath(
+                bucket = "avatars",
+                paths = listOf("a.png"),
+                transform = ImageTransformOptions(width = 100),
+            )
 
         assertEquals(
             mapOf(
@@ -365,12 +396,13 @@ class StorageClientExtTest {
     fun test_getAuthenticatedRenderUrls_vararg_buildsList() {
         val client = FakeStorageClient()
 
-        val urls = client.getAuthenticatedRenderUrls(
-            bucket = "avatars",
-            transform = ImageTransformOptions(width = 40),
-            "a.png",
-            "b.png",
-        )
+        val urls =
+            client.getAuthenticatedRenderUrls(
+                bucket = "avatars",
+                transform = ImageTransformOptions(width = 40),
+                "a.png",
+                "b.png",
+            )
 
         assertEquals(
             listOf(
@@ -392,24 +424,42 @@ private class FakeStorageClient : StorageClient {
     var lastSignedUrlsDownload: Boolean? = null
     var lastSignedUrlsFileName: String? = null
     var lastRemovedPaths: List<String> = emptyList()
+
     override suspend fun listBuckets(limit: Int?, offset: Int?, sortColumn: String?, sortOrder: SortOrder?, search: String?): SupabaseResult<List<Bucket>> =
         SupabaseResult.Success(emptyList())
+
     override suspend fun getBucket(id: String): SupabaseResult<Bucket> = error("not used")
+
     override suspend fun createBucket(id: String, name: String, public: Boolean, fileSizeLimit: Long?, allowedMimeTypes: List<String>?): SupabaseResult<Bucket> = error("not used")
+
     override suspend fun updateBucket(id: String, name: String?, public: Boolean?, fileSizeLimit: Long?, allowedMimeTypes: List<String>?): SupabaseResult<Bucket> = error("not used")
+
     override suspend fun deleteBucket(id: String): SupabaseResult<Unit> = error("not used")
+
     override suspend fun emptyBucket(id: String): SupabaseResult<Unit> = error("not used")
+
     override suspend fun upload(bucket: String, path: String, data: ByteArray, contentType: String, upsert: Boolean, cacheControl: Int?): SupabaseResult<String> = error("not used")
+
     override suspend fun update(bucket: String, path: String, data: ByteArray, contentType: String, upsert: Boolean, cacheControl: Int?): SupabaseResult<String> = error("not used")
+
     override suspend fun download(bucket: String, path: String): SupabaseResult<String> = error("not used")
+
     override suspend fun downloadPublic(bucket: String, path: String): SupabaseResult<String> = error("not used")
+
     override suspend fun download(bucket: String, path: String, download: Boolean, fileName: String?): SupabaseResult<String> = error("not used")
+
     override suspend fun downloadPublic(bucket: String, path: String, download: Boolean, fileName: String?): SupabaseResult<String> = error("not used")
+
     override suspend fun info(bucket: String, path: String): SupabaseResult<FileObject> = error("not used")
+
     override suspend fun infoPublic(bucket: String, path: String): SupabaseResult<FileObject> = error("not used")
+
     override suspend fun exists(bucket: String, path: String): SupabaseResult<Boolean> = error("not used")
+
     override suspend fun existsPublic(bucket: String, path: String): SupabaseResult<Boolean> = error("not used")
+
     override suspend fun list(bucket: String, prefix: String, limit: Int, offset: Int, sortBy: String?, sortOrder: SortOrder, search: String?): SupabaseResult<List<FileObject>> = error("not used")
+
     override suspend fun listV2(
         bucket: String,
         prefix: String?,
@@ -419,17 +469,23 @@ private class FakeStorageClient : StorageClient {
         sortBy: String?,
         sortOrder: SortOrder,
     ): SupabaseResult<ObjectListV2Result> = error("not used")
+
     override suspend fun move(bucket: String, fromPath: String, toPath: String, destinationBucket: String?): SupabaseResult<Unit> = error("not used")
+
     override suspend fun deleteObject(bucket: String, path: String): SupabaseResult<Unit> = error("not used")
+
     override suspend fun copy(bucket: String, fromPath: String, toPath: String, destinationBucket: String?, copyMetadata: Boolean?): SupabaseResult<Unit> = error("not used")
+
     override suspend fun remove(bucket: String, paths: List<String>): SupabaseResult<Unit> {
         lastRemovedPaths = paths
         return SupabaseResult.Success(Unit)
     }
+
     override suspend fun removeWithResult(bucket: String, paths: List<String>): SupabaseResult<List<FileObject>> {
         lastRemovedPaths = paths
         return SupabaseResult.Success(emptyList())
     }
+
     override suspend fun createSignedUrl(
         bucket: String,
         path: String,
@@ -444,22 +500,25 @@ private class FakeStorageClient : StorageClient {
         lastSignedPath = path
         lastSignedBucket = bucket
         val base = "https://example.supabase.co/storage/v1/object/sign/$bucket/$path?token=abc"
-        val value = when {
-            !download -> {
-                val transformQuery = buildList {
-                    transform?.width?.let { add("width=$it") }
-                    transform?.height?.let { add("height=$it") }
-                    transform?.resize?.let { add("resize=${it.name.lowercase()}") }
-                    transform?.format?.let { add("format=$it") }
-                    transform?.quality?.let { add("quality=$it") }
-                }.joinToString("&")
-                if (transformQuery.isBlank()) base else "$base&$transformQuery"
+        val value =
+            when {
+                !download -> {
+                    val transformQuery =
+                        buildList {
+                            transform?.width?.let { add("width=$it") }
+                            transform?.height?.let { add("height=$it") }
+                            transform?.resize?.let { add("resize=${it.name.lowercase()}") }
+                            transform?.format?.let { add("format=$it") }
+                            transform?.quality?.let { add("quality=$it") }
+                        }.joinToString("&")
+                    if (transformQuery.isBlank()) base else "$base&$transformQuery"
+                }
+                fileName == null -> "$base&download"
+                else -> "$base&download=my%20avatar.png"
             }
-            fileName == null -> "$base&download"
-            else -> "$base&download=my%20avatar.png"
-        }
         return SupabaseResult.Success(value)
     }
+
     override suspend fun createSignedUrls(
         bucket: String,
         paths: List<String>,
@@ -472,13 +531,19 @@ private class FakeStorageClient : StorageClient {
         lastSignedUrlsFileName = fileName
         return SupabaseResult.Success(paths.map { "https://example.supabase.co/storage/v1/object/sign/$bucket/$it?token=abc" })
     }
+
     override suspend fun createUploadSignedUrl(bucket: String, path: String, upsert: Boolean): SupabaseResult<String> = error("not used")
+
     override suspend fun createUploadSignedUrlWithPath(bucket: String, path: String, upsert: Boolean): SupabaseResult<UploadSignedUrl> = error("not used")
+
     override suspend fun uploadToSignedUrl(bucket: String, path: String, token: String, data: ByteArray, contentType: String, upsert: Boolean, cacheControl: Int?): SupabaseResult<String> = error("not used")
+
     override fun getPublicUrl(bucket: String, path: String, transform: ImageTransformOptions?): String =
         "https://example.supabase.co/storage/v1/object/public/$bucket/$path"
+
     override fun getAuthenticatedUrl(bucket: String, path: String, transform: ImageTransformOptions?): String =
         "https://example.supabase.co/storage/v1/object/authenticated/$bucket/$path"
+
     override fun getPublicUrl(bucket: String, path: String, download: Boolean, fileName: String?, transform: ImageTransformOptions?): String {
         val base = "https://example.supabase.co/storage/v1/object/public/$bucket/$path"
         return when {
@@ -487,6 +552,7 @@ private class FakeStorageClient : StorageClient {
             else -> "$base?download=$fileName"
         }
     }
+
     override fun getAuthenticatedUrl(bucket: String, path: String, download: Boolean, fileName: String?, transform: ImageTransformOptions?): String {
         val base = "https://example.supabase.co/storage/v1/object/authenticated/$bucket/$path"
         return when {
@@ -495,23 +561,35 @@ private class FakeStorageClient : StorageClient {
             else -> "$base?download=$fileName"
         }
     }
+
     override fun getPublicRenderUrl(bucket: String, path: String, transform: ImageTransformOptions?): String {
         val base = "https://example.supabase.co/storage/v1/render/image/public/$bucket/$path"
         return transform?.width?.let { "$base?width=$it" } ?: base
     }
+
     override fun getAuthenticatedRenderUrl(bucket: String, path: String, transform: ImageTransformOptions?): String {
         val base = "https://example.supabase.co/storage/v1/render/image/authenticated/$bucket/$path"
         return transform?.width?.let { "$base?width=$it" } ?: base
     }
+
     override fun getSignedDownloadUrl(bucket: String, path: String, token: String, download: Boolean, fileName: String?): String = error("not used")
+
     override suspend fun createAnalyticsBucket(name: String): SupabaseResult<AnalyticsBucket> = error("not used")
+
     override suspend fun listAnalyticsBuckets(limit: Int?, offset: Int?, sortColumn: String?, sortOrder: SortOrder?, search: String?): SupabaseResult<List<AnalyticsBucket>> = error("not used")
+
     override suspend fun deleteAnalyticsBucket(name: String): SupabaseResult<Unit> = error("not used")
+
     override fun analyticsCatalog(bucketName: String): AnalyticsCatalogClient = error("not used")
+
     override suspend fun createVectorBucket(vectorBucketName: String): SupabaseResult<Unit> = error("not used")
+
     override suspend fun getVectorBucket(vectorBucketName: String): SupabaseResult<VectorBucket> = error("not used")
+
     override suspend fun listVectorBuckets(prefix: String?, maxResults: Int?, nextToken: String?): SupabaseResult<VectorBucketListResponse> = error("not used")
+
     override suspend fun deleteVectorBucket(vectorBucketName: String): SupabaseResult<Unit> = error("not used")
+
     override suspend fun createVectorIndex(
         vectorBucketName: String,
         indexName: String,
@@ -520,11 +598,17 @@ private class FakeStorageClient : StorageClient {
         distanceMetric: VectorDistanceMetric,
         metadataConfiguration: VectorMetadataConfiguration?,
     ): SupabaseResult<Unit> = error("not used")
+
     override suspend fun getVectorIndex(vectorBucketName: String, indexName: String): SupabaseResult<VectorIndex> = error("not used")
+
     override suspend fun listVectorIndexes(vectorBucketName: String, prefix: String?, maxResults: Int?, nextToken: String?): SupabaseResult<VectorIndexListResponse> = error("not used")
+
     override suspend fun deleteVectorIndex(vectorBucketName: String, indexName: String): SupabaseResult<Unit> = error("not used")
+
     override suspend fun putVectors(vectorBucketName: String, indexName: String, vectors: List<VectorObject>): SupabaseResult<Unit> = error("not used")
+
     override suspend fun getVectors(vectorBucketName: String, indexName: String, keys: List<String>, returnData: Boolean?, returnMetadata: Boolean?): SupabaseResult<List<VectorMatch>> = error("not used")
+
     override suspend fun listVectors(
         vectorBucketName: String,
         indexName: String,
@@ -535,6 +619,7 @@ private class FakeStorageClient : StorageClient {
         segmentCount: Int?,
         segmentIndex: Int?,
     ): SupabaseResult<VectorListResponse> = error("not used")
+
     override suspend fun queryVectors(
         vectorBucketName: String,
         indexName: String,
@@ -544,5 +629,6 @@ private class FakeStorageClient : StorageClient {
         returnDistance: Boolean?,
         returnMetadata: Boolean?,
     ): SupabaseResult<VectorQueryResponse> = error("not used")
+
     override suspend fun deleteVectors(vectorBucketName: String, indexName: String, keys: List<String>): SupabaseResult<Unit> = error("not used")
 }

--- a/supabase-storage/src/commonTest/kotlin/io/github/androidpoet/supabase/storage/StorageClientImplTest.kt
+++ b/supabase-storage/src/commonTest/kotlin/io/github/androidpoet/supabase/storage/StorageClientImplTest.kt
@@ -24,357 +24,400 @@ import kotlin.test.assertTrue
 
 class StorageClientImplTest {
     @Test
-    fun test_listBuckets_includesQueryParams() = runTest {
-        val client = FakeSupabaseClient()
-        val sut = StorageClientImpl(client)
+    fun test_listBuckets_includesQueryParams() =
+        runTest {
+            val client = FakeSupabaseClient()
+            val sut = StorageClientImpl(client)
 
-        val result = sut.listBuckets(
-            limit = 10,
-            offset = 20,
-            sortColumn = "name",
-            sortOrder = SortOrder.DESC,
-            search = "prod",
-        )
+            val result =
+                sut.listBuckets(
+                    limit = 10,
+                    offset = 20,
+                    sortColumn = "name",
+                    sortOrder = SortOrder.DESC,
+                    search = "prod",
+                )
 
-        assertTrue(result is SupabaseResult.Success)
-        assertEquals("/storage/v1/bucket", client.lastGetEndpoint)
-        assertEquals(
-            listOf(
-                "limit" to "10",
-                "offset" to "20",
-                "sortColumn" to "name",
-                "sortOrder" to "desc",
-                "search" to "prod",
-            ),
-            client.lastGetQueryParams,
-        )
-    }
-
-    @Test
-    fun test_createSignedUrls_usesBatchSignEndpoint() = runTest {
-        val client = FakeSupabaseClient()
-        val sut = StorageClientImpl(client)
-
-        val result = sut.createSignedUrls(
-            bucket = "avatars",
-            paths = listOf("a.png", "b.png"),
-            expiresIn = 60,
-        )
-
-        assertEquals("/storage/v1/object/sign/avatars", client.lastPostEndpoint)
-        assertTrue(result is SupabaseResult.Success)
-        assertEquals(2, result.value.size)
-        assertEquals("https://example.supabase.co/sign/a", result.value[0])
-    }
+            assertTrue(result is SupabaseResult.Success)
+            assertEquals("/storage/v1/bucket", client.lastGetEndpoint)
+            assertEquals(
+                listOf(
+                    "limit" to "10",
+                    "offset" to "20",
+                    "sortColumn" to "name",
+                    "sortOrder" to "desc",
+                    "search" to "prod",
+                ),
+                client.lastGetQueryParams,
+            )
+        }
 
     @Test
-    fun test_listV2_postsOptionsToListV2Endpoint() = runTest {
-        val client = FakeSupabaseClient()
-        val sut = StorageClientImpl(client)
+    fun test_createSignedUrls_usesBatchSignEndpoint() =
+        runTest {
+            val client = FakeSupabaseClient()
+            val sut = StorageClientImpl(client)
 
-        val result = sut.listV2(
-            bucket = "avatars",
-            prefix = "folder/",
-            cursor = "cursor-1",
-            limit = 50,
-            withDelimiter = true,
-            sortBy = "created_at",
-            sortOrder = SortOrder.DESC,
-        )
+            val result =
+                sut.createSignedUrls(
+                    bucket = "avatars",
+                    paths = listOf("a.png", "b.png"),
+                    expiresIn = 60,
+                )
 
-        assertTrue(result is SupabaseResult.Success)
-        assertEquals("/storage/v1/object/list-v2/avatars", client.lastPostEndpoint)
-        assertEquals(
-            """{"prefix":"folder/","cursor":"cursor-1","limit":50,"with_delimiter":true,"sortBy":{"column":"created_at","order":"desc"}}""",
-            client.lastPostBody,
-        )
-        assertEquals(true, result.value.hasNext)
-        assertEquals("nested", result.value.folders.first().name)
-        assertEquals("avatar.png", result.value.objects.first().name)
-        assertEquals("cursor-2", result.value.nextCursor)
-    }
+            assertEquals("/storage/v1/object/sign/avatars", client.lastPostEndpoint)
+            assertTrue(result is SupabaseResult.Success)
+            assertEquals(2, result.value.size)
+            assertEquals("https://example.supabase.co/sign/a", result.value[0])
+        }
 
     @Test
-    fun test_createSignedUrl_withDownload_addsDownloadQuery() = runTest {
-        val client = FakeSupabaseClient()
-        val sut = StorageClientImpl(client)
+    fun test_listV2_postsOptionsToListV2Endpoint() =
+        runTest {
+            val client = FakeSupabaseClient()
+            val sut = StorageClientImpl(client)
 
-        val result = sut.createSignedUrl(
-            bucket = "avatars",
-            path = "a.png",
-            expiresIn = 120,
-            download = true,
-            fileName = "my avatar.png",
-        )
+            val result =
+                sut.listV2(
+                    bucket = "avatars",
+                    prefix = "folder/",
+                    cursor = "cursor-1",
+                    limit = 50,
+                    withDelimiter = true,
+                    sortBy = "created_at",
+                    sortOrder = SortOrder.DESC,
+                )
 
-        assertTrue(result is SupabaseResult.Success)
-        assertEquals("https://example.supabase.co/sign/single?download=my%20avatar.png", result.value)
-    }
-
-    @Test
-    fun test_createSignedUrl_returnsResolvedAbsoluteUrl() = runTest {
-        val client = FakeSupabaseClient()
-        val sut = StorageClientImpl(client)
-
-        val result = sut.createSignedUrl(
-            bucket = "avatars",
-            path = "a.png",
-            expiresIn = 120,
-        )
-
-        assertTrue(result is SupabaseResult.Success)
-        assertEquals("https://example.supabase.co/sign/single", result.value)
-    }
-
-    @Test
-    fun test_createUploadSignedUrl_returnsToken() = runTest {
-        val client = FakeSupabaseClient()
-        val sut = StorageClientImpl(client)
-
-        val result = sut.createUploadSignedUrl(
-            bucket = "avatars",
-            path = "a.png",
-        )
-
-        assertEquals("/storage/v1/object/upload/sign/avatars/a.png", client.lastPostEndpoint)
-        assertTrue(result is SupabaseResult.Success)
-        assertEquals("upload-token-123", result.value)
-    }
+            assertTrue(result is SupabaseResult.Success)
+            assertEquals("/storage/v1/object/list-v2/avatars", client.lastPostEndpoint)
+            assertEquals(
+                """{"prefix":"folder/","cursor":"cursor-1","limit":50,"with_delimiter":true,"sortBy":{"column":"created_at","order":"desc"}}""",
+                client.lastPostBody,
+            )
+            assertEquals(true, result.value.hasNext)
+            assertEquals(
+                "nested",
+                result.value.folders
+                    .first()
+                    .name,
+            )
+            assertEquals(
+                "avatar.png",
+                result.value.objects
+                    .first()
+                    .name,
+            )
+            assertEquals("cursor-2", result.value.nextCursor)
+        }
 
     @Test
-    fun test_createUploadSignedUrl_withUpsert_setsUpsertHeader() = runTest {
-        val client = FakeSupabaseClient()
-        val sut = StorageClientImpl(client)
+    fun test_createSignedUrl_withDownload_addsDownloadQuery() =
+        runTest {
+            val client = FakeSupabaseClient()
+            val sut = StorageClientImpl(client)
 
-        sut.createUploadSignedUrl(
-            bucket = "avatars",
-            path = "a.png",
-            upsert = true,
-        )
+            val result =
+                sut.createSignedUrl(
+                    bucket = "avatars",
+                    path = "a.png",
+                    expiresIn = 120,
+                    download = true,
+                    fileName = "my avatar.png",
+                )
 
-        assertEquals("true", client.lastPostHeaders["x-upsert"])
-    }
-
-    @Test
-    fun test_createUploadSignedUrlWithPath_returnsResolvedUrlAndToken() = runTest {
-        val client = FakeSupabaseClient()
-        val sut = StorageClientImpl(client)
-
-        val result = sut.createUploadSignedUrlWithPath(
-            bucket = "avatars",
-            path = "a.png",
-        )
-
-        assertTrue(result is SupabaseResult.Success)
-        assertEquals("https://example.supabase.co/upload/sign/path", result.value.url)
-        assertEquals("upload-token-123", result.value.token)
-    }
+            assertTrue(result is SupabaseResult.Success)
+            assertEquals("https://example.supabase.co/sign/single?download=my%20avatar.png", result.value)
+        }
 
     @Test
-    fun test_updateBucket_usesPutBucketEndpoint() = runTest {
-        val client = FakeSupabaseClient()
-        val sut = StorageClientImpl(client)
+    fun test_createSignedUrl_returnsResolvedAbsoluteUrl() =
+        runTest {
+            val client = FakeSupabaseClient()
+            val sut = StorageClientImpl(client)
 
-        val result = sut.updateBucket(
-            id = "avatars",
-            public = true,
-        )
+            val result =
+                sut.createSignedUrl(
+                    bucket = "avatars",
+                    path = "a.png",
+                    expiresIn = 120,
+                )
 
-        assertEquals("/storage/v1/bucket/avatars", client.lastPostEndpoint)
-        assertTrue(result is SupabaseResult.Success)
-    }
-
-    @Test
-    fun test_uploadToSignedUrl_usesSignedUploadPathWithToken() = runTest {
-        val client = FakeSupabaseClient()
-        val sut = StorageClientImpl(client)
-
-        sut.uploadToSignedUrl(
-            bucket = "avatars",
-            path = "a.png",
-            token = "abc",
-            data = byteArrayOf(1, 2, 3),
-            upsert = true,
-        )
-
-        assertEquals("/storage/v1/object/upload/sign/avatars/a.png?token=abc", client.lastPostRawUrl)
-        assertEquals("true", client.lastPostRawHeaders["x-upsert"])
-    }
+            assertTrue(result is SupabaseResult.Success)
+            assertEquals("https://example.supabase.co/sign/single", result.value)
+        }
 
     @Test
-    fun test_uploadToSignedUrl_withCacheControl_includesCacheControlQuery() = runTest {
-        val client = FakeSupabaseClient()
-        val sut = StorageClientImpl(client)
+    fun test_createUploadSignedUrl_returnsToken() =
+        runTest {
+            val client = FakeSupabaseClient()
+            val sut = StorageClientImpl(client)
 
-        sut.uploadToSignedUrl(
-            bucket = "avatars",
-            path = "a.png",
-            token = "abc",
-            data = byteArrayOf(1, 2, 3),
-            cacheControl = 3600,
-        )
+            val result =
+                sut.createUploadSignedUrl(
+                    bucket = "avatars",
+                    path = "a.png",
+                )
 
-        assertEquals("/storage/v1/object/upload/sign/avatars/a.png?token=abc&cacheControl=3600", client.lastPostRawUrl)
-    }
-
-    @Test
-    fun test_update_usesPutRawAndUpsertHeader() = runTest {
-        val client = FakeSupabaseClient()
-        val sut = StorageClientImpl(client)
-
-        sut.update(
-            bucket = "avatars",
-            path = "a.png",
-            data = byteArrayOf(1, 2, 3),
-            upsert = true,
-        )
-
-        assertEquals("/storage/v1/object/avatars/a.png", client.lastPutRawUrl)
-        assertEquals("true", client.lastPutRawHeaders["x-upsert"])
-    }
+            assertEquals("/storage/v1/object/upload/sign/avatars/a.png", client.lastPostEndpoint)
+            assertTrue(result is SupabaseResult.Success)
+            assertEquals("upload-token-123", result.value)
+        }
 
     @Test
-    fun test_upload_withCacheControl_includesCacheControlQuery() = runTest {
-        val client = FakeSupabaseClient()
-        val sut = StorageClientImpl(client)
+    fun test_createUploadSignedUrl_withUpsert_setsUpsertHeader() =
+        runTest {
+            val client = FakeSupabaseClient()
+            val sut = StorageClientImpl(client)
 
-        sut.upload(
-            bucket = "avatars",
-            path = "a.png",
-            data = byteArrayOf(1),
-            cacheControl = 1200,
-        )
+            sut.createUploadSignedUrl(
+                bucket = "avatars",
+                path = "a.png",
+                upsert = true,
+            )
 
-        assertEquals("/storage/v1/object/avatars/a.png?cacheControl=1200", client.lastPostRawUrl)
-    }
-
-    @Test
-    fun test_update_withCacheControl_includesCacheControlQuery() = runTest {
-        val client = FakeSupabaseClient()
-        val sut = StorageClientImpl(client)
-
-        sut.update(
-            bucket = "avatars",
-            path = "a.png",
-            data = byteArrayOf(1),
-            cacheControl = 900,
-        )
-
-        assertEquals("/storage/v1/object/avatars/a.png?cacheControl=900", client.lastPutRawUrl)
-    }
+            assertEquals("true", client.lastPostHeaders["x-upsert"])
+        }
 
     @Test
-    fun test_copy_usesCopyEndpoint() = runTest {
-        val client = FakeSupabaseClient()
-        val sut = StorageClientImpl(client)
+    fun test_createUploadSignedUrlWithPath_returnsResolvedUrlAndToken() =
+        runTest {
+            val client = FakeSupabaseClient()
+            val sut = StorageClientImpl(client)
 
-        val result = sut.copy(
-            bucket = "avatars",
-            fromPath = "old.png",
-            toPath = "new.png",
-        )
+            val result =
+                sut.createUploadSignedUrlWithPath(
+                    bucket = "avatars",
+                    path = "a.png",
+                )
 
-        assertEquals("/storage/v1/object/copy", client.lastPostEndpoint)
-        assertTrue(result is SupabaseResult.Success)
-    }
-
-    @Test
-    fun test_copy_includesCopyMetadataWhenProvided() = runTest {
-        val client = FakeSupabaseClient()
-        val sut = StorageClientImpl(client)
-
-        sut.copy(
-            bucket = "avatars",
-            fromPath = "old.png",
-            toPath = "new.png",
-            copyMetadata = true,
-        )
-
-        assertTrue(client.lastPostBody?.contains("\"copyMetadata\":true") == true)
-    }
+            assertTrue(result is SupabaseResult.Success)
+            assertEquals("https://example.supabase.co/upload/sign/path", result.value.url)
+            assertEquals("upload-token-123", result.value.token)
+        }
 
     @Test
-    fun test_removeWithResult_returnsDeletedFileEntries() = runTest {
-        val client = FakeSupabaseClient()
-        val sut = StorageClientImpl(client)
+    fun test_updateBucket_usesPutBucketEndpoint() =
+        runTest {
+            val client = FakeSupabaseClient()
+            val sut = StorageClientImpl(client)
 
-        val result = sut.removeWithResult(bucket = "avatars", paths = listOf("a.png"))
+            val result =
+                sut.updateBucket(
+                    id = "avatars",
+                    public = true,
+                )
 
-        assertEquals("/storage/v1/object/remove/avatars", client.lastPostEndpoint)
-        assertTrue(result is SupabaseResult.Success)
-        assertEquals(1, result.value.size)
-        assertEquals("a.png", result.value.first().name)
-    }
-
-    @Test
-    fun test_move_allowsDestinationBucket() = runTest {
-        val client = FakeSupabaseClient()
-        val sut = StorageClientImpl(client)
-
-        val result = sut.move(
-            bucket = "avatars",
-            fromPath = "old.png",
-            toPath = "new.png",
-            destinationBucket = "archive",
-        )
-
-        assertEquals("/storage/v1/object/move", client.lastPostEndpoint)
-        assertTrue(client.lastPostBody?.contains("\"destinationBucket\":\"archive\"") == true)
-        assertTrue(result is SupabaseResult.Success)
-    }
+            assertEquals("/storage/v1/bucket/avatars", client.lastPostEndpoint)
+            assertTrue(result is SupabaseResult.Success)
+        }
 
     @Test
-    fun test_deleteObject_usesDeleteObjectEndpoint() = runTest {
-        val client = FakeSupabaseClient()
-        val sut = StorageClientImpl(client)
+    fun test_uploadToSignedUrl_usesSignedUploadPathWithToken() =
+        runTest {
+            val client = FakeSupabaseClient()
+            val sut = StorageClientImpl(client)
 
-        val result = sut.deleteObject(bucket = "avatars", path = "a.png")
+            sut.uploadToSignedUrl(
+                bucket = "avatars",
+                path = "a.png",
+                token = "abc",
+                data = byteArrayOf(1, 2, 3),
+                upsert = true,
+            )
 
-        assertEquals("/storage/v1/object/avatars/a.png", client.lastDeleteEndpoint)
-        assertTrue(result is SupabaseResult.Success)
-    }
-
-    @Test
-    fun test_downloadPublic_usesPublicEndpoint() = runTest {
-        val client = FakeSupabaseClient()
-        val sut = StorageClientImpl(client)
-
-        sut.downloadPublic(bucket = "avatars", path = "a.png")
-
-        assertEquals("/storage/v1/object/public/avatars/a.png", client.lastGetEndpoint)
-    }
+            assertEquals("/storage/v1/object/upload/sign/avatars/a.png?token=abc", client.lastPostRawUrl)
+            assertEquals("true", client.lastPostRawHeaders["x-upsert"])
+        }
 
     @Test
-    fun test_download_usesAuthenticatedEndpoint() = runTest {
-        val client = FakeSupabaseClient()
-        val sut = StorageClientImpl(client)
+    fun test_uploadToSignedUrl_withCacheControl_includesCacheControlQuery() =
+        runTest {
+            val client = FakeSupabaseClient()
+            val sut = StorageClientImpl(client)
 
-        sut.download(bucket = "avatars", path = "a.png")
+            sut.uploadToSignedUrl(
+                bucket = "avatars",
+                path = "a.png",
+                token = "abc",
+                data = byteArrayOf(1, 2, 3),
+                cacheControl = 3600,
+            )
 
-        assertEquals("/storage/v1/object/authenticated/avatars/a.png", client.lastGetEndpoint)
-    }
+            assertEquals("/storage/v1/object/upload/sign/avatars/a.png?token=abc&cacheControl=3600", client.lastPostRawUrl)
+        }
 
     @Test
-    fun test_download_withDownloadFileName_appendsDownloadQuery() = runTest {
-        val client = FakeSupabaseClient()
-        val sut = StorageClientImpl(client)
+    fun test_update_usesPutRawAndUpsertHeader() =
+        runTest {
+            val client = FakeSupabaseClient()
+            val sut = StorageClientImpl(client)
 
-        sut.download(bucket = "avatars", path = "a.png", download = true, fileName = "avatar.png")
+            sut.update(
+                bucket = "avatars",
+                path = "a.png",
+                data = byteArrayOf(1, 2, 3),
+                upsert = true,
+            )
 
-        assertEquals("/storage/v1/object/authenticated/avatars/a.png?download=avatar.png", client.lastGetEndpoint)
-    }
+            assertEquals("/storage/v1/object/avatars/a.png", client.lastPutRawUrl)
+            assertEquals("true", client.lastPutRawHeaders["x-upsert"])
+        }
+
+    @Test
+    fun test_upload_withCacheControl_includesCacheControlQuery() =
+        runTest {
+            val client = FakeSupabaseClient()
+            val sut = StorageClientImpl(client)
+
+            sut.upload(
+                bucket = "avatars",
+                path = "a.png",
+                data = byteArrayOf(1),
+                cacheControl = 1200,
+            )
+
+            assertEquals("/storage/v1/object/avatars/a.png?cacheControl=1200", client.lastPostRawUrl)
+        }
+
+    @Test
+    fun test_update_withCacheControl_includesCacheControlQuery() =
+        runTest {
+            val client = FakeSupabaseClient()
+            val sut = StorageClientImpl(client)
+
+            sut.update(
+                bucket = "avatars",
+                path = "a.png",
+                data = byteArrayOf(1),
+                cacheControl = 900,
+            )
+
+            assertEquals("/storage/v1/object/avatars/a.png?cacheControl=900", client.lastPutRawUrl)
+        }
+
+    @Test
+    fun test_copy_usesCopyEndpoint() =
+        runTest {
+            val client = FakeSupabaseClient()
+            val sut = StorageClientImpl(client)
+
+            val result =
+                sut.copy(
+                    bucket = "avatars",
+                    fromPath = "old.png",
+                    toPath = "new.png",
+                )
+
+            assertEquals("/storage/v1/object/copy", client.lastPostEndpoint)
+            assertTrue(result is SupabaseResult.Success)
+        }
+
+    @Test
+    fun test_copy_includesCopyMetadataWhenProvided() =
+        runTest {
+            val client = FakeSupabaseClient()
+            val sut = StorageClientImpl(client)
+
+            sut.copy(
+                bucket = "avatars",
+                fromPath = "old.png",
+                toPath = "new.png",
+                copyMetadata = true,
+            )
+
+            assertTrue(client.lastPostBody?.contains("\"copyMetadata\":true") == true)
+        }
+
+    @Test
+    fun test_removeWithResult_returnsDeletedFileEntries() =
+        runTest {
+            val client = FakeSupabaseClient()
+            val sut = StorageClientImpl(client)
+
+            val result = sut.removeWithResult(bucket = "avatars", paths = listOf("a.png"))
+
+            assertEquals("/storage/v1/object/remove/avatars", client.lastPostEndpoint)
+            assertTrue(result is SupabaseResult.Success)
+            assertEquals(1, result.value.size)
+            assertEquals("a.png", result.value.first().name)
+        }
+
+    @Test
+    fun test_move_allowsDestinationBucket() =
+        runTest {
+            val client = FakeSupabaseClient()
+            val sut = StorageClientImpl(client)
+
+            val result =
+                sut.move(
+                    bucket = "avatars",
+                    fromPath = "old.png",
+                    toPath = "new.png",
+                    destinationBucket = "archive",
+                )
+
+            assertEquals("/storage/v1/object/move", client.lastPostEndpoint)
+            assertTrue(client.lastPostBody?.contains("\"destinationBucket\":\"archive\"") == true)
+            assertTrue(result is SupabaseResult.Success)
+        }
+
+    @Test
+    fun test_deleteObject_usesDeleteObjectEndpoint() =
+        runTest {
+            val client = FakeSupabaseClient()
+            val sut = StorageClientImpl(client)
+
+            val result = sut.deleteObject(bucket = "avatars", path = "a.png")
+
+            assertEquals("/storage/v1/object/avatars/a.png", client.lastDeleteEndpoint)
+            assertTrue(result is SupabaseResult.Success)
+        }
+
+    @Test
+    fun test_downloadPublic_usesPublicEndpoint() =
+        runTest {
+            val client = FakeSupabaseClient()
+            val sut = StorageClientImpl(client)
+
+            sut.downloadPublic(bucket = "avatars", path = "a.png")
+
+            assertEquals("/storage/v1/object/public/avatars/a.png", client.lastGetEndpoint)
+        }
+
+    @Test
+    fun test_download_usesAuthenticatedEndpoint() =
+        runTest {
+            val client = FakeSupabaseClient()
+            val sut = StorageClientImpl(client)
+
+            sut.download(bucket = "avatars", path = "a.png")
+
+            assertEquals("/storage/v1/object/authenticated/avatars/a.png", client.lastGetEndpoint)
+        }
+
+    @Test
+    fun test_download_withDownloadFileName_appendsDownloadQuery() =
+        runTest {
+            val client = FakeSupabaseClient()
+            val sut = StorageClientImpl(client)
+
+            sut.download(bucket = "avatars", path = "a.png", download = true, fileName = "avatar.png")
+
+            assertEquals("/storage/v1/object/authenticated/avatars/a.png?download=avatar.png", client.lastGetEndpoint)
+        }
 
     @Test
     fun test_getSignedDownloadUrl_withFileName_buildsExpectedUrl() {
         val sut = StorageClientImpl(FakeSupabaseClient())
 
-        val url = sut.getSignedDownloadUrl(
-            bucket = "avatars",
-            path = "a.png",
-            token = "tok123",
-            download = true,
-            fileName = "avatar.png",
-        )
+        val url =
+            sut.getSignedDownloadUrl(
+                bucket = "avatars",
+                path = "a.png",
+                token = "tok123",
+                download = true,
+                fileName = "avatar.png",
+            )
 
         assertEquals(
             "https://example.supabase.co/storage/v1/object/sign/avatars/a.png?token=tok123&download=avatar.png",
@@ -383,105 +426,114 @@ class StorageClientImplTest {
     }
 
     @Test
-    fun test_info_usesAuthenticatedInfoEndpoint() = runTest {
-        val client = FakeSupabaseClient()
-        val sut = StorageClientImpl(client)
+    fun test_info_usesAuthenticatedInfoEndpoint() =
+        runTest {
+            val client = FakeSupabaseClient()
+            val sut = StorageClientImpl(client)
 
-        val result = sut.info(bucket = "avatars", path = "a.png")
+            val result = sut.info(bucket = "avatars", path = "a.png")
 
-        assertTrue(result is SupabaseResult.Success)
-        assertEquals("/storage/v1/object/info/avatars/a.png", client.lastGetEndpoint)
-        assertEquals("a.png", result.value.name)
-    }
-
-    @Test
-    fun test_infoPublic_usesPublicInfoEndpoint() = runTest {
-        val client = FakeSupabaseClient()
-        val sut = StorageClientImpl(client)
-
-        val result = sut.infoPublic(bucket = "avatars", path = "a.png")
-
-        assertTrue(result is SupabaseResult.Success)
-        assertEquals("/storage/v1/object/info/public/avatars/a.png", client.lastGetEndpoint)
-        assertEquals("a.png", result.value.name)
-    }
+            assertTrue(result is SupabaseResult.Success)
+            assertEquals("/storage/v1/object/info/avatars/a.png", client.lastGetEndpoint)
+            assertEquals("a.png", result.value.name)
+        }
 
     @Test
-    fun test_exists_returnsTrueWhenInfoExists() = runTest {
-        val client = FakeSupabaseClient()
-        val sut = StorageClientImpl(client)
+    fun test_infoPublic_usesPublicInfoEndpoint() =
+        runTest {
+            val client = FakeSupabaseClient()
+            val sut = StorageClientImpl(client)
 
-        val result = sut.exists(bucket = "avatars", path = "a.png")
+            val result = sut.infoPublic(bucket = "avatars", path = "a.png")
 
-        assertTrue(result is SupabaseResult.Success)
-        assertEquals(true, result.value)
-    }
-
-    @Test
-    fun test_exists_returnsFalseWhenInfoNotFound() = runTest {
-        val client = FakeSupabaseClient()
-        val sut = StorageClientImpl(client)
-
-        val result = sut.exists(bucket = "avatars", path = "missing.png")
-
-        assertTrue(result is SupabaseResult.Success)
-        assertEquals(false, result.value)
-    }
+            assertTrue(result is SupabaseResult.Success)
+            assertEquals("/storage/v1/object/info/public/avatars/a.png", client.lastGetEndpoint)
+            assertEquals("a.png", result.value.name)
+        }
 
     @Test
-    fun test_list_includesSortOrderAndSearchInBody() = runTest {
-        val client = FakeSupabaseClient()
-        val sut = StorageClientImpl(client)
+    fun test_exists_returnsTrueWhenInfoExists() =
+        runTest {
+            val client = FakeSupabaseClient()
+            val sut = StorageClientImpl(client)
 
-        sut.list(
-            bucket = "avatars",
-            prefix = "folder/",
-            sortBy = "name",
-            sortOrder = SortOrder.DESC,
-            search = "cat",
-        )
+            val result = sut.exists(bucket = "avatars", path = "a.png")
 
-        assertEquals("/storage/v1/object/list/avatars", client.lastPostEndpoint)
-        assertTrue(client.lastPostBody?.contains("\"order\":\"desc\"") == true)
-        assertTrue(client.lastPostBody?.contains("\"search\":\"cat\"") == true)
-    }
+            assertTrue(result is SupabaseResult.Success)
+            assertEquals(true, result.value)
+        }
 
     @Test
-    fun test_createSignedUrl_withTransform_includesTransformPayload() = runTest {
-        val client = FakeSupabaseClient()
-        val sut = StorageClientImpl(client)
+    fun test_exists_returnsFalseWhenInfoNotFound() =
+        runTest {
+            val client = FakeSupabaseClient()
+            val sut = StorageClientImpl(client)
 
-        sut.createSignedUrl(
-            bucket = "avatars",
-            path = "a.png",
-            expiresIn = 120,
-            transform = ImageTransformOptions(
-                width = 200,
-                height = 300,
-                resize = ResizeMode.COVER,
-                quality = 80,
-            ),
-        )
+            val result = sut.exists(bucket = "avatars", path = "missing.png")
 
-        assertTrue(client.lastPostBody?.contains("\"transform\"") == true)
-        assertTrue(client.lastPostBody?.contains("\"width\":200") == true)
-        assertTrue(client.lastPostBody?.contains("\"resize\":\"cover\"") == true)
-    }
+            assertTrue(result is SupabaseResult.Success)
+            assertEquals(false, result.value)
+        }
+
+    @Test
+    fun test_list_includesSortOrderAndSearchInBody() =
+        runTest {
+            val client = FakeSupabaseClient()
+            val sut = StorageClientImpl(client)
+
+            sut.list(
+                bucket = "avatars",
+                prefix = "folder/",
+                sortBy = "name",
+                sortOrder = SortOrder.DESC,
+                search = "cat",
+            )
+
+            assertEquals("/storage/v1/object/list/avatars", client.lastPostEndpoint)
+            assertTrue(client.lastPostBody?.contains("\"order\":\"desc\"") == true)
+            assertTrue(client.lastPostBody?.contains("\"search\":\"cat\"") == true)
+        }
+
+    @Test
+    fun test_createSignedUrl_withTransform_includesTransformPayload() =
+        runTest {
+            val client = FakeSupabaseClient()
+            val sut = StorageClientImpl(client)
+
+            sut.createSignedUrl(
+                bucket = "avatars",
+                path = "a.png",
+                expiresIn = 120,
+                transform =
+                    ImageTransformOptions(
+                        width = 200,
+                        height = 300,
+                        resize = ResizeMode.COVER,
+                        quality = 80,
+                    ),
+            )
+
+            assertTrue(client.lastPostBody?.contains("\"transform\"") == true)
+            assertTrue(client.lastPostBody?.contains("\"width\":200") == true)
+            assertTrue(client.lastPostBody?.contains("\"resize\":\"cover\"") == true)
+        }
 
     @Test
     fun test_getPublicUrl_withTransform_includesQueryParams() {
         val sut = StorageClientImpl(FakeSupabaseClient())
 
-        val url = sut.getPublicUrl(
-            bucket = "avatars",
-            path = "a.png",
-            transform = ImageTransformOptions(
-                width = 100,
-                height = 100,
-                resize = ResizeMode.FILL,
-                format = "webp",
-            ),
-        )
+        val url =
+            sut.getPublicUrl(
+                bucket = "avatars",
+                path = "a.png",
+                transform =
+                    ImageTransformOptions(
+                        width = 100,
+                        height = 100,
+                        resize = ResizeMode.FILL,
+                        format = "webp",
+                    ),
+            )
 
         assertEquals(
             "https://example.supabase.co/storage/v1/object/public/avatars/a.png?width=100&height=100&resize=fill&format=webp",
@@ -493,13 +545,14 @@ class StorageClientImplTest {
     fun test_getPublicUrl_withDownloadAndTransform_buildsCombinedQuery() {
         val sut = StorageClientImpl(FakeSupabaseClient())
 
-        val url = sut.getPublicUrl(
-            bucket = "avatars",
-            path = "a.png",
-            download = true,
-            fileName = "avatar.png",
-            transform = ImageTransformOptions(width = 50),
-        )
+        val url =
+            sut.getPublicUrl(
+                bucket = "avatars",
+                path = "a.png",
+                download = true,
+                fileName = "avatar.png",
+                transform = ImageTransformOptions(width = 50),
+            )
 
         assertEquals(
             "https://example.supabase.co/storage/v1/object/public/avatars/a.png?width=50&download=avatar.png",
@@ -511,15 +564,17 @@ class StorageClientImplTest {
     fun test_getAuthenticatedUrl_withTransform_includesQueryParams() {
         val sut = StorageClientImpl(FakeSupabaseClient())
 
-        val url = sut.getAuthenticatedUrl(
-            bucket = "avatars",
-            path = "a.png",
-            transform = ImageTransformOptions(
-                width = 80,
-                height = 120,
-                resize = ResizeMode.CONTAIN,
-            ),
-        )
+        val url =
+            sut.getAuthenticatedUrl(
+                bucket = "avatars",
+                path = "a.png",
+                transform =
+                    ImageTransformOptions(
+                        width = 80,
+                        height = 120,
+                        resize = ResizeMode.CONTAIN,
+                    ),
+            )
 
         assertEquals(
             "https://example.supabase.co/storage/v1/object/authenticated/avatars/a.png?width=80&height=120&resize=contain",
@@ -531,13 +586,14 @@ class StorageClientImplTest {
     fun test_getAuthenticatedUrl_withDownloadAndTransform_buildsCombinedQuery() {
         val sut = StorageClientImpl(FakeSupabaseClient())
 
-        val url = sut.getAuthenticatedUrl(
-            bucket = "avatars",
-            path = "a.png",
-            download = true,
-            fileName = "auth-avatar.png",
-            transform = ImageTransformOptions(width = 50),
-        )
+        val url =
+            sut.getAuthenticatedUrl(
+                bucket = "avatars",
+                path = "a.png",
+                download = true,
+                fileName = "auth-avatar.png",
+                transform = ImageTransformOptions(width = 50),
+            )
 
         assertEquals(
             "https://example.supabase.co/storage/v1/object/authenticated/avatars/a.png?width=50&download=auth-avatar.png",
@@ -549,11 +605,12 @@ class StorageClientImplTest {
     fun test_getPublicRenderUrl_withTransform_usesRenderEndpoint() {
         val sut = StorageClientImpl(FakeSupabaseClient())
 
-        val url = sut.getPublicRenderUrl(
-            bucket = "avatars",
-            path = "a.png",
-            transform = ImageTransformOptions(width = 200, resize = ResizeMode.COVER),
-        )
+        val url =
+            sut.getPublicRenderUrl(
+                bucket = "avatars",
+                path = "a.png",
+                transform = ImageTransformOptions(width = 200, resize = ResizeMode.COVER),
+            )
 
         assertEquals(
             "https://example.supabase.co/storage/v1/render/image/public/avatars/a.png?width=200&resize=cover",
@@ -565,11 +622,12 @@ class StorageClientImplTest {
     fun test_getAuthenticatedRenderUrl_withTransform_usesRenderEndpoint() {
         val sut = StorageClientImpl(FakeSupabaseClient())
 
-        val url = sut.getAuthenticatedRenderUrl(
-            bucket = "avatars",
-            path = "a.png",
-            transform = ImageTransformOptions(height = 300, resize = ResizeMode.FILL),
-        )
+        val url =
+            sut.getAuthenticatedRenderUrl(
+                bucket = "avatars",
+                path = "a.png",
+                transform = ImageTransformOptions(height = 300, resize = ResizeMode.FILL),
+            )
 
         assertEquals(
             "https://example.supabase.co/storage/v1/render/image/authenticated/avatars/a.png?height=300&resize=fill",
@@ -578,242 +636,285 @@ class StorageClientImplTest {
     }
 
     @Test
-    fun test_analyticsBucketMethods_useIcebergEndpoints() = runTest {
-        val client = FakeSupabaseClient()
-        val sut = StorageClientImpl(client)
+    fun test_analyticsBucketMethods_useIcebergEndpoints() =
+        runTest {
+            val client = FakeSupabaseClient()
+            val sut = StorageClientImpl(client)
 
-        val created = sut.createAnalyticsBucket("events")
-        val listed = sut.listAnalyticsBuckets(
-            limit = 10,
-            offset = 2,
-            sortColumn = "created_at",
-            sortOrder = SortOrder.DESC,
-            search = "event",
-        )
-        val deleted = sut.deleteAnalyticsBucket("events")
+            val created = sut.createAnalyticsBucket("events")
+            val listed =
+                sut.listAnalyticsBuckets(
+                    limit = 10,
+                    offset = 2,
+                    sortColumn = "created_at",
+                    sortOrder = SortOrder.DESC,
+                    search = "event",
+                )
+            val deleted = sut.deleteAnalyticsBucket("events")
 
-        assertTrue(created is SupabaseResult.Success)
-        assertEquals("events", created.value.name)
-        assertTrue(listed is SupabaseResult.Success)
-        assertEquals("events", listed.value.first().name)
-        assertEquals("/storage/v1/iceberg/bucket/events", client.lastDeleteEndpoint)
-        assertTrue(deleted is SupabaseResult.Success)
-    }
-
-    @Test
-    fun test_analyticsCatalog_namespaceMethods_useIcebergRestCatalogEndpoints() = runTest {
-        val client = FakeSupabaseClient()
-        val sut = StorageClientImpl(client)
-        val catalog = sut.analyticsCatalog("events")
-
-        val namespaces = catalog.listNamespaces(pageSize = 10)
-        assertTrue(namespaces is SupabaseResult.Success)
-        assertEquals("/storage/v1/iceberg/v1/catalog-prefix/namespaces?pageSize=10", client.lastGetEndpoint)
-
-        val created = catalog.createNamespace(
-            namespace = listOf("prod", "events"),
-            properties = mapOf("owner" to "data-team"),
-        )
-        assertTrue(created is SupabaseResult.Success)
-        assertTrue(client.lastPostBody?.contains("\"namespace\":[\"prod\",\"events\"]") == true)
-
-        val metadata = catalog.loadNamespaceMetadata(listOf("prod", "events"))
-        val updated = catalog.updateNamespaceProperties(
-            namespace = listOf("prod", "events"),
-            removals = listOf("old"),
-            updates = mapOf("owner" to "platform"),
-        )
-        val dropped = catalog.dropNamespace(listOf("prod", "events"))
-
-        assertTrue(metadata is SupabaseResult.Success)
-        assertTrue(updated is SupabaseResult.Success)
-        assertTrue(client.lastPostBody?.contains("\"removals\":[\"old\"]") == true)
-        assertEquals("/storage/v1/iceberg/v1/catalog-prefix/namespaces/prod%1Fevents", client.lastDeleteEndpoint)
-        assertTrue(dropped is SupabaseResult.Success)
-    }
-
-    @Test
-    fun test_analyticsCatalog_tableMethods_useIcebergRestCatalogEndpoints() = runTest {
-        val client = FakeSupabaseClient()
-        val sut = StorageClientImpl(client)
-        val catalog = sut.analyticsCatalog("events")
-        val tableRequest = buildJsonObject {
-            put("name", "clicks")
-            put("schema", buildJsonObject { put("type", "struct") })
+            assertTrue(created is SupabaseResult.Success)
+            assertEquals("events", created.value.name)
+            assertTrue(listed is SupabaseResult.Success)
+            assertEquals("events", listed.value.first().name)
+            assertEquals("/storage/v1/iceberg/bucket/events", client.lastDeleteEndpoint)
+            assertTrue(deleted is SupabaseResult.Success)
         }
 
-        val tables = catalog.listTables(namespace = listOf("prod"), pageToken = "p1", pageSize = 20)
-        assertTrue(tables is SupabaseResult.Success)
-        assertEquals("/storage/v1/iceberg/v1/catalog-prefix/namespaces/prod/tables?pageToken=p1&pageSize=20", client.lastGetEndpoint)
-
-        val created = catalog.createTable(namespace = listOf("prod"), request = tableRequest)
-        val loaded = catalog.loadTable(namespace = listOf("prod"), name = "clicks", snapshots = "all")
-        val updated = catalog.updateTable(namespace = listOf("prod"), name = "clicks", request = buildJsonObject { put("updates", "[]") })
-        val registered = catalog.registerTable(namespace = listOf("prod"), request = buildJsonObject { put("name", "external") })
-        val renamed = catalog.renameTable(buildJsonObject { put("source", "clicks") })
-        val dropped = catalog.dropTable(namespace = listOf("prod"), name = "clicks", purge = true)
-
-        assertTrue(created is SupabaseResult.Success)
-        assertEquals("clicks", created.value["name"]?.toString()?.trim('"'))
-        assertTrue(loaded is SupabaseResult.Success)
-        assertTrue(updated is SupabaseResult.Success)
-        assertTrue(registered is SupabaseResult.Success)
-        assertEquals("/storage/v1/iceberg/v1/catalog-prefix/tables/rename", client.lastPostEndpoint)
-        assertTrue(renamed is SupabaseResult.Success)
-        assertEquals("/storage/v1/iceberg/v1/catalog-prefix/namespaces/prod/tables/clicks?purgeRequested=true", client.lastDeleteEndpoint)
-        assertTrue(dropped is SupabaseResult.Success)
-    }
-
     @Test
-    fun test_analyticsCatalogTypedMethods_decodeIcebergModels() = runTest {
-        val client = FakeSupabaseClient()
-        val sut = StorageClientImpl(client)
-        val catalog = sut.analyticsCatalog("events")
+    fun test_analyticsCatalog_namespaceMethods_useIcebergRestCatalogEndpoints() =
+        runTest {
+            val client = FakeSupabaseClient()
+            val sut = StorageClientImpl(client)
+            val catalog = sut.analyticsCatalog("events")
 
-        val config = catalog.loadConfigTyped()
-        val namespaces = catalog.listNamespacesTyped(pageSize = 10)
-        val namespace = catalog.createNamespaceTyped(
-            IcebergCreateNamespaceRequest(
-                namespace = listOf("prod", "events"),
-                properties = mapOf("owner" to "data-team"),
-            ),
-        )
-        val namespaceMetadata = catalog.loadNamespaceMetadataTyped(listOf("prod", "events"))
-        val namespaceUpdate = catalog.updateNamespacePropertiesTyped(
-            namespace = listOf("prod", "events"),
-            request = IcebergUpdateNamespacePropertiesRequest(
-                removals = listOf("old"),
-                updates = mapOf("owner" to "platform"),
-            ),
-        )
-        val tables = catalog.listTablesTyped(namespace = listOf("prod"))
-        val table = catalog.createTableTyped(
-            namespace = listOf("prod"),
-            request = IcebergTableCreateRequest(
-                name = "clicks",
-                schema = buildJsonObject { put("type", "struct") },
-            ),
-        )
-        val loaded = catalog.loadTableTyped(namespace = listOf("prod"), name = "clicks")
-        val committed = catalog.commitTableTyped(
-            namespace = listOf("prod"),
-            name = "clicks",
-            request = IcebergTableCommitRequest(updates = listOf(buildJsonObject { put("action", "noop") })),
-        )
-        val registered = catalog.registerTableTyped(
-            namespace = listOf("prod"),
-            request = IcebergTableRegisterRequest(name = "external", metadataLocation = "s3://bucket/metadata.json"),
-        )
-        val renamed = catalog.renameTableTyped(
-            source = IcebergTableIdentifier(namespace = listOf("prod"), name = "clicks"),
-            destination = IcebergTableIdentifier(namespace = listOf("prod"), name = "clicks_renamed"),
-        )
+            val namespaces = catalog.listNamespaces(pageSize = 10)
+            assertTrue(namespaces is SupabaseResult.Success)
+            assertEquals("/storage/v1/iceberg/v1/catalog-prefix/namespaces?pageSize=10", client.lastGetEndpoint)
 
-        assertTrue(config is SupabaseResult.Success)
-        assertEquals("catalog-prefix", config.value.overrides["prefix"])
-        assertTrue(namespaces is SupabaseResult.Success)
-        assertEquals(listOf("prod", "events"), namespaces.value.namespaces.first())
-        assertTrue(namespace is SupabaseResult.Success)
-        assertEquals("data-team", namespace.value.properties["owner"])
-        assertTrue(namespaceMetadata is SupabaseResult.Success)
-        assertEquals(listOf("prod", "events"), namespaceMetadata.value.namespace)
-        assertTrue(namespaceUpdate is SupabaseResult.Success)
-        assertEquals(listOf("owner"), namespaceUpdate.value.updated)
-        assertTrue(tables is SupabaseResult.Success)
-        assertEquals("clicks", tables.value.identifiers.first().name)
-        assertTrue(table is SupabaseResult.Success)
-        assertEquals("clicks", table.value.name)
-        assertTrue(loaded is SupabaseResult.Success)
-        assertEquals(2, loaded.value.metadata?.get("format-version")?.toString()?.toInt())
-        assertTrue(committed is SupabaseResult.Success)
-        assertTrue(registered is SupabaseResult.Success)
-        assertEquals("/storage/v1/iceberg/v1/catalog-prefix/tables/rename", client.lastPostEndpoint)
-        assertTrue(client.lastPostBody?.contains("\"destination\"") == true)
-        assertTrue(renamed is SupabaseResult.Success)
-    }
+            val created =
+                catalog.createNamespace(
+                    namespace = listOf("prod", "events"),
+                    properties = mapOf("owner" to "data-team"),
+                )
+            assertTrue(created is SupabaseResult.Success)
+            assertTrue(client.lastPostBody?.contains("\"namespace\":[\"prod\",\"events\"]") == true)
 
-    @Test
-    fun test_vectorBucketAndIndexMethods_useVectorActionEndpoints() = runTest {
-        val client = FakeSupabaseClient()
-        val sut = StorageClientImpl(client)
+            val metadata = catalog.loadNamespaceMetadata(listOf("prod", "events"))
+            val updated =
+                catalog.updateNamespaceProperties(
+                    namespace = listOf("prod", "events"),
+                    removals = listOf("old"),
+                    updates = mapOf("owner" to "platform"),
+                )
+            val dropped = catalog.dropNamespace(listOf("prod", "events"))
 
-        val createBucket = sut.createVectorBucket("embeddings")
-        val bucket = sut.getVectorBucket("embeddings")
-        val buckets = sut.listVectorBuckets(prefix = "emb", maxResults = 10, nextToken = "n1")
-        val createIndex = sut.createVectorIndex(
-            vectorBucketName = "embeddings",
-            indexName = "documents",
-            dataType = VectorDataType.FLOAT32,
-            dimension = 1536,
-            distanceMetric = VectorDistanceMetric.COSINE,
-            metadataConfiguration = VectorMetadataConfiguration(nonFilterableMetadataKeys = listOf("raw_text")),
-        )
-        val index = sut.getVectorIndex("embeddings", "documents")
-        val indexes = sut.listVectorIndexes("embeddings", prefix = "doc", maxResults = 5)
-        val deleteIndex = sut.deleteVectorIndex("embeddings", "documents")
-        val deleteBucket = sut.deleteVectorBucket("embeddings")
-
-        assertTrue(createBucket is SupabaseResult.Success)
-        assertTrue(bucket is SupabaseResult.Success)
-        assertEquals("embeddings", bucket.value.vectorBucketName)
-        assertTrue(buckets is SupabaseResult.Success)
-        assertEquals("embeddings", buckets.value.vectorBuckets.first().vectorBucketName)
-        assertTrue(createIndex is SupabaseResult.Success)
-        assertTrue(index is SupabaseResult.Success)
-        assertEquals("documents", index.value.indexName)
-        assertEquals(VectorDistanceMetric.COSINE, index.value.distanceMetric)
-        assertTrue(indexes is SupabaseResult.Success)
-        assertEquals("documents", indexes.value.indexes.first().indexName)
-        assertTrue(deleteIndex is SupabaseResult.Success)
-        assertEquals("/storage/v1/vector/DeleteVectorBucket", client.lastPostEndpoint)
-        assertTrue(client.lastPostBody?.contains("\"vectorBucketName\":\"embeddings\"") == true)
-        assertTrue(deleteBucket is SupabaseResult.Success)
-    }
-
-    @Test
-    fun test_vectorDataMethods_useVectorActionEndpointsAndPayloads() = runTest {
-        val client = FakeSupabaseClient()
-        val sut = StorageClientImpl(client)
-        val vector = VectorObject(
-            key = "doc-1",
-            data = VectorData(float32 = listOf(0.1, 0.2)),
-            metadata = buildJsonObject { put("category", "docs") },
-        )
-
-        val putResult = sut.putVectors("embeddings", "documents", listOf(vector))
-        val getResult = sut.getVectors("embeddings", "documents", keys = listOf("doc-1"), returnData = true, returnMetadata = true)
-        val listResult = sut.listVectors("embeddings", "documents", maxResults = 10, segmentCount = 2, segmentIndex = 1)
-        val queryResult = sut.queryVectors(
-            vectorBucketName = "embeddings",
-            indexName = "documents",
-            queryVector = VectorData(float32 = listOf(0.1, 0.2)),
-            topK = 5,
-            filter = buildJsonObject { put("category", "docs") },
-            returnDistance = true,
-            returnMetadata = true,
-        )
-        val deleteResult = sut.deleteVectors("embeddings", "documents", keys = listOf("doc-1"))
-
-        assertTrue(putResult is SupabaseResult.Success)
-        assertTrue(getResult is SupabaseResult.Success)
-        assertEquals("doc-1", getResult.value.first().key)
-        assertTrue(listResult is SupabaseResult.Success)
-        assertEquals("cursor-2", listResult.value.nextToken)
-        assertTrue(queryResult is SupabaseResult.Success)
-        assertEquals(VectorDistanceMetric.COSINE, queryResult.value.distanceMetric)
-        assertEquals("/storage/v1/vector/DeleteVectors", client.lastPostEndpoint)
-        assertTrue(client.lastPostBody?.contains("\"keys\":[\"doc-1\"]") == true)
-        assertTrue(deleteResult is SupabaseResult.Success)
-    }
-
-    @Test
-    fun test_putVectors_rejectsInvalidBatchSize() = runTest {
-        val sut = StorageClientImpl(FakeSupabaseClient())
-
-        assertFailsWith<IllegalArgumentException> {
-            sut.putVectors("embeddings", "documents", emptyList())
+            assertTrue(metadata is SupabaseResult.Success)
+            assertTrue(updated is SupabaseResult.Success)
+            assertTrue(client.lastPostBody?.contains("\"removals\":[\"old\"]") == true)
+            assertEquals("/storage/v1/iceberg/v1/catalog-prefix/namespaces/prod%1Fevents", client.lastDeleteEndpoint)
+            assertTrue(dropped is SupabaseResult.Success)
         }
-    }
+
+    @Test
+    fun test_analyticsCatalog_tableMethods_useIcebergRestCatalogEndpoints() =
+        runTest {
+            val client = FakeSupabaseClient()
+            val sut = StorageClientImpl(client)
+            val catalog = sut.analyticsCatalog("events")
+            val tableRequest =
+                buildJsonObject {
+                    put("name", "clicks")
+                    put("schema", buildJsonObject { put("type", "struct") })
+                }
+
+            val tables = catalog.listTables(namespace = listOf("prod"), pageToken = "p1", pageSize = 20)
+            assertTrue(tables is SupabaseResult.Success)
+            assertEquals("/storage/v1/iceberg/v1/catalog-prefix/namespaces/prod/tables?pageToken=p1&pageSize=20", client.lastGetEndpoint)
+
+            val created = catalog.createTable(namespace = listOf("prod"), request = tableRequest)
+            val loaded = catalog.loadTable(namespace = listOf("prod"), name = "clicks", snapshots = "all")
+            val updated = catalog.updateTable(namespace = listOf("prod"), name = "clicks", request = buildJsonObject { put("updates", "[]") })
+            val registered = catalog.registerTable(namespace = listOf("prod"), request = buildJsonObject { put("name", "external") })
+            val renamed = catalog.renameTable(buildJsonObject { put("source", "clicks") })
+            val dropped = catalog.dropTable(namespace = listOf("prod"), name = "clicks", purge = true)
+
+            assertTrue(created is SupabaseResult.Success)
+            assertEquals("clicks", created.value["name"]?.toString()?.trim('"'))
+            assertTrue(loaded is SupabaseResult.Success)
+            assertTrue(updated is SupabaseResult.Success)
+            assertTrue(registered is SupabaseResult.Success)
+            assertEquals("/storage/v1/iceberg/v1/catalog-prefix/tables/rename", client.lastPostEndpoint)
+            assertTrue(renamed is SupabaseResult.Success)
+            assertEquals("/storage/v1/iceberg/v1/catalog-prefix/namespaces/prod/tables/clicks?purgeRequested=true", client.lastDeleteEndpoint)
+            assertTrue(dropped is SupabaseResult.Success)
+        }
+
+    @Test
+    fun test_analyticsCatalogTypedMethods_decodeIcebergModels() =
+        runTest {
+            val client = FakeSupabaseClient()
+            val sut = StorageClientImpl(client)
+            val catalog = sut.analyticsCatalog("events")
+
+            val config = catalog.loadConfigTyped()
+            val namespaces = catalog.listNamespacesTyped(pageSize = 10)
+            val namespace =
+                catalog.createNamespaceTyped(
+                    IcebergCreateNamespaceRequest(
+                        namespace = listOf("prod", "events"),
+                        properties = mapOf("owner" to "data-team"),
+                    ),
+                )
+            val namespaceMetadata = catalog.loadNamespaceMetadataTyped(listOf("prod", "events"))
+            val namespaceUpdate =
+                catalog.updateNamespacePropertiesTyped(
+                    namespace = listOf("prod", "events"),
+                    request =
+                        IcebergUpdateNamespacePropertiesRequest(
+                            removals = listOf("old"),
+                            updates = mapOf("owner" to "platform"),
+                        ),
+                )
+            val tables = catalog.listTablesTyped(namespace = listOf("prod"))
+            val table =
+                catalog.createTableTyped(
+                    namespace = listOf("prod"),
+                    request =
+                        IcebergTableCreateRequest(
+                            name = "clicks",
+                            schema = buildJsonObject { put("type", "struct") },
+                        ),
+                )
+            val loaded = catalog.loadTableTyped(namespace = listOf("prod"), name = "clicks")
+            val committed =
+                catalog.commitTableTyped(
+                    namespace = listOf("prod"),
+                    name = "clicks",
+                    request = IcebergTableCommitRequest(updates = listOf(buildJsonObject { put("action", "noop") })),
+                )
+            val registered =
+                catalog.registerTableTyped(
+                    namespace = listOf("prod"),
+                    request = IcebergTableRegisterRequest(name = "external", metadataLocation = "s3://bucket/metadata.json"),
+                )
+            val renamed =
+                catalog.renameTableTyped(
+                    source = IcebergTableIdentifier(namespace = listOf("prod"), name = "clicks"),
+                    destination = IcebergTableIdentifier(namespace = listOf("prod"), name = "clicks_renamed"),
+                )
+
+            assertTrue(config is SupabaseResult.Success)
+            assertEquals("catalog-prefix", config.value.overrides["prefix"])
+            assertTrue(namespaces is SupabaseResult.Success)
+            assertEquals(listOf("prod", "events"), namespaces.value.namespaces.first())
+            assertTrue(namespace is SupabaseResult.Success)
+            assertEquals("data-team", namespace.value.properties["owner"])
+            assertTrue(namespaceMetadata is SupabaseResult.Success)
+            assertEquals(listOf("prod", "events"), namespaceMetadata.value.namespace)
+            assertTrue(namespaceUpdate is SupabaseResult.Success)
+            assertEquals(listOf("owner"), namespaceUpdate.value.updated)
+            assertTrue(tables is SupabaseResult.Success)
+            assertEquals(
+                "clicks",
+                tables.value.identifiers
+                    .first()
+                    .name,
+            )
+            assertTrue(table is SupabaseResult.Success)
+            assertEquals("clicks", table.value.name)
+            assertTrue(loaded is SupabaseResult.Success)
+            assertEquals(
+                2,
+                loaded.value.metadata
+                    ?.get("format-version")
+                    ?.toString()
+                    ?.toInt(),
+            )
+            assertTrue(committed is SupabaseResult.Success)
+            assertTrue(registered is SupabaseResult.Success)
+            assertEquals("/storage/v1/iceberg/v1/catalog-prefix/tables/rename", client.lastPostEndpoint)
+            assertTrue(client.lastPostBody?.contains("\"destination\"") == true)
+            assertTrue(renamed is SupabaseResult.Success)
+        }
+
+    @Test
+    fun test_vectorBucketAndIndexMethods_useVectorActionEndpoints() =
+        runTest {
+            val client = FakeSupabaseClient()
+            val sut = StorageClientImpl(client)
+
+            val createBucket = sut.createVectorBucket("embeddings")
+            val bucket = sut.getVectorBucket("embeddings")
+            val buckets = sut.listVectorBuckets(prefix = "emb", maxResults = 10, nextToken = "n1")
+            val createIndex =
+                sut.createVectorIndex(
+                    vectorBucketName = "embeddings",
+                    indexName = "documents",
+                    dataType = VectorDataType.FLOAT32,
+                    dimension = 1536,
+                    distanceMetric = VectorDistanceMetric.COSINE,
+                    metadataConfiguration = VectorMetadataConfiguration(nonFilterableMetadataKeys = listOf("raw_text")),
+                )
+            val index = sut.getVectorIndex("embeddings", "documents")
+            val indexes = sut.listVectorIndexes("embeddings", prefix = "doc", maxResults = 5)
+            val deleteIndex = sut.deleteVectorIndex("embeddings", "documents")
+            val deleteBucket = sut.deleteVectorBucket("embeddings")
+
+            assertTrue(createBucket is SupabaseResult.Success)
+            assertTrue(bucket is SupabaseResult.Success)
+            assertEquals("embeddings", bucket.value.vectorBucketName)
+            assertTrue(buckets is SupabaseResult.Success)
+            assertEquals(
+                "embeddings",
+                buckets.value.vectorBuckets
+                    .first()
+                    .vectorBucketName,
+            )
+            assertTrue(createIndex is SupabaseResult.Success)
+            assertTrue(index is SupabaseResult.Success)
+            assertEquals("documents", index.value.indexName)
+            assertEquals(VectorDistanceMetric.COSINE, index.value.distanceMetric)
+            assertTrue(indexes is SupabaseResult.Success)
+            assertEquals(
+                "documents",
+                indexes.value.indexes
+                    .first()
+                    .indexName,
+            )
+            assertTrue(deleteIndex is SupabaseResult.Success)
+            assertEquals("/storage/v1/vector/DeleteVectorBucket", client.lastPostEndpoint)
+            assertTrue(client.lastPostBody?.contains("\"vectorBucketName\":\"embeddings\"") == true)
+            assertTrue(deleteBucket is SupabaseResult.Success)
+        }
+
+    @Test
+    fun test_vectorDataMethods_useVectorActionEndpointsAndPayloads() =
+        runTest {
+            val client = FakeSupabaseClient()
+            val sut = StorageClientImpl(client)
+            val vector =
+                VectorObject(
+                    key = "doc-1",
+                    data = VectorData(float32 = listOf(0.1, 0.2)),
+                    metadata = buildJsonObject { put("category", "docs") },
+                )
+
+            val putResult = sut.putVectors("embeddings", "documents", listOf(vector))
+            val getResult = sut.getVectors("embeddings", "documents", keys = listOf("doc-1"), returnData = true, returnMetadata = true)
+            val listResult = sut.listVectors("embeddings", "documents", maxResults = 10, segmentCount = 2, segmentIndex = 1)
+            val queryResult =
+                sut.queryVectors(
+                    vectorBucketName = "embeddings",
+                    indexName = "documents",
+                    queryVector = VectorData(float32 = listOf(0.1, 0.2)),
+                    topK = 5,
+                    filter = buildJsonObject { put("category", "docs") },
+                    returnDistance = true,
+                    returnMetadata = true,
+                )
+            val deleteResult = sut.deleteVectors("embeddings", "documents", keys = listOf("doc-1"))
+
+            assertTrue(putResult is SupabaseResult.Success)
+            assertTrue(getResult is SupabaseResult.Success)
+            assertEquals("doc-1", getResult.value.first().key)
+            assertTrue(listResult is SupabaseResult.Success)
+            assertEquals("cursor-2", listResult.value.nextToken)
+            assertTrue(queryResult is SupabaseResult.Success)
+            assertEquals(VectorDistanceMetric.COSINE, queryResult.value.distanceMetric)
+            assertEquals("/storage/v1/vector/DeleteVectors", client.lastPostEndpoint)
+            assertTrue(client.lastPostBody?.contains("\"keys\":[\"doc-1\"]") == true)
+            assertTrue(deleteResult is SupabaseResult.Success)
+        }
+
+    @Test
+    fun test_putVectors_rejectsInvalidBatchSize() =
+        runTest {
+            val sut = StorageClientImpl(FakeSupabaseClient())
+
+            assertFailsWith<IllegalArgumentException> {
+                sut.putVectors("embeddings", "documents", emptyList())
+            }
+        }
 }
 
 private class FakeSupabaseClient : SupabaseClient {
@@ -926,6 +1027,7 @@ private class FakeSupabaseClient : SupabaseClient {
             else -> SupabaseResult.Success("""{}""")
         }
     }
+
     override suspend fun put(
         endpoint: String,
         body: String?,


### PR DESCRIPTION
## What

Adds **Spotless 8.6.0** with the **ktlint 1.5.0** engine (`ktlint_official` style) as the code formatter, complementing the existing detekt static analysis. This was the one missing piece of the library's quality tooling — Dokka, Kover, binary-compatibility-validator, vanniktech publishing, dependabot and multi-platform CI were already in place.

## Changes

- **`gradle/libs.versions.toml`** — `spotless`/`ktlint` versions + the spotless plugin alias.
- **`build.gradle.kts`** — apply Spotless to every subproject and the root build (Kotlin sources + `*.gradle.kts` + misc files). A shared `editorConfigOverride` makes ktlint coexist with detekt:
  - disables ktlint's `function-signature` rule (it collapses author-wrapped expression bodies onto one over-long line) and its `max-line-length` reporting (detekt owns line length);
  - exempts `@Composable` and `@FilterDsl` functions from `function-naming`.
- **`.editorconfig`** — shared `ktlint_official` rules so IDE and CI agree.
- **`config/detekt/detekt.yml`** — `MaxLineLength` 140→150 and `LongMethod` 80→100 to match `ktlint_official`'s wrapping (documented in-file).
- **`.github/workflows/build.yml`** — `spotlessCheck` runs in the quality gate before detekt.
- **desktop sample** — expanded a wildcard import (ktlint can't auto-fix it).
- Ran `spotlessApply` across the codebase (bulk of the diff is formatting).

## Verification

Locally green: `spotlessCheck`, `detekt`, `apiCheck` (**public ABI unchanged**), and all JVM tests pass.

## Usage

- `./gradlew spotlessApply` — auto-format
- `./gradlew spotlessCheck` — verify formatting (CI)