### PR TITLE
feat(auth): verify ES256 getClaims signatures locally via JWKS

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -40,6 +40,11 @@ ktor-client-cio = { module = "io.ktor:ktor-client-cio", version.ref = "ktor" }
 kotlin-test = { module = "org.jetbrains.kotlin:kotlin-test", version.ref = "kotlin" }
 
 cryptography-random = { module = "dev.whyoleg.cryptography:cryptography-random", version.ref = "cryptography" }
+cryptography-core = { module = "dev.whyoleg.cryptography:cryptography-core", version.ref = "cryptography" }
+cryptography-provider-jdk = { module = "dev.whyoleg.cryptography:cryptography-provider-jdk", version.ref = "cryptography" }
+cryptography-provider-apple = { module = "dev.whyoleg.cryptography:cryptography-provider-apple", version.ref = "cryptography" }
+cryptography-provider-webcrypto = { module = "dev.whyoleg.cryptography:cryptography-provider-webcrypto", version.ref = "cryptography" }
+cryptography-provider-openssl3-prebuilt = { module = "dev.whyoleg.cryptography:cryptography-provider-openssl3-prebuilt", version.ref = "cryptography" }
 
 kotlinx-coroutines-android = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-android", version.ref = "coroutines" }
 androidx-core-ktx = { module = "androidx.core:core-ktx", version.ref = "androidxCoreKtx" }

