### PR TITLE
docs: animated hero, nicer code blocks, GitHub CTA + title fix

### DIFF
--- a/website/components/Hero.jsx
+++ b/website/components/Hero.jsx
@@ -1,0 +1,37 @@
+import Link from 'next/link'
+
+const REPO = 'https://github.com/AndroidPoet/supabase-kmp'
+
+const GitHubMark = () => (
+  <svg width="18" height="18" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true">
+    <path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0 0 16 8c0-4.42-3.58-8-8-8Z" />
+  </svg>
+)
+
+export function Hero() {
+  return (
+    <div className="skmp-hero">
+      <div className="skmp-hero-glow" aria-hidden="true" />
+      <span className="skmp-hero-badge">Kotlin Multiplatform · 13 targets</span>
+      <h1 className="skmp-hero-title">Supabase KMP</h1>
+      <p className="skmp-hero-sub">
+        A fully typed Kotlin Multiplatform client for Supabase — Auth, Database,
+        Storage, Realtime &amp; Edge Functions from one shared codebase.
+      </p>
+      <div className="skmp-hero-cta">
+        <Link href="/getting-started" className="skmp-btn skmp-btn-primary">
+          Get started →
+        </Link>
+        <a
+          href={REPO}
+          target="_blank"
+          rel="noreferrer"
+          className="skmp-btn skmp-btn-ghost"
+        >
+          <GitHubMark />
+          View on GitHub
+        </a>
+      </div>
+    </div>
+  )
+}

--- a/website/pages/_app.jsx
+++ b/website/pages/_app.jsx
@@ -1,4 +1,5 @@
 import 'nextra-theme-docs/style.css'
+import '../styles/globals.css'
 
 export default function App({ Component, pageProps }) {
   return <Component {...pageProps} />

--- a/website/pages/_meta.jsx
+++ b/website/pages/_meta.jsx
@@ -9,7 +9,8 @@ export default {
   functions: 'Edge Functions',
   platforms: 'Platforms',
   github_link: {
-    title: 'GitHub ↗',
+    title: 'GitHub',
+    type: 'page',
     href: 'https://github.com/AndroidPoet/supabase-kmp',
     newWindow: true,
   },

--- a/website/pages/index.mdx
+++ b/website/pages/index.mdx
@@ -1,14 +1,11 @@
 ---
-title: Supabase KMP — Kotlin Multiplatform client for Supabase
+title: Kotlin Multiplatform client for Supabase
 ---
 
 import { Cards } from 'nextra/components'
+import { Hero } from '../components/Hero'
 
-# Supabase KMP
-
-A fully typed **Kotlin Multiplatform** client for Supabase — Auth, Database (PostgREST),
-Storage, Realtime and Edge Functions, from one shared codebase across **13 targets**:
-Android, iOS, macOS, tvOS, watchOS, JVM, Linux, Windows and WebAssembly.
+<Hero />
 
 ```kotlin
 val client = Supabase.create(

--- a/website/styles/globals.css
+++ b/website/styles/globals.css
@@ -1,0 +1,157 @@
+/* ---- Entrance animations ---- */
+@keyframes skmp-fade-up {
+  from {
+    opacity: 0;
+    transform: translateY(18px);
+  }
+  to {
+    opacity: 1;
+    transform: none;
+  }
+}
+
+@keyframes skmp-gradient {
+  0%,
+  100% {
+    background-position: 0% 50%;
+  }
+  50% {
+    background-position: 100% 50%;
+  }
+}
+
+@keyframes skmp-float {
+  0%,
+  100% {
+    transform: translate(-50%, 0) scale(1);
+    opacity: 0.55;
+  }
+  50% {
+    transform: translate(-50%, -18px) scale(1.08);
+    opacity: 0.8;
+  }
+}
+
+/* ---- Hero ---- */
+.skmp-hero {
+  position: relative;
+  text-align: center;
+  padding: 4.5rem 1rem 3rem;
+  overflow: hidden;
+}
+
+.skmp-hero-glow {
+  position: absolute;
+  top: -40%;
+  left: 50%;
+  width: min(720px, 90%);
+  height: 420px;
+  transform: translateX(-50%);
+  background: radial-gradient(
+    closest-side,
+    rgba(62, 207, 142, 0.4),
+    rgba(62, 207, 142, 0) 70%
+  );
+  filter: blur(8px);
+  z-index: -1;
+  animation: skmp-float 9s ease-in-out infinite;
+  pointer-events: none;
+}
+
+.skmp-hero-badge {
+  display: inline-block;
+  font-size: 0.78rem;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  padding: 0.3rem 0.75rem;
+  border-radius: 999px;
+  color: #3ecf8e;
+  background: rgba(62, 207, 142, 0.12);
+  border: 1px solid rgba(62, 207, 142, 0.3);
+  animation: skmp-fade-up 0.5s ease both;
+}
+
+.skmp-hero-title {
+  font-size: clamp(2.75rem, 7vw, 4.5rem);
+  font-weight: 800;
+  line-height: 1.05;
+  margin: 1.25rem 0 0;
+  letter-spacing: -0.03em;
+  background: linear-gradient(110deg, #3ecf8e, #24b47e, #38bdf8, #3ecf8e);
+  background-size: 250% 250%;
+  -webkit-background-clip: text;
+  background-clip: text;
+  -webkit-text-fill-color: transparent;
+  animation: skmp-fade-up 0.6s ease both 0.05s, skmp-gradient 8s ease infinite;
+}
+
+.skmp-hero-sub {
+  max-width: 38rem;
+  margin: 1.1rem auto 0;
+  font-size: clamp(1rem, 2.2vw, 1.18rem);
+  line-height: 1.6;
+  color: var(--nextra-fg, #6b7280);
+  opacity: 0.9;
+  animation: skmp-fade-up 0.6s ease both 0.15s;
+}
+
+.skmp-hero-cta {
+  display: flex;
+  gap: 0.75rem;
+  justify-content: center;
+  flex-wrap: wrap;
+  margin-top: 2rem;
+  animation: skmp-fade-up 0.6s ease both 0.25s;
+}
+
+.skmp-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.7rem 1.4rem;
+  border-radius: 0.6rem;
+  font-weight: 600;
+  font-size: 0.95rem;
+  text-decoration: none !important;
+  transition: transform 0.15s ease, box-shadow 0.15s ease, background 0.15s ease;
+}
+
+.skmp-btn:hover {
+  transform: translateY(-2px);
+}
+
+.skmp-btn-primary {
+  color: #022c22 !important;
+  background: linear-gradient(120deg, #3ecf8e, #24b47e);
+  box-shadow: 0 6px 20px -6px rgba(62, 207, 142, 0.7);
+}
+
+.skmp-btn-primary:hover {
+  box-shadow: 0 10px 28px -6px rgba(62, 207, 142, 0.8);
+}
+
+.skmp-btn-ghost {
+  color: inherit !important;
+  border: 1px solid var(--nextra-border, rgba(125, 125, 125, 0.3));
+  background: transparent;
+}
+
+.skmp-btn-ghost:hover {
+  background: rgba(125, 125, 125, 0.08);
+}
+
+/* ---- Code block polish ---- */
+.nextra-code pre {
+  border-radius: 0.7rem !important;
+  box-shadow: 0 4px 18px -10px rgba(0, 0, 0, 0.5);
+  transition: box-shadow 0.2s ease;
+}
+
+.nextra-code:hover pre {
+  box-shadow: 0 8px 26px -10px rgba(62, 207, 142, 0.45);
+}
+
+/* Fade content cards in as the page mounts */
+.nextra-content .nextra-cards {
+  animation: skmp-fade-up 0.5s ease both 0.1s;
+}

--- a/website/theme.config.jsx
+++ b/website/theme.config.jsx
@@ -1,3 +1,5 @@
+import { useConfig } from 'nextra-theme-docs'
+
 const Logo = () => (
   <span style={{ display: 'flex', alignItems: 'center', gap: '0.5rem', fontWeight: 700 }}>
     <svg width="22" height="22" viewBox="0 0 24 24" fill="none" aria-hidden="true">
@@ -31,20 +33,29 @@ export default {
       </span>
     ),
   },
-  head: (
-    <>
-      <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-      <meta name="description" content="Supabase KMP — a fully typed Kotlin Multiplatform client for Supabase Auth, Database, Storage, Realtime and Edge Functions." />
-      <meta property="og:title" content="Supabase KMP" />
-      <meta property="og:description" content="A fully typed Kotlin Multiplatform client for Supabase." />
-    </>
-  ),
+  head: function useHead() {
+    const { frontMatter } = useConfig()
+    const pageTitle = frontMatter?.title
+    const title = pageTitle ? `${pageTitle} – Supabase KMP` : 'Supabase KMP'
+    const description =
+      frontMatter?.description ??
+      'Supabase KMP — a fully typed Kotlin Multiplatform client for Supabase Auth, Database, Storage, Realtime and Edge Functions.'
+    return (
+      <>
+        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+        <title>{title}</title>
+        <meta name="description" content={description} />
+        <meta property="og:title" content={pageTitle ?? 'Supabase KMP'} />
+        <meta property="og:description" content={description} />
+      </>
+    )
+  },
   banner: {
     key: 'native-signin',
     content: (
       <span>
         🎉 Native Google &amp; Apple sign-in is here →{' '}
-        <a href="/auth/native-sign-in" style={{ textDecoration: 'underline' }}>
+        <a href="/supabase-kmp/auth/native-sign-in" style={{ textDecoration: 'underline' }}>
           read the guide
         </a>
       </span>


### PR DESCRIPTION
Follow-up polish on the docs site (#20).

- **Animated hero** — gradient animated title, pill badge, fade-up entrance, floating glow blob (pure CSS, no new deps)
- **GitHub CTA** — prominent "View on GitHub" button (→ repo) alongside "Get started"; both use `next/link` so they respect the `/supabase-kmp` basePath
- **Nicer code blocks** — rounded corners, soft shadow, subtle green hover lift
- **Fix `<title>`** — the previous custom `head` overrode the theme's default and dropped the document title entirely; it now renders a per-page `Title – Supabase KMP` from frontmatter
- **Fix banner deep link** — now includes the basePath so it doesn't 404 on Pages

Verified with `pnpm build` — all routes prerender, titles correct, links carry the basePath.