--- a/supabase-auth/api/android/supabase-auth.api
+++ b/supabase-auth/api/android/supabase-auth.api
@@ -1,5 +1,6 @@
 public abstract interface class io/github/androidpoet/supabase/auth/AuthClient {
 	public abstract fun exchangeCodeForSession (Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun fetchJwks (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun generatePkceParams (Lkotlin/jvm/functions/Function1;)Lio/github/androidpoet/supabase/auth/models/PkceParams;
 	public abstract fun getOAuthSignInUrl (Lio/github/androidpoet/supabase/auth/models/OAuthProvider;Ljava/lang/String;Ljava/util/List;Ljava/util/Map;ZLio/github/androidpoet/supabase/auth/models/PkceParams;)Ljava/lang/String;
 	public abstract fun getUser (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
@@ -317,6 +318,77 @@ public synthetic class io/github/androidpoet/supabase/auth/models/IdTokenRequest
 }
 
 public final class io/github/androidpoet/supabase/auth/models/IdTokenRequest$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/androidpoet/supabase/auth/models/Jwk {
+	public static final field Companion Lio/github/androidpoet/supabase/auth/models/Jwk$Companion;
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()Ljava/lang/String;
+	public final fun component6 ()Ljava/lang/String;
+	public final fun component7 ()Ljava/lang/String;
+	public final fun component8 ()Ljava/lang/String;
+	public final fun component9 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lio/github/androidpoet/supabase/auth/models/Jwk;
+	public static synthetic fun copy$default (Lio/github/androidpoet/supabase/auth/models/Jwk;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lio/github/androidpoet/supabase/auth/models/Jwk;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAlgorithm ()Ljava/lang/String;
+	public final fun getCurve ()Ljava/lang/String;
+	public final fun getExponent ()Ljava/lang/String;
+	public final fun getKeyId ()Ljava/lang/String;
+	public final fun getKeyType ()Ljava/lang/String;
+	public final fun getModulus ()Ljava/lang/String;
+	public final fun getUse ()Ljava/lang/String;
+	public final fun getX ()Ljava/lang/String;
+	public final fun getY ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public synthetic class io/github/androidpoet/supabase/auth/models/Jwk$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/androidpoet/supabase/auth/models/Jwk$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/androidpoet/supabase/auth/models/Jwk;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/androidpoet/supabase/auth/models/Jwk;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+}
+
+public final class io/github/androidpoet/supabase/auth/models/Jwk$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/androidpoet/supabase/auth/models/JwkSet {
+	public static final field Companion Lio/github/androidpoet/supabase/auth/models/JwkSet$Companion;
+	public fun <init> ()V
+	public fun <init> (Ljava/util/List;)V
+	public synthetic fun <init> (Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/util/List;
+	public final fun copy (Ljava/util/List;)Lio/github/androidpoet/supabase/auth/models/JwkSet;
+	public static synthetic fun copy$default (Lio/github/androidpoet/supabase/auth/models/JwkSet;Ljava/util/List;ILjava/lang/Object;)Lio/github/androidpoet/supabase/auth/models/JwkSet;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getKeys ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public synthetic class io/github/androidpoet/supabase/auth/models/JwkSet$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/androidpoet/supabase/auth/models/JwkSet$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/androidpoet/supabase/auth/models/JwkSet;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/androidpoet/supabase/auth/models/JwkSet;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+}
+
+public final class io/github/androidpoet/supabase/auth/models/JwkSet$Companion {
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 

--- a/supabase-auth/api/jvm/supabase-auth.api
+++ b/supabase-auth/api/jvm/supabase-auth.api
@@ -1,5 +1,6 @@
 public abstract interface class io/github/androidpoet/supabase/auth/AuthClient {
 	public abstract fun exchangeCodeForSession (Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun fetchJwks (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun generatePkceParams (Lkotlin/jvm/functions/Function1;)Lio/github/androidpoet/supabase/auth/models/PkceParams;
 	public abstract fun getOAuthSignInUrl (Lio/github/androidpoet/supabase/auth/models/OAuthProvider;Ljava/lang/String;Ljava/util/List;Ljava/util/Map;ZLio/github/androidpoet/supabase/auth/models/PkceParams;)Ljava/lang/String;
 	public abstract fun getUser (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
@@ -317,6 +318,77 @@ public synthetic class io/github/androidpoet/supabase/auth/models/IdTokenRequest
 }
 
 public final class io/github/androidpoet/supabase/auth/models/IdTokenRequest$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/androidpoet/supabase/auth/models/Jwk {
+	public static final field Companion Lio/github/androidpoet/supabase/auth/models/Jwk$Companion;
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()Ljava/lang/String;
+	public final fun component6 ()Ljava/lang/String;
+	public final fun component7 ()Ljava/lang/String;
+	public final fun component8 ()Ljava/lang/String;
+	public final fun component9 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lio/github/androidpoet/supabase/auth/models/Jwk;
+	public static synthetic fun copy$default (Lio/github/androidpoet/supabase/auth/models/Jwk;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lio/github/androidpoet/supabase/auth/models/Jwk;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAlgorithm ()Ljava/lang/String;
+	public final fun getCurve ()Ljava/lang/String;
+	public final fun getExponent ()Ljava/lang/String;
+	public final fun getKeyId ()Ljava/lang/String;
+	public final fun getKeyType ()Ljava/lang/String;
+	public final fun getModulus ()Ljava/lang/String;
+	public final fun getUse ()Ljava/lang/String;
+	public final fun getX ()Ljava/lang/String;
+	public final fun getY ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public synthetic class io/github/androidpoet/supabase/auth/models/Jwk$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/androidpoet/supabase/auth/models/Jwk$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/androidpoet/supabase/auth/models/Jwk;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/androidpoet/supabase/auth/models/Jwk;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+}
+
+public final class io/github/androidpoet/supabase/auth/models/Jwk$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/androidpoet/supabase/auth/models/JwkSet {
+	public static final field Companion Lio/github/androidpoet/supabase/auth/models/JwkSet$Companion;
+	public fun <init> ()V
+	public fun <init> (Ljava/util/List;)V
+	public synthetic fun <init> (Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/util/List;
+	public final fun copy (Ljava/util/List;)Lio/github/androidpoet/supabase/auth/models/JwkSet;
+	public static synthetic fun copy$default (Lio/github/androidpoet/supabase/auth/models/JwkSet;Ljava/util/List;ILjava/lang/Object;)Lio/github/androidpoet/supabase/auth/models/JwkSet;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getKeys ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public synthetic class io/github/androidpoet/supabase/auth/models/JwkSet$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/androidpoet/supabase/auth/models/JwkSet$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/androidpoet/supabase/auth/models/JwkSet;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/androidpoet/supabase/auth/models/JwkSet;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+}
+
+public final class io/github/androidpoet/supabase/auth/models/JwkSet$Companion {
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 

--- a/supabase-auth/api/supabase-auth.klib.api
+++ b/supabase-auth/api/supabase-auth.klib.api
@@ -176,6 +176,7 @@ abstract interface io.github.androidpoet.supabase.auth/AuthClient { // io.github
     abstract fun generatePkceParams(kotlin/Function1<kotlin/ByteArray, kotlin/ByteArray>? = ...): io.github.androidpoet.supabase.auth.models/PkceParams // io.github.androidpoet.supabase.auth/AuthClient.generatePkceParams|generatePkceParams(kotlin.Function1<kotlin.ByteArray,kotlin.ByteArray>?){}[0]
     abstract fun getOAuthSignInUrl(io.github.androidpoet.supabase.auth.models/OAuthProvider, kotlin/String? = ..., kotlin.collections/List<kotlin/String> = ..., kotlin.collections/Map<kotlin/String, kotlin/String> = ..., kotlin/Boolean = ..., io.github.androidpoet.supabase.auth.models/PkceParams? = ...): kotlin/String // io.github.androidpoet.supabase.auth/AuthClient.getOAuthSignInUrl|getOAuthSignInUrl(io.github.androidpoet.supabase.auth.models.OAuthProvider;kotlin.String?;kotlin.collections.List<kotlin.String>;kotlin.collections.Map<kotlin.String,kotlin.String>;kotlin.Boolean;io.github.androidpoet.supabase.auth.models.PkceParams?){}[0]
     abstract suspend fun exchangeCodeForSession(kotlin/String, kotlin/String): io.github.androidpoet.supabase.core.result/SupabaseResult<io.github.androidpoet.supabase.auth.models/Session> // io.github.androidpoet.supabase.auth/AuthClient.exchangeCodeForSession|exchangeCodeForSession(kotlin.String;kotlin.String){}[0]
+    abstract suspend fun fetchJwks(): io.github.androidpoet.supabase.core.result/SupabaseResult<kotlin/String> // io.github.androidpoet.supabase.auth/AuthClient.fetchJwks|fetchJwks(){}[0]
     abstract suspend fun getUser(kotlin/String): io.github.androidpoet.supabase.core.result/SupabaseResult<io.github.androidpoet.supabase.auth.models/User> // io.github.androidpoet.supabase.auth/AuthClient.getUser|getUser(kotlin.String){}[0]
     abstract suspend fun getUserIdentities(kotlin/String): io.github.androidpoet.supabase.core.result/SupabaseResult<kotlin.collections/List<io.github.androidpoet.supabase.auth.models/UserIdentity>> // io.github.androidpoet.supabase.auth/AuthClient.getUserIdentities|getUserIdentities(kotlin.String){}[0]
     abstract suspend fun linkIdentity(kotlin/String, io.github.androidpoet.supabase.auth.models/OAuthProvider, kotlin/String? = ..., kotlin.collections/List<kotlin/String> = ..., kotlin.collections/Map<kotlin/String, kotlin/String> = ...): io.github.androidpoet.supabase.core.result/SupabaseResult<io.github.androidpoet.supabase.auth.models/LinkIdentityResponse> // io.github.androidpoet.supabase.auth/AuthClient.linkIdentity|linkIdentity(kotlin.String;io.github.androidpoet.supabase.auth.models.OAuthProvider;kotlin.String?;kotlin.collections.List<kotlin.String>;kotlin.collections.Map<kotlin.String,kotlin.String>){}[0]
@@ -406,6 +407,84 @@ final class io.github.androidpoet.supabase.auth.models/IdTokenRequest { // io.gi
 
     final object Companion { // io.github.androidpoet.supabase.auth.models/IdTokenRequest.Companion|null[0]
         final fun serializer(): kotlinx.serialization/KSerializer<io.github.androidpoet.supabase.auth.models/IdTokenRequest> // io.github.androidpoet.supabase.auth.models/IdTokenRequest.Companion.serializer|serializer(){}[0]
+    }
+}
+
+final class io.github.androidpoet.supabase.auth.models/Jwk { // io.github.androidpoet.supabase.auth.models/Jwk|null[0]
+    constructor <init>(kotlin/String, kotlin/String? = ..., kotlin/String? = ..., kotlin/String? = ..., kotlin/String? = ..., kotlin/String? = ..., kotlin/String? = ..., kotlin/String? = ..., kotlin/String? = ...) // io.github.androidpoet.supabase.auth.models/Jwk.<init>|<init>(kotlin.String;kotlin.String?;kotlin.String?;kotlin.String?;kotlin.String?;kotlin.String?;kotlin.String?;kotlin.String?;kotlin.String?){}[0]
+
+    final val algorithm // io.github.androidpoet.supabase.auth.models/Jwk.algorithm|{}algorithm[0]
+        final fun <get-algorithm>(): kotlin/String? // io.github.androidpoet.supabase.auth.models/Jwk.algorithm.<get-algorithm>|<get-algorithm>(){}[0]
+    final val curve // io.github.androidpoet.supabase.auth.models/Jwk.curve|{}curve[0]
+        final fun <get-curve>(): kotlin/String? // io.github.androidpoet.supabase.auth.models/Jwk.curve.<get-curve>|<get-curve>(){}[0]
+    final val exponent // io.github.androidpoet.supabase.auth.models/Jwk.exponent|{}exponent[0]
+        final fun <get-exponent>(): kotlin/String? // io.github.androidpoet.supabase.auth.models/Jwk.exponent.<get-exponent>|<get-exponent>(){}[0]
+    final val keyId // io.github.androidpoet.supabase.auth.models/Jwk.keyId|{}keyId[0]
+        final fun <get-keyId>(): kotlin/String? // io.github.androidpoet.supabase.auth.models/Jwk.keyId.<get-keyId>|<get-keyId>(){}[0]
+    final val keyType // io.github.androidpoet.supabase.auth.models/Jwk.keyType|{}keyType[0]
+        final fun <get-keyType>(): kotlin/String // io.github.androidpoet.supabase.auth.models/Jwk.keyType.<get-keyType>|<get-keyType>(){}[0]
+    final val modulus // io.github.androidpoet.supabase.auth.models/Jwk.modulus|{}modulus[0]
+        final fun <get-modulus>(): kotlin/String? // io.github.androidpoet.supabase.auth.models/Jwk.modulus.<get-modulus>|<get-modulus>(){}[0]
+    final val use // io.github.androidpoet.supabase.auth.models/Jwk.use|{}use[0]
+        final fun <get-use>(): kotlin/String? // io.github.androidpoet.supabase.auth.models/Jwk.use.<get-use>|<get-use>(){}[0]
+    final val x // io.github.androidpoet.supabase.auth.models/Jwk.x|{}x[0]
+        final fun <get-x>(): kotlin/String? // io.github.androidpoet.supabase.auth.models/Jwk.x.<get-x>|<get-x>(){}[0]
+    final val y // io.github.androidpoet.supabase.auth.models/Jwk.y|{}y[0]
+        final fun <get-y>(): kotlin/String? // io.github.androidpoet.supabase.auth.models/Jwk.y.<get-y>|<get-y>(){}[0]
+
+    final fun component1(): kotlin/String // io.github.androidpoet.supabase.auth.models/Jwk.component1|component1(){}[0]
+    final fun component2(): kotlin/String? // io.github.androidpoet.supabase.auth.models/Jwk.component2|component2(){}[0]
+    final fun component3(): kotlin/String? // io.github.androidpoet.supabase.auth.models/Jwk.component3|component3(){}[0]
+    final fun component4(): kotlin/String? // io.github.androidpoet.supabase.auth.models/Jwk.component4|component4(){}[0]
+    final fun component5(): kotlin/String? // io.github.androidpoet.supabase.auth.models/Jwk.component5|component5(){}[0]
+    final fun component6(): kotlin/String? // io.github.androidpoet.supabase.auth.models/Jwk.component6|component6(){}[0]
+    final fun component7(): kotlin/String? // io.github.androidpoet.supabase.auth.models/Jwk.component7|component7(){}[0]
+    final fun component8(): kotlin/String? // io.github.androidpoet.supabase.auth.models/Jwk.component8|component8(){}[0]
+    final fun component9(): kotlin/String? // io.github.androidpoet.supabase.auth.models/Jwk.component9|component9(){}[0]
+    final fun copy(kotlin/String = ..., kotlin/String? = ..., kotlin/String? = ..., kotlin/String? = ..., kotlin/String? = ..., kotlin/String? = ..., kotlin/String? = ..., kotlin/String? = ..., kotlin/String? = ...): io.github.androidpoet.supabase.auth.models/Jwk // io.github.androidpoet.supabase.auth.models/Jwk.copy|copy(kotlin.String;kotlin.String?;kotlin.String?;kotlin.String?;kotlin.String?;kotlin.String?;kotlin.String?;kotlin.String?;kotlin.String?){}[0]
+    final fun equals(kotlin/Any?): kotlin/Boolean // io.github.androidpoet.supabase.auth.models/Jwk.equals|equals(kotlin.Any?){}[0]
+    final fun hashCode(): kotlin/Int // io.github.androidpoet.supabase.auth.models/Jwk.hashCode|hashCode(){}[0]
+    final fun toString(): kotlin/String // io.github.androidpoet.supabase.auth.models/Jwk.toString|toString(){}[0]
+
+    final object $serializer : kotlinx.serialization.internal/GeneratedSerializer<io.github.androidpoet.supabase.auth.models/Jwk> { // io.github.androidpoet.supabase.auth.models/Jwk.$serializer|null[0]
+        final val descriptor // io.github.androidpoet.supabase.auth.models/Jwk.$serializer.descriptor|{}descriptor[0]
+            final fun <get-descriptor>(): kotlinx.serialization.descriptors/SerialDescriptor // io.github.androidpoet.supabase.auth.models/Jwk.$serializer.descriptor.<get-descriptor>|<get-descriptor>(){}[0]
+
+        final fun childSerializers(): kotlin/Array<kotlinx.serialization/KSerializer<*>> // io.github.androidpoet.supabase.auth.models/Jwk.$serializer.childSerializers|childSerializers(){}[0]
+        final fun deserialize(kotlinx.serialization.encoding/Decoder): io.github.androidpoet.supabase.auth.models/Jwk // io.github.androidpoet.supabase.auth.models/Jwk.$serializer.deserialize|deserialize(kotlinx.serialization.encoding.Decoder){}[0]
+        final fun serialize(kotlinx.serialization.encoding/Encoder, io.github.androidpoet.supabase.auth.models/Jwk) // io.github.androidpoet.supabase.auth.models/Jwk.$serializer.serialize|serialize(kotlinx.serialization.encoding.Encoder;io.github.androidpoet.supabase.auth.models.Jwk){}[0]
+    }
+
+    final object Companion { // io.github.androidpoet.supabase.auth.models/Jwk.Companion|null[0]
+        final fun serializer(): kotlinx.serialization/KSerializer<io.github.androidpoet.supabase.auth.models/Jwk> // io.github.androidpoet.supabase.auth.models/Jwk.Companion.serializer|serializer(){}[0]
+    }
+}
+
+final class io.github.androidpoet.supabase.auth.models/JwkSet { // io.github.androidpoet.supabase.auth.models/JwkSet|null[0]
+    constructor <init>(kotlin.collections/List<io.github.androidpoet.supabase.auth.models/Jwk> = ...) // io.github.androidpoet.supabase.auth.models/JwkSet.<init>|<init>(kotlin.collections.List<io.github.androidpoet.supabase.auth.models.Jwk>){}[0]
+
+    final val keys // io.github.androidpoet.supabase.auth.models/JwkSet.keys|{}keys[0]
+        final fun <get-keys>(): kotlin.collections/List<io.github.androidpoet.supabase.auth.models/Jwk> // io.github.androidpoet.supabase.auth.models/JwkSet.keys.<get-keys>|<get-keys>(){}[0]
+
+    final fun component1(): kotlin.collections/List<io.github.androidpoet.supabase.auth.models/Jwk> // io.github.androidpoet.supabase.auth.models/JwkSet.component1|component1(){}[0]
+    final fun copy(kotlin.collections/List<io.github.androidpoet.supabase.auth.models/Jwk> = ...): io.github.androidpoet.supabase.auth.models/JwkSet // io.github.androidpoet.supabase.auth.models/JwkSet.copy|copy(kotlin.collections.List<io.github.androidpoet.supabase.auth.models.Jwk>){}[0]
+    final fun equals(kotlin/Any?): kotlin/Boolean // io.github.androidpoet.supabase.auth.models/JwkSet.equals|equals(kotlin.Any?){}[0]
+    final fun hashCode(): kotlin/Int // io.github.androidpoet.supabase.auth.models/JwkSet.hashCode|hashCode(){}[0]
+    final fun toString(): kotlin/String // io.github.androidpoet.supabase.auth.models/JwkSet.toString|toString(){}[0]
+
+    final object $serializer : kotlinx.serialization.internal/GeneratedSerializer<io.github.androidpoet.supabase.auth.models/JwkSet> { // io.github.androidpoet.supabase.auth.models/JwkSet.$serializer|null[0]
+        final val descriptor // io.github.androidpoet.supabase.auth.models/JwkSet.$serializer.descriptor|{}descriptor[0]
+            final fun <get-descriptor>(): kotlinx.serialization.descriptors/SerialDescriptor // io.github.androidpoet.supabase.auth.models/JwkSet.$serializer.descriptor.<get-descriptor>|<get-descriptor>(){}[0]
+
+        final fun childSerializers(): kotlin/Array<kotlinx.serialization/KSerializer<*>> // io.github.androidpoet.supabase.auth.models/JwkSet.$serializer.childSerializers|childSerializers(){}[0]
+        final fun deserialize(kotlinx.serialization.encoding/Decoder): io.github.androidpoet.supabase.auth.models/JwkSet // io.github.androidpoet.supabase.auth.models/JwkSet.$serializer.deserialize|deserialize(kotlinx.serialization.encoding.Decoder){}[0]
+        final fun serialize(kotlinx.serialization.encoding/Encoder, io.github.androidpoet.supabase.auth.models/JwkSet) // io.github.androidpoet.supabase.auth.models/JwkSet.$serializer.serialize|serialize(kotlinx.serialization.encoding.Encoder;io.github.androidpoet.supabase.auth.models.JwkSet){}[0]
+    }
+
+    final object Companion { // io.github.androidpoet.supabase.auth.models/JwkSet.Companion|null[0]
+        final val $childSerializers // io.github.androidpoet.supabase.auth.models/JwkSet.Companion.$childSerializers|{}$childSerializers[0]
+
+        final fun serializer(): kotlinx.serialization/KSerializer<io.github.androidpoet.supabase.auth.models/JwkSet> // io.github.androidpoet.supabase.auth.models/JwkSet.Companion.serializer|serializer(){}[0]
     }
 }
 

--- a/supabase-auth/build.gradle.kts
+++ b/supabase-auth/build.gradle.kts
@@ -37,11 +37,20 @@ kotlin {
             implementation(libs.kotlinx.coroutines.core)
             implementation(libs.kotlinx.serialization.json)
             implementation(libs.cryptography.random)
+            implementation(libs.cryptography.core)
         }
         commonTest.dependencies {
             implementation(libs.kotlin.test)
             implementation(libs.kotlinx.coroutines.test)
         }
+        // Local JWT (ES256) verification delegates to each platform's native crypto backend.
+        // cryptography-kotlin has no single multiplatform provider for 0.4.x, so wire one per target.
+        jvmMain.dependencies { implementation(libs.cryptography.provider.jdk) }
+        androidMain.dependencies { implementation(libs.cryptography.provider.jdk) }
+        appleMain.dependencies { implementation(libs.cryptography.provider.apple) }
+        wasmJsMain.dependencies { implementation(libs.cryptography.provider.webcrypto) }
+        val linuxX64Main by getting { dependencies { implementation(libs.cryptography.provider.openssl3.prebuilt) } }
+        val mingwX64Main by getting { dependencies { implementation(libs.cryptography.provider.openssl3.prebuilt) } }
     }
 }
 

--- a/supabase-auth/detekt-baseline.xml
+++ b/supabase-auth/detekt-baseline.xml
@@ -3,7 +3,7 @@
   <ManuallySuppressedIssues/>
   <CurrentIssues>
     <ID>ComplexCondition:AuthClientExt.kt$b1 &lt; 0 || b2 &lt; 0 || (c3 != '=' &amp;&amp; b3 &lt; 0) || (c4 != '=' &amp;&amp; b4 &lt; 0)</ID>
-    <ID>CyclomaticComplexMethod:AuthClientExt.kt$private fun decodeBase64Url(input: String): String?</ID>
+    <ID>CyclomaticComplexMethod:AuthClientExt.kt$private fun decodeBase64UrlBytes(input: String): ByteArray?</ID>
     <ID>InstanceOfCheckForException:AuthClientExt.kt$e is CancellationException</ID>
     <ID>LargeClass:AuthClientImpl.kt$AuthClientImpl : AuthClient</ID>
     <ID>LoopWithTooManyJumpStatements:AuthClientExt.kt$while</ID>
@@ -18,6 +18,6 @@
     <ID>MaxLineLength:AuthClientImplTest.kt$FakeSupabaseClient$endpoint == "/auth/v1/oauth/authorizations/authz-1/consent" &amp;&amp; body?.contains("\"action\":\"approve\"") == true</ID>
     <ID>MaxLineLength:AuthClientImplTest.kt$FakeSupabaseClient$endpoint == "/auth/v1/oauth/authorizations/authz-1/consent" &amp;&amp; body?.contains("\"action\":\"deny\"") == true</ID>
     <ID>MaxLineLength:SessionManagerImplTest.kt$SessionFakeSupabaseClient$"""{"access_token":"refreshed-acc","refresh_token":"refreshed-ref","expires_in":3600,"token_type":"bearer","user":{"id":"user-1"}}"""</ID>
-    <ID>ReturnCount:AuthClientExt.kt$private fun decodeBase64Url(input: String): String?</ID>
+    <ID>ReturnCount:AuthClientExt.kt$private fun decodeBase64UrlBytes(input: String): ByteArray?</ID>
   </CurrentIssues>
 </SmellBaseline>

--- a/supabase-auth/src/commonMain/kotlin/io/github/androidpoet/supabase/auth/AuthClient.kt
+++ b/supabase-auth/src/commonMain/kotlin/io/github/androidpoet/supabase/auth/AuthClient.kt
@@ -142,6 +142,12 @@ public interface AuthClient {
 
     public suspend fun getUser(accessToken: String): SupabaseResult<User>
 
+    /**
+     * Fetches the raw JSON Web Key Set (JWKS) from `/auth/v1/.well-known/jwks.json`. Used by
+     * [getClaims] to verify asymmetric token signatures locally without an Auth server round-trip.
+     */
+    public suspend fun fetchJwks(): SupabaseResult<String>
+
     public suspend fun getUserIdentities(accessToken: String): SupabaseResult<List<UserIdentity>>
 
     public suspend fun updateUser(

--- a/supabase-auth/src/commonMain/kotlin/io/github/androidpoet/supabase/auth/AuthClientExt.kt
+++ b/supabase-auth/src/commonMain/kotlin/io/github/androidpoet/supabase/auth/AuthClientExt.kt
@@ -1,5 +1,11 @@
 package io.github.androidpoet.supabase.auth
 
+import dev.whyoleg.cryptography.CryptographyProvider
+import dev.whyoleg.cryptography.algorithms.EC
+import dev.whyoleg.cryptography.algorithms.ECDSA
+import dev.whyoleg.cryptography.algorithms.SHA256
+import io.github.androidpoet.supabase.auth.models.Jwk
+import io.github.androidpoet.supabase.auth.models.JwkSet
 import io.github.androidpoet.supabase.auth.models.JwtClaims
 import io.github.androidpoet.supabase.auth.models.JwtClaimsResult
 import io.github.androidpoet.supabase.auth.models.JwtHeader
@@ -17,6 +23,7 @@ import io.github.androidpoet.supabase.auth.models.UserUpdateRequest
 import io.github.androidpoet.supabase.auth.session.SessionManager
 import io.github.androidpoet.supabase.core.result.SupabaseError
 import io.github.androidpoet.supabase.core.result.SupabaseResult
+import io.github.androidpoet.supabase.core.result.map
 import kotlinx.coroutines.CancellationException
 import kotlinx.datetime.Clock
 import kotlinx.serialization.json.Json
@@ -797,13 +804,21 @@ private fun decodeJwt(jwt: String): SupabaseResult<JwtClaimsResult> {
  * `auth.getClaims()`.
  *
  * The header and payload are decoded locally into [JwtClaims] (use [JwtClaimsResult.raw] for any
- * non-standard claim). When [verify] is true the token's authenticity is confirmed against the
- * Auth server (the same validation [AuthClient.getUser] performs), which covers both symmetric
- * (HS256) and asymmetric signing. Local JWKS signature verification is not yet implemented, so a
- * server round-trip is used when [verify] is true.
+ * non-standard claim). When [verify] is true the token's signature is checked:
+ *
+ * - For asymmetric `ES256` (ECDSA P-256) tokens the signature is verified **locally** against the
+ *   project's JWKS (fetched via [AuthClient.fetchJwks]), avoiding a network round-trip — this is
+ *   what distinguishes `getClaims` from [AuthClient.getUser].
+ * - For any other case (symmetric `HS256`, other asymmetric algorithms, a missing `kid`, an
+ *   unreachable JWKS endpoint, or a platform without local crypto), it falls back to validating the
+ *   token against the Auth server, the same check [AuthClient.getUser] performs. Falling back is
+ *   always safe because the server re-validates the signature.
+ *
+ * Local verification uses platform-native crypto (JDK/JCA, Apple Security, WebCrypto, OpenSSL3) via
+ * the `cryptography-kotlin` library; signature math is never hand-rolled.
  *
  * @param jwt the JWT to inspect, e.g. a session access token.
- * @param verify when true, validate the token against the Auth server before returning the claims.
+ * @param verify when true, verify the token's signature before returning the claims.
  * @param allowExpired when false, a token whose `exp` is in the past is rejected without a network call.
  */
 public suspend fun AuthClient.getClaims(
@@ -821,10 +836,109 @@ public suspend fun AuthClient.getClaims(
         return SupabaseResult.Failure(SupabaseError(message = "JWT has expired"))
     }
     if (verify) {
-        val validation = getUser(accessToken = jwt)
+        val validation = verifyJwt(jwt, decoded.header)
         if (validation is SupabaseResult.Failure) return validation
     }
     return SupabaseResult.Success(decoded)
+}
+
+/**
+ * Verifies [jwt] either locally (asymmetric ES256 against the project JWKS) or, when local
+ * verification isn't applicable, by asking the Auth server. The server path is always safe.
+ */
+private suspend fun AuthClient.verifyJwt(
+    jwt: String,
+    header: JwtHeader,
+): SupabaseResult<Unit> =
+    when (verifyEs256Locally(jwt, header)) {
+        LocalVerification.VALID -> SupabaseResult.Success(Unit)
+        LocalVerification.INVALID ->
+            SupabaseResult.Failure(SupabaseError(message = "JWT signature verification failed"))
+        LocalVerification.UNSUPPORTED -> getUser(accessToken = jwt).map { }
+    }
+
+private enum class LocalVerification { VALID, INVALID, UNSUPPORTED }
+
+/** Material required to verify an ES256 signature: the RAW public key, the signing input, and the signature. */
+private class Es256Material(
+    val publicKey: ByteArray,
+    val signingInput: ByteArray,
+    val signature: ByteArray,
+)
+
+private const val ES256_ALG = "ES256"
+private const val EC_CURVE_P256 = "P-256"
+private const val EC_KEY_TYPE = "EC"
+private const val EC_COORDINATE_SIZE = 32
+private const val EC_UNCOMPRESSED_TAG: Byte = 0x04
+private const val JWT_PART_COUNT = 3
+
+/**
+ * Attempts a local ES256 signature check. Returns [LocalVerification.UNSUPPORTED] for any token that
+ * can't be verified locally (wrong alg, missing key, JWKS fetch failure, or no platform crypto), so
+ * the caller can fall back to the server.
+ */
+private suspend fun AuthClient.verifyEs256Locally(
+    jwt: String,
+    header: JwtHeader,
+): LocalVerification {
+    val material = buildEs256Material(jwt, header) ?: return LocalVerification.UNSUPPORTED
+    return try {
+        if (verifyEs256(material)) LocalVerification.VALID else LocalVerification.INVALID
+    } catch (e: Throwable) {
+        if (e is CancellationException) throw e
+        LocalVerification.UNSUPPORTED
+    }
+}
+
+private suspend fun AuthClient.buildEs256Material(
+    jwt: String,
+    header: JwtHeader,
+): Es256Material? {
+    val parts = jwt.split('.')
+    val kid = header.keyId
+    if (header.algorithm != ES256_ALG || kid == null || parts.size < JWT_PART_COUNT) return null
+    val publicKey = resolveJwk(kid)?.let(::ecPublicKeyBytes) ?: return null
+    val signature = decodeBase64UrlBytes(parts[2]) ?: return null
+    return Es256Material(
+        publicKey = publicKey,
+        signingInput = "${parts[0]}.${parts[1]}".encodeToByteArray(),
+        signature = signature,
+    )
+}
+
+private suspend fun AuthClient.resolveJwk(kid: String): Jwk? {
+    val raw =
+        when (val result = fetchJwks()) {
+            is SupabaseResult.Failure -> return null
+            is SupabaseResult.Success -> result.value
+        }
+    return try {
+        claimsJson.decodeFromString(JwkSet.serializer(), raw).keys.firstOrNull { it.keyId == kid }
+    } catch (e: Throwable) {
+        if (e is CancellationException) throw e
+        null
+    }
+}
+
+/** Reconstructs the RAW (uncompressed `0x04 || X || Y`) public key bytes for an EC P-256 JWK. */
+private fun ecPublicKeyBytes(jwk: Jwk): ByteArray? {
+    if (jwk.keyType != EC_KEY_TYPE || jwk.curve != EC_CURVE_P256) return null
+    val x = jwk.x?.let(::decodeBase64UrlBytes) ?: return null
+    val y = jwk.y?.let(::decodeBase64UrlBytes) ?: return null
+    if (x.size != EC_COORDINATE_SIZE || y.size != EC_COORDINATE_SIZE) return null
+    return byteArrayOf(EC_UNCOMPRESSED_TAG) + x + y
+}
+
+private suspend fun verifyEs256(material: Es256Material): Boolean {
+    val ecdsa = CryptographyProvider.Default.get(ECDSA)
+    val publicKey =
+        ecdsa
+            .publicKeyDecoder(EC.Curve.P256)
+            .decodeFromByteArray(EC.PublicKey.Format.RAW, material.publicKey)
+    return publicKey
+        .signatureVerifier(SHA256, ECDSA.SignatureFormat.RAW)
+        .tryVerifySignature(material.signingInput, material.signature)
 }
 
 /** Decodes and verifies the claims of the current session's access token. See [getClaims]. */
@@ -839,7 +953,9 @@ public suspend fun SessionManager.getClaimsForCurrentSession(
     return authClient.getClaims(jwt = token, verify = verify, allowExpired = allowExpired)
 }
 
-private fun decodeBase64Url(input: String): String? {
+private fun decodeBase64Url(input: String): String? = decodeBase64UrlBytes(input)?.decodeToString()
+
+private fun decodeBase64UrlBytes(input: String): ByteArray? {
     val normalized =
         input
             .replace('-', '+')
@@ -870,5 +986,5 @@ private fun decodeBase64Url(input: String): String? {
         if (c4 != '=') output += (n and 0xFF).toByte()
         i += 4
     }
-    return output.toByteArray().decodeToString()
+    return output.toByteArray()
 }

--- a/supabase-auth/src/commonMain/kotlin/io/github/androidpoet/supabase/auth/AuthClientImpl.kt
+++ b/supabase-auth/src/commonMain/kotlin/io/github/androidpoet/supabase/auth/AuthClientImpl.kt
@@ -315,6 +315,8 @@ internal class AuthClientImpl(
                 headers = bearerHeaders(accessToken),
             ).deserialize()
 
+    override suspend fun fetchJwks(): SupabaseResult<String> = client.get(endpoint = "/auth/v1/.well-known/jwks.json")
+
     override suspend fun getUserIdentities(accessToken: String): SupabaseResult<List<UserIdentity>> =
         when (val result = getUser(accessToken = accessToken)) {
             is SupabaseResult.Failure -> result

--- a/supabase-auth/src/commonMain/kotlin/io/github/androidpoet/supabase/auth/models/AuthModels.kt
+++ b/supabase-auth/src/commonMain/kotlin/io/github/androidpoet/supabase/auth/models/AuthModels.kt
@@ -494,3 +494,26 @@ public data class JwtClaimsResult(
     public val signature: String,
     public val raw: JsonObject,
 )
+
+/**
+ * A single JSON Web Key from a project's JWKS endpoint. Only the fields needed to reconstruct a
+ * public key for signature verification are modelled; unknown fields are ignored.
+ */
+@Serializable
+public data class Jwk(
+    @SerialName("kty") public val keyType: String,
+    @SerialName("alg") public val algorithm: String? = null,
+    @SerialName("kid") public val keyId: String? = null,
+    @SerialName("crv") public val curve: String? = null,
+    @SerialName("use") public val use: String? = null,
+    @SerialName("x") public val x: String? = null,
+    @SerialName("y") public val y: String? = null,
+    @SerialName("n") public val modulus: String? = null,
+    @SerialName("e") public val exponent: String? = null,
+)
+
+/** A JSON Web Key Set, as returned by `/auth/v1/.well-known/jwks.json`. */
+@Serializable
+public data class JwkSet(
+    @SerialName("keys") public val keys: List<Jwk> = emptyList(),
+)

--- a/supabase-auth/src/commonTest/kotlin/io/github/androidpoet/supabase/auth/AuthClientExtTest.kt
+++ b/supabase-auth/src/commonTest/kotlin/io/github/androidpoet/supabase/auth/AuthClientExtTest.kt
@@ -52,6 +52,21 @@ private const val JWT_VALID_PAYLOAD =
         "MTAyNDQ0ODAwLCJpYXQiOjE3MDAwMDAwMDAsInNlc3Npb25faWQiOiJzZXNzLTEiLCJhYWwiOiJhYWwxIn0"
 private const val JWT_EXPIRED_PAYLOAD = "eyJzdWIiOiJ1MSIsInJvbGUiOiJhdXRoZW50aWNhdGVkIiwiZXhwIjoxNzAwMDAwMDAwfQ"
 
+// Real ES256 fixture: a P-256 key pair signs the JWT below; JWKS_ES256_JSON is the matching public key.
+//   header  = {"alg":"ES256","typ":"JWT","kid":"test-es256-key"}
+//   payload = {"sub":"user-123","email":"jwt@example.com","role":"authenticated",...,"exp":4102444800,...}
+private const val JWT_ES256_HEADER = "eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCIsImtpZCI6InRlc3QtZXMyNTYta2V5In0"
+private const val JWT_ES256_PAYLOAD =
+    "eyJzdWIiOiJ1c2VyLTEyMyIsImVtYWlsIjoiand0QGV4YW1wbGUuY29tIiwicm9sZSI6ImF1dGhlbnRpY2F0ZWQiLC" +
+        "Jpc3MiOiJodHRwczovL2RlbW8uc3VwYWJhc2UuY28vYXV0aC92MSIsImV4cCI6NDEwMjQ0NDgwMCwiaWF0IjoxNzAw" +
+        "MDAwMDAwLCJzZXNzaW9uX2lkIjoic2Vzcy0xIn0"
+private const val JWT_ES256_SIG = "TYd2l98wlxvmYMfOX8-hI6M5zsnhJqTm5v_l9thVyGF61YCnJBOTrykgxsd-xwaAJjcGx32V9dBVBEuS1WBwpQ"
+private const val JWT_ES256_BAD_SIG = "TYd2l98wlxvmYMfOX8-hI6M5zsnhJqTm5v_l9thVyGF61YCnJBOTrykgxsd-xwaAJjcGx32V9dBVBEuS1WBwpA"
+private const val JWKS_ES256_JSON =
+    "{\"keys\":[{\"kty\":\"EC\",\"crv\":\"P-256\",\"kid\":\"test-es256-key\",\"alg\":\"ES256\"," +
+        "\"use\":\"sig\",\"x\":\"Rxw-dYxJBChbun5TEY7Q9SSt6wdX0lvS-Oew1236cUw\",\"y\":\"3VIPesqKi5F6" +
+        "zDf1HejwybvjrYWDgucC3CWhLQn3qFg\"}]}"
+
 class AuthClientExtTest {
     @Test
     fun test_signUp_alias_routesToEmailSignup() =
@@ -429,6 +444,46 @@ class AuthClientExtTest {
             val result = FakeAuthClient().getClaims("not-a-jwt")
 
             assertTrue(result is SupabaseResult.Failure)
+        }
+
+    @Test
+    fun test_getClaims_verifiesEs256SignatureLocallyWithoutServerCall() =
+        runTest {
+            val auth = FakeAuthClient().apply { jwksResponse = SupabaseResult.Success(JWKS_ES256_JSON) }
+            val jwt = "$JWT_ES256_HEADER.$JWT_ES256_PAYLOAD.$JWT_ES256_SIG"
+
+            val result = auth.getClaims(jwt)
+
+            assertTrue(result is SupabaseResult.Success)
+            assertEquals("user-123", result.value.claims.subject)
+            // A valid local ES256 verification must NOT fall back to the Auth server.
+            assertNull(auth.lastGetUserAccessToken)
+        }
+
+    @Test
+    fun test_getClaims_rejectsTamperedEs256SignatureWithoutServerCall() =
+        runTest {
+            val auth = FakeAuthClient().apply { jwksResponse = SupabaseResult.Success(JWKS_ES256_JSON) }
+            val jwt = "$JWT_ES256_HEADER.$JWT_ES256_PAYLOAD.$JWT_ES256_BAD_SIG"
+
+            val result = auth.getClaims(jwt)
+
+            assertTrue(result is SupabaseResult.Failure)
+            // A definitive local "invalid" verdict is final — no server fallback that might mask forgery.
+            assertNull(auth.lastGetUserAccessToken)
+        }
+
+    @Test
+    fun test_getClaims_fallsBackToServerWhenJwksMissingKey() =
+        runTest {
+            // Default JWKS has no matching key, so local verification can't run and the server is used.
+            val auth = FakeAuthClient()
+            val jwt = "$JWT_ES256_HEADER.$JWT_ES256_PAYLOAD.$JWT_ES256_SIG"
+
+            val result = auth.getClaims(jwt)
+
+            assertTrue(result is SupabaseResult.Success)
+            assertEquals(jwt, auth.lastGetUserAccessToken)
         }
 
     @Test
@@ -870,6 +925,7 @@ private class FakeAuthClient : AuthClient {
     var lastSignOutScope: SignOutScope? = null
     var lastSignOutAccessToken: String? = null
     var lastGetUserAccessToken: String? = null
+    var jwksResponse: SupabaseResult<String> = SupabaseResult.Success("{\"keys\":[]}")
     var lastReauthenticateAccessToken: String? = null
     var lastExchangeAuthCode: String? = null
     var lastExchangeCodeVerifier: String? = null
@@ -1015,6 +1071,8 @@ private class FakeAuthClient : AuthClient {
         SupabaseResult.Success(dummySession.user.copy(email = "updated@b.com")).also {
             lastGetUserAccessToken = accessToken
         }
+
+    override suspend fun fetchJwks(): SupabaseResult<String> = jwksResponse
 
     override suspend fun getUserIdentities(accessToken: String): SupabaseResult<List<UserIdentity>> =
         SupabaseResult.Success(currentUserIdentities).also {


### PR DESCRIPTION
## What

Makes `getClaims()` verify **asymmetric ES256 (ECDSA P-256)** token signatures **locally** against the project's JWKS, instead of always round-tripping to the Auth server.

### Why
Until now `getClaims(verify = true)` simply called `getUser()` under the hood, so it was behaviourally identical to a server round-trip — it gave callers nothing over `getUser()`. In the reference SDK, the whole point of `getClaims` is the fast, offline, local-verification path. This change restores that distinction.

## How
- **New `AuthClient.fetchJwks()`** — fetches `/auth/v1/.well-known/jwks.json` (the apikey is auto-injected by the transport; the endpoint is public).
- **Local ES256 verification** — for ES256 tokens with a `kid`, the matching JWK is resolved, the RAW public key (`0x04 || X || Y`) reconstructed, and the signature checked against the `header.payload` signing input.
- **Safe fallback** — anything that can't be verified locally (HS256, other algorithms, missing `kid`, JWKS fetch failure, or a platform without crypto) falls back to server validation via `getUser()`. Falling back is always safe because the server re-validates the signature. A definitive local *invalid* verdict is final (no fallback that could mask a forgery).
- **No hand-rolled crypto** — signature math is delegated to platform-native backends via [`cryptography-kotlin`](https://github.com/whyoleg/cryptography-kotlin): JDK/JCA (JVM/Android), Apple Security (Apple targets), WebCrypto (wasmJs), OpenSSL3 (linux/mingw). Providers are wired per source set because 0.4.x has no single multiplatform "optimal" provider (and 0.5.0+ require Kotlin 2.2).

## Models
Adds `Jwk` and `JwkSet`.

## Tests
A real ES256 fixture (P-256 key signs a JWT; matching JWKS as the public key):
- valid signature verifies locally, **no** server call
- tampered signature is rejected, **no** server fallback
- missing key in JWKS falls back to the server

Validated on **JVM (JDK crypto)** and **macOS native (Apple Security)**; all 13 targets compile; `apiCheck`, `detekt`, `spotlessCheck` pass.