### PR TITLE
feat(storage): resumable (TUS) uploads + centralized paths

### DIFF
--- a/supabase-auth-admin/src/commonTest/kotlin/io/github/androidpoet/supabase/auth/admin/AuthAdminClientImplTest.kt
+++ b/supabase-auth-admin/src/commonTest/kotlin/io/github/androidpoet/supabase/auth/admin/AuthAdminClientImplTest.kt
@@ -570,6 +570,18 @@ private class FakeSupabaseClient : SupabaseClient {
 
     override fun clearAccessToken() = Unit
 
+    override suspend fun rawRequest(
+        method: io.github.androidpoet.supabase.client.SupabaseHttpMethod,
+        url: String,
+        body: ByteArray?,
+        contentType: String?,
+        headers: Map<String, String>,
+    ): io.github.androidpoet.supabase.core.result.SupabaseResult<io.github.androidpoet.supabase.client.SupabaseHttpResponse> =
+        io.github.androidpoet.supabase.core.result.SupabaseResult.Failure(
+            io.github.androidpoet.supabase.core.result
+                .SupabaseError("rawRequest not supported in test fake"),
+        )
+
     override fun close() = Unit
 
     private fun oauthClientJson(clientSecret: String? = "secret"): String {

--- a/supabase-auth/src/commonTest/kotlin/io/github/androidpoet/supabase/auth/AuthClientImplTest.kt
+++ b/supabase-auth/src/commonTest/kotlin/io/github/androidpoet/supabase/auth/AuthClientImplTest.kt
@@ -641,5 +641,17 @@ private class FakeSupabaseClient : SupabaseClient {
 
     override fun clearAccessToken() = Unit
 
+    override suspend fun rawRequest(
+        method: io.github.androidpoet.supabase.client.SupabaseHttpMethod,
+        url: String,
+        body: ByteArray?,
+        contentType: String?,
+        headers: Map<String, String>,
+    ): io.github.androidpoet.supabase.core.result.SupabaseResult<io.github.androidpoet.supabase.client.SupabaseHttpResponse> =
+        io.github.androidpoet.supabase.core.result.SupabaseResult.Failure(
+            io.github.androidpoet.supabase.core.result
+                .SupabaseError("rawRequest not supported in test fake"),
+        )
+
     override fun close() = Unit
 }

--- a/supabase-auth/src/commonTest/kotlin/io/github/androidpoet/supabase/auth/session/SessionManagerImplTest.kt
+++ b/supabase-auth/src/commonTest/kotlin/io/github/androidpoet/supabase/auth/session/SessionManagerImplTest.kt
@@ -105,6 +105,18 @@ private class SessionFakeSupabaseClient : SupabaseClient {
         accessTokenHeader = null
     }
 
+    override suspend fun rawRequest(
+        method: io.github.androidpoet.supabase.client.SupabaseHttpMethod,
+        url: String,
+        body: ByteArray?,
+        contentType: String?,
+        headers: Map<String, String>,
+    ): io.github.androidpoet.supabase.core.result.SupabaseResult<io.github.androidpoet.supabase.client.SupabaseHttpResponse> =
+        io.github.androidpoet.supabase.core.result.SupabaseResult.Failure(
+            io.github.androidpoet.supabase.core.result
+                .SupabaseError("rawRequest not supported in test fake"),
+        )
+
     override fun close() = Unit
 
     override suspend fun get(

--- a/supabase-client/api/android/supabase-client.api
+++ b/supabase-client/api/android/supabase-client.api
@@ -17,6 +17,7 @@ public abstract interface class io/github/androidpoet/supabase/client/SupabaseCl
 	public abstract fun postRaw (Ljava/lang/String;[BLjava/lang/String;Ljava/util/Map;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun put (Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun putRaw (Ljava/lang/String;[BLjava/lang/String;Ljava/util/Map;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun rawRequest (Lio/github/androidpoet/supabase/client/SupabaseHttpMethod;Ljava/lang/String;[BLjava/lang/String;Ljava/util/Map;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun setAccessToken (Ljava/lang/String;)V
 }
 
@@ -28,6 +29,7 @@ public final class io/github/androidpoet/supabase/client/SupabaseClient$DefaultI
 	public static synthetic fun postRaw$default (Lio/github/androidpoet/supabase/client/SupabaseClient;Ljava/lang/String;[BLjava/lang/String;Ljava/util/Map;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public static synthetic fun put$default (Lio/github/androidpoet/supabase/client/SupabaseClient;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public static synthetic fun putRaw$default (Lio/github/androidpoet/supabase/client/SupabaseClient;Ljava/lang/String;[BLjava/lang/String;Ljava/util/Map;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static synthetic fun rawRequest$default (Lio/github/androidpoet/supabase/client/SupabaseClient;Lio/github/androidpoet/supabase/client/SupabaseHttpMethod;Ljava/lang/String;[BLjava/lang/String;Ljava/util/Map;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 }
 
 public final class io/github/androidpoet/supabase/client/SupabaseClientExtKt {
@@ -59,6 +61,26 @@ public final class io/github/androidpoet/supabase/client/SupabaseConfigBuilder {
 }
 
 public abstract interface annotation class io/github/androidpoet/supabase/client/SupabaseDsl : java/lang/annotation/Annotation {
+}
+
+public final class io/github/androidpoet/supabase/client/SupabaseHttpMethod : java/lang/Enum {
+	public static final field DELETE Lio/github/androidpoet/supabase/client/SupabaseHttpMethod;
+	public static final field GET Lio/github/androidpoet/supabase/client/SupabaseHttpMethod;
+	public static final field HEAD Lio/github/androidpoet/supabase/client/SupabaseHttpMethod;
+	public static final field PATCH Lio/github/androidpoet/supabase/client/SupabaseHttpMethod;
+	public static final field POST Lio/github/androidpoet/supabase/client/SupabaseHttpMethod;
+	public static final field PUT Lio/github/androidpoet/supabase/client/SupabaseHttpMethod;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public static fun valueOf (Ljava/lang/String;)Lio/github/androidpoet/supabase/client/SupabaseHttpMethod;
+	public static fun values ()[Lio/github/androidpoet/supabase/client/SupabaseHttpMethod;
+}
+
+public final class io/github/androidpoet/supabase/client/SupabaseHttpResponse {
+	public fun <init> (ILjava/util/Map;[B)V
+	public final fun getBody ()[B
+	public final fun getHeaders ()Ljava/util/Map;
+	public final fun getStatus ()I
+	public final fun header (Ljava/lang/String;)Ljava/lang/String;
 }
 
 public abstract interface class io/github/androidpoet/supabase/client/auth/AuthState {

--- a/supabase-client/api/jvm/supabase-client.api
+++ b/supabase-client/api/jvm/supabase-client.api
@@ -17,6 +17,7 @@ public abstract interface class io/github/androidpoet/supabase/client/SupabaseCl
 	public abstract fun postRaw (Ljava/lang/String;[BLjava/lang/String;Ljava/util/Map;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun put (Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun putRaw (Ljava/lang/String;[BLjava/lang/String;Ljava/util/Map;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun rawRequest (Lio/github/androidpoet/supabase/client/SupabaseHttpMethod;Ljava/lang/String;[BLjava/lang/String;Ljava/util/Map;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun setAccessToken (Ljava/lang/String;)V
 }
 
@@ -28,6 +29,7 @@ public final class io/github/androidpoet/supabase/client/SupabaseClient$DefaultI
 	public static synthetic fun postRaw$default (Lio/github/androidpoet/supabase/client/SupabaseClient;Ljava/lang/String;[BLjava/lang/String;Ljava/util/Map;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public static synthetic fun put$default (Lio/github/androidpoet/supabase/client/SupabaseClient;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public static synthetic fun putRaw$default (Lio/github/androidpoet/supabase/client/SupabaseClient;Ljava/lang/String;[BLjava/lang/String;Ljava/util/Map;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static synthetic fun rawRequest$default (Lio/github/androidpoet/supabase/client/SupabaseClient;Lio/github/androidpoet/supabase/client/SupabaseHttpMethod;Ljava/lang/String;[BLjava/lang/String;Ljava/util/Map;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 }
 
 public final class io/github/androidpoet/supabase/client/SupabaseClientExtKt {
@@ -59,6 +61,26 @@ public final class io/github/androidpoet/supabase/client/SupabaseConfigBuilder {
 }
 
 public abstract interface annotation class io/github/androidpoet/supabase/client/SupabaseDsl : java/lang/annotation/Annotation {
+}
+
+public final class io/github/androidpoet/supabase/client/SupabaseHttpMethod : java/lang/Enum {
+	public static final field DELETE Lio/github/androidpoet/supabase/client/SupabaseHttpMethod;
+	public static final field GET Lio/github/androidpoet/supabase/client/SupabaseHttpMethod;
+	public static final field HEAD Lio/github/androidpoet/supabase/client/SupabaseHttpMethod;
+	public static final field PATCH Lio/github/androidpoet/supabase/client/SupabaseHttpMethod;
+	public static final field POST Lio/github/androidpoet/supabase/client/SupabaseHttpMethod;
+	public static final field PUT Lio/github/androidpoet/supabase/client/SupabaseHttpMethod;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public static fun valueOf (Ljava/lang/String;)Lio/github/androidpoet/supabase/client/SupabaseHttpMethod;
+	public static fun values ()[Lio/github/androidpoet/supabase/client/SupabaseHttpMethod;
+}
+
+public final class io/github/androidpoet/supabase/client/SupabaseHttpResponse {
+	public fun <init> (ILjava/util/Map;[B)V
+	public final fun getBody ()[B
+	public final fun getHeaders ()Ljava/util/Map;
+	public final fun getStatus ()I
+	public final fun header (Ljava/lang/String;)Ljava/lang/String;
 }
 
 public abstract interface class io/github/androidpoet/supabase/client/auth/AuthState {

--- a/supabase-client/api/supabase-client.klib.api
+++ b/supabase-client/api/supabase-client.klib.api
@@ -10,6 +10,21 @@ open annotation class io.github.androidpoet.supabase.client/SupabaseDsl : kotlin
     constructor <init>() // io.github.androidpoet.supabase.client/SupabaseDsl.<init>|<init>(){}[0]
 }
 
+final enum class io.github.androidpoet.supabase.client/SupabaseHttpMethod : kotlin/Enum<io.github.androidpoet.supabase.client/SupabaseHttpMethod> { // io.github.androidpoet.supabase.client/SupabaseHttpMethod|null[0]
+    enum entry DELETE // io.github.androidpoet.supabase.client/SupabaseHttpMethod.DELETE|null[0]
+    enum entry GET // io.github.androidpoet.supabase.client/SupabaseHttpMethod.GET|null[0]
+    enum entry HEAD // io.github.androidpoet.supabase.client/SupabaseHttpMethod.HEAD|null[0]
+    enum entry PATCH // io.github.androidpoet.supabase.client/SupabaseHttpMethod.PATCH|null[0]
+    enum entry POST // io.github.androidpoet.supabase.client/SupabaseHttpMethod.POST|null[0]
+    enum entry PUT // io.github.androidpoet.supabase.client/SupabaseHttpMethod.PUT|null[0]
+
+    final val entries // io.github.androidpoet.supabase.client/SupabaseHttpMethod.entries|#static{}entries[0]
+        final fun <get-entries>(): kotlin.enums/EnumEntries<io.github.androidpoet.supabase.client/SupabaseHttpMethod> // io.github.androidpoet.supabase.client/SupabaseHttpMethod.entries.<get-entries>|<get-entries>#static(){}[0]
+
+    final fun valueOf(kotlin/String): io.github.androidpoet.supabase.client/SupabaseHttpMethod // io.github.androidpoet.supabase.client/SupabaseHttpMethod.valueOf|valueOf#static(kotlin.String){}[0]
+    final fun values(): kotlin/Array<io.github.androidpoet.supabase.client/SupabaseHttpMethod> // io.github.androidpoet.supabase.client/SupabaseHttpMethod.values|values#static(){}[0]
+}
+
 abstract interface io.github.androidpoet.supabase.client/SupabaseClient : kotlin/AutoCloseable { // io.github.androidpoet.supabase.client/SupabaseClient|null[0]
     abstract val accessTokenOrNull // io.github.androidpoet.supabase.client/SupabaseClient.accessTokenOrNull|{}accessTokenOrNull[0]
         abstract fun <get-accessTokenOrNull>(): kotlin/String? // io.github.androidpoet.supabase.client/SupabaseClient.accessTokenOrNull.<get-accessTokenOrNull>|<get-accessTokenOrNull>(){}[0]
@@ -28,6 +43,7 @@ abstract interface io.github.androidpoet.supabase.client/SupabaseClient : kotlin
     abstract suspend fun postRaw(kotlin/String, kotlin/ByteArray, kotlin/String, kotlin.collections/Map<kotlin/String, kotlin/String> = ...): io.github.androidpoet.supabase.core.result/SupabaseResult<kotlin/String> // io.github.androidpoet.supabase.client/SupabaseClient.postRaw|postRaw(kotlin.String;kotlin.ByteArray;kotlin.String;kotlin.collections.Map<kotlin.String,kotlin.String>){}[0]
     abstract suspend fun put(kotlin/String, kotlin/String? = ..., kotlin.collections/Map<kotlin/String, kotlin/String> = ...): io.github.androidpoet.supabase.core.result/SupabaseResult<kotlin/String> // io.github.androidpoet.supabase.client/SupabaseClient.put|put(kotlin.String;kotlin.String?;kotlin.collections.Map<kotlin.String,kotlin.String>){}[0]
     abstract suspend fun putRaw(kotlin/String, kotlin/ByteArray, kotlin/String, kotlin.collections/Map<kotlin/String, kotlin/String> = ...): io.github.androidpoet.supabase.core.result/SupabaseResult<kotlin/String> // io.github.androidpoet.supabase.client/SupabaseClient.putRaw|putRaw(kotlin.String;kotlin.ByteArray;kotlin.String;kotlin.collections.Map<kotlin.String,kotlin.String>){}[0]
+    abstract suspend fun rawRequest(io.github.androidpoet.supabase.client/SupabaseHttpMethod, kotlin/String, kotlin/ByteArray? = ..., kotlin/String? = ..., kotlin.collections/Map<kotlin/String, kotlin/String> = ...): io.github.androidpoet.supabase.core.result/SupabaseResult<io.github.androidpoet.supabase.client/SupabaseHttpResponse> // io.github.androidpoet.supabase.client/SupabaseClient.rawRequest|rawRequest(io.github.androidpoet.supabase.client.SupabaseHttpMethod;kotlin.String;kotlin.ByteArray?;kotlin.String?;kotlin.collections.Map<kotlin.String,kotlin.String>){}[0]
 }
 
 sealed interface io.github.androidpoet.supabase.client.auth/AuthState { // io.github.androidpoet.supabase.client.auth/AuthState|null[0]
@@ -95,6 +111,19 @@ final class io.github.androidpoet.supabase.client/SupabaseConfigBuilder { // io.
     final var logging // io.github.androidpoet.supabase.client/SupabaseConfigBuilder.logging|{}logging[0]
         final fun <get-logging>(): kotlin/Boolean // io.github.androidpoet.supabase.client/SupabaseConfigBuilder.logging.<get-logging>|<get-logging>(){}[0]
         final fun <set-logging>(kotlin/Boolean) // io.github.androidpoet.supabase.client/SupabaseConfigBuilder.logging.<set-logging>|<set-logging>(kotlin.Boolean){}[0]
+}
+
+final class io.github.androidpoet.supabase.client/SupabaseHttpResponse { // io.github.androidpoet.supabase.client/SupabaseHttpResponse|null[0]
+    constructor <init>(kotlin/Int, kotlin.collections/Map<kotlin/String, kotlin/String>, kotlin/ByteArray) // io.github.androidpoet.supabase.client/SupabaseHttpResponse.<init>|<init>(kotlin.Int;kotlin.collections.Map<kotlin.String,kotlin.String>;kotlin.ByteArray){}[0]
+
+    final val body // io.github.androidpoet.supabase.client/SupabaseHttpResponse.body|{}body[0]
+        final fun <get-body>(): kotlin/ByteArray // io.github.androidpoet.supabase.client/SupabaseHttpResponse.body.<get-body>|<get-body>(){}[0]
+    final val headers // io.github.androidpoet.supabase.client/SupabaseHttpResponse.headers|{}headers[0]
+        final fun <get-headers>(): kotlin.collections/Map<kotlin/String, kotlin/String> // io.github.androidpoet.supabase.client/SupabaseHttpResponse.headers.<get-headers>|<get-headers>(){}[0]
+    final val status // io.github.androidpoet.supabase.client/SupabaseHttpResponse.status|{}status[0]
+        final fun <get-status>(): kotlin/Int // io.github.androidpoet.supabase.client/SupabaseHttpResponse.status.<get-status>|<get-status>(){}[0]
+
+    final fun header(kotlin/String): kotlin/String? // io.github.androidpoet.supabase.client/SupabaseHttpResponse.header|header(kotlin.String){}[0]
 }
 
 final object io.github.androidpoet.supabase.client/Supabase { // io.github.androidpoet.supabase.client/Supabase|null[0]

--- a/supabase-client/src/commonMain/kotlin/io/github/androidpoet/supabase/client/SupabaseClient.kt
+++ b/supabase-client/src/commonMain/kotlin/io/github/androidpoet/supabase/client/SupabaseClient.kt
@@ -1,6 +1,31 @@
 package io.github.androidpoet.supabase.client
 import io.github.androidpoet.supabase.core.result.SupabaseResult
 
+/** HTTP method for [SupabaseClient.rawRequest]. */
+public enum class SupabaseHttpMethod {
+    GET,
+    POST,
+    PUT,
+    PATCH,
+    DELETE,
+    HEAD,
+}
+
+/**
+ * A low-level HTTP response exposing the status code, response headers and raw
+ * body bytes — used by features that need to read response headers (e.g. the
+ * resumable-upload `Location` / `Upload-Offset`) rather than just the body.
+ */
+public class SupabaseHttpResponse(
+    public val status: Int,
+    public val headers: Map<String, String>,
+    public val body: ByteArray,
+) {
+    /** Case-insensitive header lookup. */
+    public fun header(name: String): String? =
+        headers.entries.firstOrNull { it.key.equals(name, ignoreCase = true) }?.value
+}
+
 public interface SupabaseClient : AutoCloseable {
     public val projectUrl: String
     public val apiKey: String
@@ -49,6 +74,21 @@ public interface SupabaseClient : AutoCloseable {
         contentType: String,
         headers: Map<String, String> = emptyMap(),
     ): SupabaseResult<String>
+
+    /**
+     * Performs an arbitrary HTTP request and returns the status, headers and raw
+     * body bytes. [url] may be an absolute URL (`http(s)://…`) or an endpoint
+     * path (prefixed with the project URL). Supports method/header/body needs
+     * that the typed helpers above don't expose — notably `HEAD` and reading
+     * response headers, as required by resumable (TUS) uploads.
+     */
+    public suspend fun rawRequest(
+        method: SupabaseHttpMethod,
+        url: String,
+        body: ByteArray? = null,
+        contentType: String? = null,
+        headers: Map<String, String> = emptyMap(),
+    ): SupabaseResult<SupabaseHttpResponse>
 
     public fun setAccessToken(token: String)
 

--- a/supabase-client/src/commonMain/kotlin/io/github/androidpoet/supabase/client/SupabaseClientImpl.kt
+++ b/supabase-client/src/commonMain/kotlin/io/github/androidpoet/supabase/client/SupabaseClientImpl.kt
@@ -61,6 +61,23 @@ internal class SupabaseClientImpl(
     ): SupabaseResult<String> =
         transport.putRaw(url = "$projectUrl$url", body = body, contentType = contentType, headers = headers)
 
+    override suspend fun rawRequest(
+        method: SupabaseHttpMethod,
+        url: String,
+        body: ByteArray?,
+        contentType: String?,
+        headers: Map<String, String>,
+    ): SupabaseResult<SupabaseHttpResponse> {
+        val fullUrl = if (url.startsWith("http://") || url.startsWith("https://")) url else "$projectUrl$url"
+        return transport.rawRequest(
+            method = method.name,
+            url = fullUrl,
+            body = body,
+            contentType = contentType,
+            requestHeaders = headers,
+        )
+    }
+
     override fun setAccessToken(token: String) {
         transport.setAccessToken(token)
     }

--- a/supabase-client/src/commonMain/kotlin/io/github/androidpoet/supabase/client/transport/HttpTransport.kt
+++ b/supabase-client/src/commonMain/kotlin/io/github/androidpoet/supabase/client/transport/HttpTransport.kt
@@ -1,5 +1,6 @@
 package io.github.androidpoet.supabase.client.transport
 import io.github.androidpoet.supabase.client.SupabaseConfig
+import io.github.androidpoet.supabase.client.SupabaseHttpResponse
 import io.github.androidpoet.supabase.core.result.SupabaseError
 import io.github.androidpoet.supabase.core.result.SupabaseErrorCodes
 import io.github.androidpoet.supabase.core.result.SupabaseResult
@@ -15,9 +16,12 @@ import io.ktor.client.request.headers
 import io.ktor.client.request.patch
 import io.ktor.client.request.post
 import io.ktor.client.request.put
+import io.ktor.client.request.request
 import io.ktor.client.request.setBody
 import io.ktor.client.statement.bodyAsText
+import io.ktor.client.statement.readRawBytes
 import io.ktor.http.ContentType
+import io.ktor.http.HttpMethod
 import io.ktor.http.contentType
 import io.ktor.http.isSuccess
 import io.ktor.serialization.kotlinx.json.json
@@ -207,6 +211,37 @@ internal class HttpTransport(
             }
         }
     }
+
+    suspend fun rawRequest(
+        method: String,
+        url: String,
+        body: ByteArray?,
+        contentType: String?,
+        requestHeaders: Map<String, String>,
+    ): SupabaseResult<SupabaseHttpResponse> =
+        try {
+            val response =
+                httpClient.request(url) {
+                    this.method = HttpMethod.parse(method)
+                    requestHeaders.forEach { (k, v) -> header(k, v) }
+                    if ("Authorization" !in requestHeaders) {
+                        header("Authorization", "Bearer ${accessToken ?: apiKey}")
+                    }
+                    contentType?.let { contentType(ContentType.parse(it)) }
+                    body?.let { setBody(it) }
+                }
+            val bytes = response.readRawBytes()
+            if (response.status.isSuccess()) {
+                val flatHeaders = response.headers.entries().associate { (k, v) -> k to v.joinToString(",") }
+                SupabaseResult.Success(SupabaseHttpResponse(response.status.value, flatHeaders, bytes))
+            } else {
+                val retryAfter = response.headers["Retry-After"]?.toLongOrNull()
+                SupabaseResult.Failure(parseError(bytes.decodeToString(), response.status.value, retryAfter))
+            }
+        } catch (e: Throwable) {
+            if (e is CancellationException) throw e
+            SupabaseResult.Failure(networkError(throwable = e))
+        }
 
     fun setAccessToken(token: String) {
         accessToken = token

--- a/supabase-database/src/commonTest/kotlin/io/github/androidpoet/supabase/database/DatabaseClientImplTest.kt
+++ b/supabase-database/src/commonTest/kotlin/io/github/androidpoet/supabase/database/DatabaseClientImplTest.kt
@@ -538,6 +538,18 @@ private class FakeSupabaseClient(
         headers: Map<String, String>,
     ): SupabaseResult<String> = SupabaseResult.Success("{}")
 
+    override suspend fun rawRequest(
+        method: io.github.androidpoet.supabase.client.SupabaseHttpMethod,
+        url: String,
+        body: ByteArray?,
+        contentType: String?,
+        headers: Map<String, String>,
+    ): SupabaseResult<io.github.androidpoet.supabase.client.SupabaseHttpResponse> =
+        SupabaseResult.Failure(
+            io.github.androidpoet.supabase.core.result
+                .SupabaseError("rawRequest not supported in test fake"),
+        )
+
     override fun setAccessToken(token: String) = Unit
 
     override fun clearAccessToken() = Unit

--- a/supabase-functions/src/commonTest/kotlin/io/github/androidpoet/supabase/functions/FunctionsClientImplTest.kt
+++ b/supabase-functions/src/commonTest/kotlin/io/github/androidpoet/supabase/functions/FunctionsClientImplTest.kt
@@ -115,5 +115,17 @@ private class FakeSupabaseClient : SupabaseClient {
 
     override fun clearAccessToken() = Unit
 
+    override suspend fun rawRequest(
+        method: io.github.androidpoet.supabase.client.SupabaseHttpMethod,
+        url: String,
+        body: ByteArray?,
+        contentType: String?,
+        headers: Map<String, String>,
+    ): io.github.androidpoet.supabase.core.result.SupabaseResult<io.github.androidpoet.supabase.client.SupabaseHttpResponse> =
+        io.github.androidpoet.supabase.core.result.SupabaseResult.Failure(
+            io.github.androidpoet.supabase.core.result
+                .SupabaseError("rawRequest not supported in test fake"),
+        )
+
     override fun close() = Unit
 }

--- a/supabase-realtime/src/commonTest/kotlin/io/github/androidpoet/supabase/realtime/RealtimeChannelBuilderConfigTest.kt
+++ b/supabase-realtime/src/commonTest/kotlin/io/github/androidpoet/supabase/realtime/RealtimeChannelBuilderConfigTest.kt
@@ -199,5 +199,17 @@ private class FakeSupabaseClient : SupabaseClient {
 
     override fun clearAccessToken() = Unit
 
+    override suspend fun rawRequest(
+        method: io.github.androidpoet.supabase.client.SupabaseHttpMethod,
+        url: String,
+        body: ByteArray?,
+        contentType: String?,
+        headers: Map<String, String>,
+    ): io.github.androidpoet.supabase.core.result.SupabaseResult<io.github.androidpoet.supabase.client.SupabaseHttpResponse> =
+        io.github.androidpoet.supabase.core.result.SupabaseResult.Failure(
+            io.github.androidpoet.supabase.core.result
+                .SupabaseError("rawRequest not supported in test fake"),
+        )
+
     override fun close() = Unit
 }

--- a/supabase-realtime/src/commonTest/kotlin/io/github/androidpoet/supabase/realtime/RealtimeClientExtTest.kt
+++ b/supabase-realtime/src/commonTest/kotlin/io/github/androidpoet/supabase/realtime/RealtimeClientExtTest.kt
@@ -280,6 +280,18 @@ private class ExtFakeSupabaseClient : SupabaseClient {
 
     override fun clearAccessToken() = Unit
 
+    override suspend fun rawRequest(
+        method: io.github.androidpoet.supabase.client.SupabaseHttpMethod,
+        url: String,
+        body: ByteArray?,
+        contentType: String?,
+        headers: Map<String, String>,
+    ): io.github.androidpoet.supabase.core.result.SupabaseResult<io.github.androidpoet.supabase.client.SupabaseHttpResponse> =
+        io.github.androidpoet.supabase.core.result.SupabaseResult.Failure(
+            io.github.androidpoet.supabase.core.result
+                .SupabaseError("rawRequest not supported in test fake"),
+        )
+
     override fun close() = Unit
 }
 

--- a/supabase-storage/api/android/supabase-storage.api
+++ b/supabase-storage/api/android/supabase-storage.api
@@ -68,6 +68,31 @@ public final class io/github/androidpoet/supabase/storage/ResizeMode : java/lang
 	public static fun values ()[Lio/github/androidpoet/supabase/storage/ResizeMode;
 }
 
+public abstract interface class io/github/androidpoet/supabase/storage/ResumableUpload {
+	public abstract fun await (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun getProgress ()Lkotlinx/coroutines/flow/StateFlow;
+	public abstract fun getUploadUrl ()Ljava/lang/String;
+}
+
+public final class io/github/androidpoet/supabase/storage/ResumableUploadKt {
+	public static final field RESUMABLE_DEFAULT_CHUNK_SIZE I
+}
+
+public final class io/github/androidpoet/supabase/storage/ResumableUploadProgress {
+	public fun <init> (JJ)V
+	public final fun component1 ()J
+	public final fun component2 ()J
+	public final fun copy (JJ)Lio/github/androidpoet/supabase/storage/ResumableUploadProgress;
+	public static synthetic fun copy$default (Lio/github/androidpoet/supabase/storage/ResumableUploadProgress;JJILjava/lang/Object;)Lio/github/androidpoet/supabase/storage/ResumableUploadProgress;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getBytesUploaded ()J
+	public final fun getFraction ()F
+	public final fun getTotalBytes ()J
+	public fun hashCode ()I
+	public final fun isComplete ()Z
+	public fun toString ()Ljava/lang/String;
+}
+
 public final class io/github/androidpoet/supabase/storage/SortOrder : java/lang/Enum {
 	public static final field ASC Lio/github/androidpoet/supabase/storage/SortOrder;
 	public static final field DESC Lio/github/androidpoet/supabase/storage/SortOrder;
@@ -81,6 +106,7 @@ public abstract interface class io/github/androidpoet/supabase/storage/StorageCl
 	public abstract fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun createAnalyticsBucket (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun createBucket (Ljava/lang/String;Ljava/lang/String;ZLjava/lang/Long;Ljava/util/List;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun createResumableUpload (Ljava/lang/String;Ljava/lang/String;[BLjava/lang/String;ZLjava/lang/Integer;ILjava/lang/String;)Lio/github/androidpoet/supabase/storage/ResumableUpload;
 	public abstract fun createSignedUrl (Ljava/lang/String;Ljava/lang/String;JZLjava/lang/String;Lio/github/androidpoet/supabase/storage/ImageTransformOptions;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun createSignedUrls (Ljava/lang/String;Ljava/util/List;JZLjava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun createUploadSignedUrl (Ljava/lang/String;Ljava/lang/String;ZLkotlin/coroutines/Continuation;)Ljava/lang/Object;
@@ -134,6 +160,7 @@ public abstract interface class io/github/androidpoet/supabase/storage/StorageCl
 public final class io/github/androidpoet/supabase/storage/StorageClient$DefaultImpls {
 	public static synthetic fun copy$default (Lio/github/androidpoet/supabase/storage/StorageClient;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public static synthetic fun createBucket$default (Lio/github/androidpoet/supabase/storage/StorageClient;Ljava/lang/String;Ljava/lang/String;ZLjava/lang/Long;Ljava/util/List;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static synthetic fun createResumableUpload$default (Lio/github/androidpoet/supabase/storage/StorageClient;Ljava/lang/String;Ljava/lang/String;[BLjava/lang/String;ZLjava/lang/Integer;ILjava/lang/String;ILjava/lang/Object;)Lio/github/androidpoet/supabase/storage/ResumableUpload;
 	public static synthetic fun createSignedUrl$default (Lio/github/androidpoet/supabase/storage/StorageClient;Ljava/lang/String;Ljava/lang/String;JZLjava/lang/String;Lio/github/androidpoet/supabase/storage/ImageTransformOptions;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public static synthetic fun createSignedUrls$default (Lio/github/androidpoet/supabase/storage/StorageClient;Ljava/lang/String;Ljava/util/List;JZLjava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public static synthetic fun createUploadSignedUrl$default (Lio/github/androidpoet/supabase/storage/StorageClient;Ljava/lang/String;Ljava/lang/String;ZLkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
@@ -220,6 +247,8 @@ public final class io/github/androidpoet/supabase/storage/StorageClientExtKt {
 	public static synthetic fun getPublicUrlsByPath$default (Lio/github/androidpoet/supabase/storage/StorageClient;Ljava/lang/String;ZLjava/lang/String;Lio/github/androidpoet/supabase/storage/ImageTransformOptions;[Ljava/lang/String;ILjava/lang/Object;)Ljava/util/Map;
 	public static final fun remove (Lio/github/androidpoet/supabase/storage/StorageClient;Ljava/lang/String;[Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static final fun removeWithResult (Lio/github/androidpoet/supabase/storage/StorageClient;Ljava/lang/String;[Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static final fun uploadResumable (Lio/github/androidpoet/supabase/storage/StorageClient;Ljava/lang/String;Ljava/lang/String;[BLjava/lang/String;ZLjava/lang/Integer;ILkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun uploadResumable$default (Lio/github/androidpoet/supabase/storage/StorageClient;Ljava/lang/String;Ljava/lang/String;[BLjava/lang/String;ZLjava/lang/Integer;ILkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 }
 
 public final class io/github/androidpoet/supabase/storage/StorageFactoryKt {

--- a/supabase-storage/api/jvm/supabase-storage.api
+++ b/supabase-storage/api/jvm/supabase-storage.api
@@ -68,6 +68,31 @@ public final class io/github/androidpoet/supabase/storage/ResizeMode : java/lang
 	public static fun values ()[Lio/github/androidpoet/supabase/storage/ResizeMode;
 }
 
+public abstract interface class io/github/androidpoet/supabase/storage/ResumableUpload {
+	public abstract fun await (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun getProgress ()Lkotlinx/coroutines/flow/StateFlow;
+	public abstract fun getUploadUrl ()Ljava/lang/String;
+}
+
+public final class io/github/androidpoet/supabase/storage/ResumableUploadKt {
+	public static final field RESUMABLE_DEFAULT_CHUNK_SIZE I
+}
+
+public final class io/github/androidpoet/supabase/storage/ResumableUploadProgress {
+	public fun <init> (JJ)V
+	public final fun component1 ()J
+	public final fun component2 ()J
+	public final fun copy (JJ)Lio/github/androidpoet/supabase/storage/ResumableUploadProgress;
+	public static synthetic fun copy$default (Lio/github/androidpoet/supabase/storage/ResumableUploadProgress;JJILjava/lang/Object;)Lio/github/androidpoet/supabase/storage/ResumableUploadProgress;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getBytesUploaded ()J
+	public final fun getFraction ()F
+	public final fun getTotalBytes ()J
+	public fun hashCode ()I
+	public final fun isComplete ()Z
+	public fun toString ()Ljava/lang/String;
+}
+
 public final class io/github/androidpoet/supabase/storage/SortOrder : java/lang/Enum {
 	public static final field ASC Lio/github/androidpoet/supabase/storage/SortOrder;
 	public static final field DESC Lio/github/androidpoet/supabase/storage/SortOrder;
@@ -81,6 +106,7 @@ public abstract interface class io/github/androidpoet/supabase/storage/StorageCl
 	public abstract fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun createAnalyticsBucket (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun createBucket (Ljava/lang/String;Ljava/lang/String;ZLjava/lang/Long;Ljava/util/List;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun createResumableUpload (Ljava/lang/String;Ljava/lang/String;[BLjava/lang/String;ZLjava/lang/Integer;ILjava/lang/String;)Lio/github/androidpoet/supabase/storage/ResumableUpload;
 	public abstract fun createSignedUrl (Ljava/lang/String;Ljava/lang/String;JZLjava/lang/String;Lio/github/androidpoet/supabase/storage/ImageTransformOptions;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun createSignedUrls (Ljava/lang/String;Ljava/util/List;JZLjava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun createUploadSignedUrl (Ljava/lang/String;Ljava/lang/String;ZLkotlin/coroutines/Continuation;)Ljava/lang/Object;
@@ -134,6 +160,7 @@ public abstract interface class io/github/androidpoet/supabase/storage/StorageCl
 public final class io/github/androidpoet/supabase/storage/StorageClient$DefaultImpls {
 	public static synthetic fun copy$default (Lio/github/androidpoet/supabase/storage/StorageClient;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public static synthetic fun createBucket$default (Lio/github/androidpoet/supabase/storage/StorageClient;Ljava/lang/String;Ljava/lang/String;ZLjava/lang/Long;Ljava/util/List;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static synthetic fun createResumableUpload$default (Lio/github/androidpoet/supabase/storage/StorageClient;Ljava/lang/String;Ljava/lang/String;[BLjava/lang/String;ZLjava/lang/Integer;ILjava/lang/String;ILjava/lang/Object;)Lio/github/androidpoet/supabase/storage/ResumableUpload;
 	public static synthetic fun createSignedUrl$default (Lio/github/androidpoet/supabase/storage/StorageClient;Ljava/lang/String;Ljava/lang/String;JZLjava/lang/String;Lio/github/androidpoet/supabase/storage/ImageTransformOptions;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public static synthetic fun createSignedUrls$default (Lio/github/androidpoet/supabase/storage/StorageClient;Ljava/lang/String;Ljava/util/List;JZLjava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public static synthetic fun createUploadSignedUrl$default (Lio/github/androidpoet/supabase/storage/StorageClient;Ljava/lang/String;Ljava/lang/String;ZLkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
@@ -220,6 +247,8 @@ public final class io/github/androidpoet/supabase/storage/StorageClientExtKt {
 	public static synthetic fun getPublicUrlsByPath$default (Lio/github/androidpoet/supabase/storage/StorageClient;Ljava/lang/String;ZLjava/lang/String;Lio/github/androidpoet/supabase/storage/ImageTransformOptions;[Ljava/lang/String;ILjava/lang/Object;)Ljava/util/Map;
 	public static final fun remove (Lio/github/androidpoet/supabase/storage/StorageClient;Ljava/lang/String;[Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static final fun removeWithResult (Lio/github/androidpoet/supabase/storage/StorageClient;Ljava/lang/String;[Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static final fun uploadResumable (Lio/github/androidpoet/supabase/storage/StorageClient;Ljava/lang/String;Ljava/lang/String;[BLjava/lang/String;ZLjava/lang/Integer;ILkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun uploadResumable$default (Lio/github/androidpoet/supabase/storage/StorageClient;Ljava/lang/String;Ljava/lang/String;[BLjava/lang/String;ZLjava/lang/Integer;ILkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 }
 
 public final class io/github/androidpoet/supabase/storage/StorageFactoryKt {

--- a/supabase-storage/api/supabase-storage.klib.api
+++ b/supabase-storage/api/supabase-storage.klib.api
@@ -89,8 +89,18 @@ abstract interface io.github.androidpoet.supabase.storage/AnalyticsCatalogClient
     abstract suspend fun updateTable(kotlin.collections/List<kotlin/String>, kotlin/String, kotlinx.serialization.json/JsonObject): io.github.androidpoet.supabase.core.result/SupabaseResult<kotlinx.serialization.json/JsonObject> // io.github.androidpoet.supabase.storage/AnalyticsCatalogClient.updateTable|updateTable(kotlin.collections.List<kotlin.String>;kotlin.String;kotlinx.serialization.json.JsonObject){}[0]
 }
 
+abstract interface io.github.androidpoet.supabase.storage/ResumableUpload { // io.github.androidpoet.supabase.storage/ResumableUpload|null[0]
+    abstract val progress // io.github.androidpoet.supabase.storage/ResumableUpload.progress|{}progress[0]
+        abstract fun <get-progress>(): kotlinx.coroutines.flow/StateFlow<io.github.androidpoet.supabase.storage/ResumableUploadProgress> // io.github.androidpoet.supabase.storage/ResumableUpload.progress.<get-progress>|<get-progress>(){}[0]
+    abstract val uploadUrl // io.github.androidpoet.supabase.storage/ResumableUpload.uploadUrl|{}uploadUrl[0]
+        abstract fun <get-uploadUrl>(): kotlin/String? // io.github.androidpoet.supabase.storage/ResumableUpload.uploadUrl.<get-uploadUrl>|<get-uploadUrl>(){}[0]
+
+    abstract suspend fun await(): io.github.androidpoet.supabase.core.result/SupabaseResult<kotlin/Unit> // io.github.androidpoet.supabase.storage/ResumableUpload.await|await(){}[0]
+}
+
 abstract interface io.github.androidpoet.supabase.storage/StorageClient { // io.github.androidpoet.supabase.storage/StorageClient|null[0]
     abstract fun analyticsCatalog(kotlin/String): io.github.androidpoet.supabase.storage/AnalyticsCatalogClient // io.github.androidpoet.supabase.storage/StorageClient.analyticsCatalog|analyticsCatalog(kotlin.String){}[0]
+    abstract fun createResumableUpload(kotlin/String, kotlin/String, kotlin/ByteArray, kotlin/String = ..., kotlin/Boolean = ..., kotlin/Int? = ..., kotlin/Int = ..., kotlin/String? = ...): io.github.androidpoet.supabase.storage/ResumableUpload // io.github.androidpoet.supabase.storage/StorageClient.createResumableUpload|createResumableUpload(kotlin.String;kotlin.String;kotlin.ByteArray;kotlin.String;kotlin.Boolean;kotlin.Int?;kotlin.Int;kotlin.String?){}[0]
     abstract fun getAuthenticatedRenderUrl(kotlin/String, kotlin/String, io.github.androidpoet.supabase.storage/ImageTransformOptions? = ...): kotlin/String // io.github.androidpoet.supabase.storage/StorageClient.getAuthenticatedRenderUrl|getAuthenticatedRenderUrl(kotlin.String;kotlin.String;io.github.androidpoet.supabase.storage.ImageTransformOptions?){}[0]
     abstract fun getAuthenticatedUrl(kotlin/String, kotlin/String, io.github.androidpoet.supabase.storage/ImageTransformOptions? = ...): kotlin/String // io.github.androidpoet.supabase.storage/StorageClient.getAuthenticatedUrl|getAuthenticatedUrl(kotlin.String;kotlin.String;io.github.androidpoet.supabase.storage.ImageTransformOptions?){}[0]
     abstract fun getAuthenticatedUrl(kotlin/String, kotlin/String, kotlin/Boolean = ..., kotlin/String? = ..., io.github.androidpoet.supabase.storage/ImageTransformOptions? = ...): kotlin/String // io.github.androidpoet.supabase.storage/StorageClient.getAuthenticatedUrl|getAuthenticatedUrl(kotlin.String;kotlin.String;kotlin.Boolean;kotlin.String?;io.github.androidpoet.supabase.storage.ImageTransformOptions?){}[0]
@@ -2110,6 +2120,26 @@ final class io.github.androidpoet.supabase.storage/ImageTransformOptions { // io
     final fun toString(): kotlin/String // io.github.androidpoet.supabase.storage/ImageTransformOptions.toString|toString(){}[0]
 }
 
+final class io.github.androidpoet.supabase.storage/ResumableUploadProgress { // io.github.androidpoet.supabase.storage/ResumableUploadProgress|null[0]
+    constructor <init>(kotlin/Long, kotlin/Long) // io.github.androidpoet.supabase.storage/ResumableUploadProgress.<init>|<init>(kotlin.Long;kotlin.Long){}[0]
+
+    final val bytesUploaded // io.github.androidpoet.supabase.storage/ResumableUploadProgress.bytesUploaded|{}bytesUploaded[0]
+        final fun <get-bytesUploaded>(): kotlin/Long // io.github.androidpoet.supabase.storage/ResumableUploadProgress.bytesUploaded.<get-bytesUploaded>|<get-bytesUploaded>(){}[0]
+    final val fraction // io.github.androidpoet.supabase.storage/ResumableUploadProgress.fraction|{}fraction[0]
+        final fun <get-fraction>(): kotlin/Float // io.github.androidpoet.supabase.storage/ResumableUploadProgress.fraction.<get-fraction>|<get-fraction>(){}[0]
+    final val isComplete // io.github.androidpoet.supabase.storage/ResumableUploadProgress.isComplete|{}isComplete[0]
+        final fun <get-isComplete>(): kotlin/Boolean // io.github.androidpoet.supabase.storage/ResumableUploadProgress.isComplete.<get-isComplete>|<get-isComplete>(){}[0]
+    final val totalBytes // io.github.androidpoet.supabase.storage/ResumableUploadProgress.totalBytes|{}totalBytes[0]
+        final fun <get-totalBytes>(): kotlin/Long // io.github.androidpoet.supabase.storage/ResumableUploadProgress.totalBytes.<get-totalBytes>|<get-totalBytes>(){}[0]
+
+    final fun component1(): kotlin/Long // io.github.androidpoet.supabase.storage/ResumableUploadProgress.component1|component1(){}[0]
+    final fun component2(): kotlin/Long // io.github.androidpoet.supabase.storage/ResumableUploadProgress.component2|component2(){}[0]
+    final fun copy(kotlin/Long = ..., kotlin/Long = ...): io.github.androidpoet.supabase.storage/ResumableUploadProgress // io.github.androidpoet.supabase.storage/ResumableUploadProgress.copy|copy(kotlin.Long;kotlin.Long){}[0]
+    final fun equals(kotlin/Any?): kotlin/Boolean // io.github.androidpoet.supabase.storage/ResumableUploadProgress.equals|equals(kotlin.Any?){}[0]
+    final fun hashCode(): kotlin/Int // io.github.androidpoet.supabase.storage/ResumableUploadProgress.hashCode|hashCode(){}[0]
+    final fun toString(): kotlin/String // io.github.androidpoet.supabase.storage/ResumableUploadProgress.toString|toString(){}[0]
+}
+
 final class io.github.androidpoet.supabase.storage/UploadSignedUrl { // io.github.androidpoet.supabase.storage/UploadSignedUrl|null[0]
     constructor <init>(kotlin/String, kotlin/String) // io.github.androidpoet.supabase.storage/UploadSignedUrl.<init>|<init>(kotlin.String;kotlin.String){}[0]
 
@@ -2125,6 +2155,9 @@ final class io.github.androidpoet.supabase.storage/UploadSignedUrl { // io.githu
     final fun hashCode(): kotlin/Int // io.github.androidpoet.supabase.storage/UploadSignedUrl.hashCode|hashCode(){}[0]
     final fun toString(): kotlin/String // io.github.androidpoet.supabase.storage/UploadSignedUrl.toString|toString(){}[0]
 }
+
+final const val io.github.androidpoet.supabase.storage/RESUMABLE_DEFAULT_CHUNK_SIZE // io.github.androidpoet.supabase.storage/RESUMABLE_DEFAULT_CHUNK_SIZE|{}RESUMABLE_DEFAULT_CHUNK_SIZE[0]
+    final fun <get-RESUMABLE_DEFAULT_CHUNK_SIZE>(): kotlin/Int // io.github.androidpoet.supabase.storage/RESUMABLE_DEFAULT_CHUNK_SIZE.<get-RESUMABLE_DEFAULT_CHUNK_SIZE>|<get-RESUMABLE_DEFAULT_CHUNK_SIZE>(){}[0]
 
 final fun (io.github.androidpoet.supabase.storage/StorageClient).io.github.androidpoet.supabase.storage/getAuthenticatedRenderUrls(kotlin/String, io.github.androidpoet.supabase.storage/ImageTransformOptions? = ..., kotlin/Array<out kotlin/String>...): kotlin.collections/List<kotlin/String> // io.github.androidpoet.supabase.storage/getAuthenticatedRenderUrls|getAuthenticatedRenderUrls@io.github.androidpoet.supabase.storage.StorageClient(kotlin.String;io.github.androidpoet.supabase.storage.ImageTransformOptions?;kotlin.Array<out|kotlin.String>...){}[0]
 final fun (io.github.androidpoet.supabase.storage/StorageClient).io.github.androidpoet.supabase.storage/getAuthenticatedRenderUrls(kotlin/String, kotlin.collections/List<kotlin/String>, io.github.androidpoet.supabase.storage/ImageTransformOptions? = ...): kotlin.collections/List<kotlin/String> // io.github.androidpoet.supabase.storage/getAuthenticatedRenderUrls|getAuthenticatedRenderUrls@io.github.androidpoet.supabase.storage.StorageClient(kotlin.String;kotlin.collections.List<kotlin.String>;io.github.androidpoet.supabase.storage.ImageTransformOptions?){}[0]
@@ -2162,3 +2195,4 @@ final suspend fun (io.github.androidpoet.supabase.storage/StorageClient).io.gith
 final suspend fun (io.github.androidpoet.supabase.storage/StorageClient).io.github.androidpoet.supabase.storage/createSignedRenderUrlsByPath(kotlin/String, kotlin/Long, io.github.androidpoet.supabase.storage/ImageTransformOptions, kotlin/Array<out kotlin/String>...): io.github.androidpoet.supabase.core.result/SupabaseResult<kotlin.collections/Map<kotlin/String, kotlin/String>> // io.github.androidpoet.supabase.storage/createSignedRenderUrlsByPath|createSignedRenderUrlsByPath@io.github.androidpoet.supabase.storage.StorageClient(kotlin.String;kotlin.Long;io.github.androidpoet.supabase.storage.ImageTransformOptions;kotlin.Array<out|kotlin.String>...){}[0]
 final suspend fun (io.github.androidpoet.supabase.storage/StorageClient).io.github.androidpoet.supabase.storage/remove(kotlin/String, kotlin/Array<out kotlin/String>...): io.github.androidpoet.supabase.core.result/SupabaseResult<kotlin/Unit> // io.github.androidpoet.supabase.storage/remove|remove@io.github.androidpoet.supabase.storage.StorageClient(kotlin.String;kotlin.Array<out|kotlin.String>...){}[0]
 final suspend fun (io.github.androidpoet.supabase.storage/StorageClient).io.github.androidpoet.supabase.storage/removeWithResult(kotlin/String, kotlin/Array<out kotlin/String>...): io.github.androidpoet.supabase.core.result/SupabaseResult<kotlin.collections/List<io.github.androidpoet.supabase.storage.models/FileObject>> // io.github.androidpoet.supabase.storage/removeWithResult|removeWithResult@io.github.androidpoet.supabase.storage.StorageClient(kotlin.String;kotlin.Array<out|kotlin.String>...){}[0]
+final suspend fun (io.github.androidpoet.supabase.storage/StorageClient).io.github.androidpoet.supabase.storage/uploadResumable(kotlin/String, kotlin/String, kotlin/ByteArray, kotlin/String = ..., kotlin/Boolean = ..., kotlin/Int? = ..., kotlin/Int = ...): io.github.androidpoet.supabase.core.result/SupabaseResult<kotlin/Unit> // io.github.androidpoet.supabase.storage/uploadResumable|uploadResumable@io.github.androidpoet.supabase.storage.StorageClient(kotlin.String;kotlin.String;kotlin.ByteArray;kotlin.String;kotlin.Boolean;kotlin.Int?;kotlin.Int){}[0]

--- a/supabase-storage/src/commonMain/kotlin/io/github/androidpoet/supabase/storage/ResumableUpload.kt
+++ b/supabase-storage/src/commonMain/kotlin/io/github/androidpoet/supabase/storage/ResumableUpload.kt
@@ -2,15 +2,6 @@ package io.github.androidpoet.supabase.storage
 import io.github.androidpoet.supabase.core.result.SupabaseResult
 import kotlinx.coroutines.flow.StateFlow
 
-/**
- * Supabase Storage HTTP endpoint paths, centralized so the literals live in one
- * place. (Existing object/bucket paths in [StorageClientImpl] can migrate here
- * in a follow-up.)
- */
-internal object StoragePaths {
-    const val RESUMABLE_UPLOAD: String = "/storage/v1/upload/resumable"
-}
-
 /** TUS protocol version Supabase Storage speaks. */
 internal const val TUS_VERSION: String = "1.0.0"
 

--- a/supabase-storage/src/commonMain/kotlin/io/github/androidpoet/supabase/storage/ResumableUpload.kt
+++ b/supabase-storage/src/commonMain/kotlin/io/github/androidpoet/supabase/storage/ResumableUpload.kt
@@ -1,0 +1,64 @@
+package io.github.androidpoet.supabase.storage
+import io.github.androidpoet.supabase.core.result.SupabaseResult
+import kotlinx.coroutines.flow.StateFlow
+
+/**
+ * Supabase Storage HTTP endpoint paths, centralized so the literals live in one
+ * place. (Existing object/bucket paths in [StorageClientImpl] can migrate here
+ * in a follow-up.)
+ */
+internal object StoragePaths {
+    const val RESUMABLE_UPLOAD: String = "/storage/v1/upload/resumable"
+}
+
+/** TUS protocol version Supabase Storage speaks. */
+internal const val TUS_VERSION: String = "1.0.0"
+
+/**
+ * Default chunk size for resumable uploads. Supabase requires 6 MiB chunks for
+ * every part except the last, so this is also the recommended value.
+ */
+public const val RESUMABLE_DEFAULT_CHUNK_SIZE: Int = 6 * 1024 * 1024
+
+/** Progress of a [ResumableUpload]. */
+public data class ResumableUploadProgress(
+    public val bytesUploaded: Long,
+    public val totalBytes: Long,
+) {
+    /** Completion fraction in `0f..1f`. */
+    public val fraction: Float
+        get() = if (totalBytes <= 0L) 0f else (bytesUploaded.toDouble() / totalBytes.toDouble()).toFloat()
+
+    public val isComplete: Boolean
+        get() = totalBytes > 0L && bytesUploaded >= totalBytes
+}
+
+/**
+ * A resumable (TUS) upload handle.
+ *
+ * Uploads in chunks with server-side offset tracking, so an interrupted upload
+ * resumes from where it stopped instead of restarting. Call [await] to run it to
+ * completion; observe [progress] for UI.
+ *
+ * **Pause / resume:** cancel the coroutine running [await] to pause. To resume —
+ * even after an app restart — persist [uploadUrl] and create a new handle with
+ * `createResumableUpload(..., uploadUrl = saved)`, then call [await] again; it
+ * `HEAD`s the server for the current offset and continues.
+ */
+public interface ResumableUpload {
+    /**
+     * The TUS upload URL once the upload has been created (null beforehand).
+     * Persist this to resume the upload later.
+     */
+    public val uploadUrl: String?
+
+    /** Upload progress, updated after every chunk. */
+    public val progress: StateFlow<ResumableUploadProgress>
+
+    /**
+     * Runs (or resumes) the upload to completion. Cancellable: cancelling the
+     * calling coroutine pauses the upload, leaving already-uploaded bytes on the
+     * server for a later resume via [uploadUrl].
+     */
+    public suspend fun await(): SupabaseResult<Unit>
+}

--- a/supabase-storage/src/commonMain/kotlin/io/github/androidpoet/supabase/storage/ResumableUploadImpl.kt
+++ b/supabase-storage/src/commonMain/kotlin/io/github/androidpoet/supabase/storage/ResumableUploadImpl.kt
@@ -1,0 +1,142 @@
+package io.github.androidpoet.supabase.storage
+import io.github.androidpoet.supabase.client.SupabaseClient
+import io.github.androidpoet.supabase.client.SupabaseHttpMethod
+import io.github.androidpoet.supabase.client.SupabaseHttpResponse
+import io.github.androidpoet.supabase.core.result.SupabaseError
+import io.github.androidpoet.supabase.core.result.SupabaseResult
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlin.concurrent.Volatile
+import kotlin.io.encoding.Base64
+import kotlin.io.encoding.ExperimentalEncodingApi
+
+internal class ResumableUploadImpl(
+    private val client: SupabaseClient,
+    private val bucket: String,
+    private val path: String,
+    private val data: ByteArray,
+    private val contentType: String,
+    private val upsert: Boolean,
+    private val cacheControl: Int?,
+    private val chunkSize: Int,
+    initialUploadUrl: String?,
+) : ResumableUpload {
+    @Volatile
+    private var resumableUrl: String? = initialUploadUrl
+    override val uploadUrl: String? get() = resumableUrl
+
+    private val total: Long = data.size.toLong()
+    private val _progress = MutableStateFlow(ResumableUploadProgress(0L, total))
+    override val progress: StateFlow<ResumableUploadProgress> = _progress.asStateFlow()
+
+    override suspend fun await(): SupabaseResult<Unit> {
+        var offset =
+            when (val start = resolveOffset()) {
+                is SupabaseResult.Success -> start.value
+                is SupabaseResult.Failure -> return start
+            }
+        publish(offset)
+
+        val url = resumableUrl ?: return SupabaseResult.Failure(SupabaseError("Resumable upload was not created"))
+        while (offset < total) {
+            val end = minOf(offset + chunkSize, total)
+            val chunk = data.copyOfRange(offset.toInt(), end.toInt())
+            offset =
+                when (val patched = patchChunk(url, offset, chunk)) {
+                    is SupabaseResult.Success -> patched.value
+                    is SupabaseResult.Failure -> return patched
+                }
+            publish(offset)
+        }
+        return SupabaseResult.Success(Unit)
+    }
+
+    private fun publish(offset: Long) {
+        _progress.value = ResumableUploadProgress(offset, total)
+    }
+
+    // Either create a fresh upload (offset 0) or HEAD an existing one to find
+    // how many bytes the server already holds.
+    private suspend fun resolveOffset(): SupabaseResult<Long> {
+        val existing = resumableUrl
+        return if (existing == null) {
+            when (val created = createUpload()) {
+                is SupabaseResult.Success -> {
+                    resumableUrl = created.value
+                    SupabaseResult.Success(0L)
+                }
+                is SupabaseResult.Failure -> created
+            }
+        } else {
+            fetchOffset(existing)
+        }
+    }
+
+    private suspend fun createUpload(): SupabaseResult<String> {
+        val headers =
+            mapOf(
+                "Tus-Resumable" to TUS_VERSION,
+                "Upload-Length" to total.toString(),
+                "Upload-Metadata" to uploadMetadata(),
+                "x-upsert" to upsert.toString(),
+            )
+        return when (val res = client.rawRequest(SupabaseHttpMethod.POST, StoragePaths.RESUMABLE_UPLOAD, headers = headers)) {
+            is SupabaseResult.Success ->
+                res.value.header("Location")?.let { SupabaseResult.Success(it) }
+                    ?: SupabaseResult.Failure(SupabaseError("Resumable upload create returned no Location header"))
+            is SupabaseResult.Failure -> res
+        }
+    }
+
+    private suspend fun fetchOffset(url: String): SupabaseResult<Long> {
+        val headers = mapOf("Tus-Resumable" to TUS_VERSION)
+        return when (val res = client.rawRequest(SupabaseHttpMethod.HEAD, url, headers = headers)) {
+            is SupabaseResult.Success -> readOffset(res.value)
+            is SupabaseResult.Failure -> res
+        }
+    }
+
+    private suspend fun patchChunk(url: String, offset: Long, chunk: ByteArray): SupabaseResult<Long> {
+        val headers =
+            mapOf(
+                "Tus-Resumable" to TUS_VERSION,
+                "Upload-Offset" to offset.toString(),
+            )
+        val res =
+            client.rawRequest(
+                method = SupabaseHttpMethod.PATCH,
+                url = url,
+                body = chunk,
+                contentType = "application/offset+octet-stream",
+                headers = headers,
+            )
+        return when (res) {
+            is SupabaseResult.Success -> readOffset(res.value)
+            is SupabaseResult.Failure -> res
+        }
+    }
+
+    private fun readOffset(response: SupabaseHttpResponse): SupabaseResult<Long> {
+        val offset = response.header("Upload-Offset")?.toLongOrNull()
+        return if (offset != null) {
+            SupabaseResult.Success(offset)
+        } else {
+            SupabaseResult.Failure(SupabaseError("Resumable upload response missing Upload-Offset header"))
+        }
+    }
+
+    @OptIn(ExperimentalEncodingApi::class)
+    private fun uploadMetadata(): String {
+        val entries =
+            buildList {
+                add("bucketName" to bucket)
+                add("objectName" to path)
+                add("contentType" to contentType)
+                cacheControl?.let { add("cacheControl" to it.toString()) }
+            }
+        return entries.joinToString(",") { (key, value) ->
+            "$key ${Base64.encode(value.encodeToByteArray())}"
+        }
+    }
+}

--- a/supabase-storage/src/commonMain/kotlin/io/github/androidpoet/supabase/storage/StorageClient.kt
+++ b/supabase-storage/src/commonMain/kotlin/io/github/androidpoet/supabase/storage/StorageClient.kt
@@ -189,6 +189,23 @@ public interface StorageClient {
         cacheControl: Int? = null,
     ): SupabaseResult<String>
 
+    /**
+     * Creates a resumable (TUS) upload handle. The upload is not started until
+     * [ResumableUpload.await] is called. Pass [uploadUrl] (a previously captured
+     * [ResumableUpload.uploadUrl]) to resume an interrupted upload instead of
+     * starting a new one.
+     */
+    public fun createResumableUpload(
+        bucket: String,
+        path: String,
+        data: ByteArray,
+        contentType: String = "application/octet-stream",
+        upsert: Boolean = false,
+        cacheControl: Int? = null,
+        chunkSize: Int = RESUMABLE_DEFAULT_CHUNK_SIZE,
+        uploadUrl: String? = null,
+    ): ResumableUpload
+
     public suspend fun update(
         bucket: String,
         path: String,

--- a/supabase-storage/src/commonMain/kotlin/io/github/androidpoet/supabase/storage/StorageClientExt.kt
+++ b/supabase-storage/src/commonMain/kotlin/io/github/androidpoet/supabase/storage/StorageClientExt.kt
@@ -2,6 +2,30 @@ package io.github.androidpoet.supabase.storage
 
 import io.github.androidpoet.supabase.core.result.SupabaseResult
 
+/**
+ * Uploads [data] in resumable (TUS) chunks and suspends until it completes.
+ * One-shot convenience over [StorageClient.createResumableUpload]; for progress
+ * or pause/resume, use that directly and observe [ResumableUpload.progress].
+ */
+public suspend fun StorageClient.uploadResumable(
+    bucket: String,
+    path: String,
+    data: ByteArray,
+    contentType: String = "application/octet-stream",
+    upsert: Boolean = false,
+    cacheControl: Int? = null,
+    chunkSize: Int = RESUMABLE_DEFAULT_CHUNK_SIZE,
+): SupabaseResult<Unit> =
+    createResumableUpload(
+        bucket = bucket,
+        path = path,
+        data = data,
+        contentType = contentType,
+        upsert = upsert,
+        cacheControl = cacheControl,
+        chunkSize = chunkSize,
+    ).await()
+
 public suspend fun StorageClient.createSignedDownloadUrl(
     bucket: String,
     path: String,

--- a/supabase-storage/src/commonMain/kotlin/io/github/androidpoet/supabase/storage/StorageClientImpl.kt
+++ b/supabase-storage/src/commonMain/kotlin/io/github/androidpoet/supabase/storage/StorageClientImpl.kt
@@ -90,11 +90,11 @@ internal class StorageClientImpl(
                 sortOrder?.let { add("sortOrder" to it.name.lowercase()) }
                 search?.let { add("search" to it) }
             }
-        return client.get("/storage/v1/bucket", queryParams = query).deserialize()
+        return client.get(StoragePaths.BUCKET, queryParams = query).deserialize()
     }
 
     override suspend fun getBucket(id: String): SupabaseResult<Bucket> =
-        client.get("/storage/v1/bucket/$id").deserialize()
+        client.get("${StoragePaths.BUCKET}/$id").deserialize()
 
     override suspend fun createBucket(
         id: String,
@@ -113,7 +113,7 @@ internal class StorageClientImpl(
                     allowedMimeTypes = allowedMimeTypes,
                 ),
             )
-        return client.post("/storage/v1/bucket", body = body).deserialize()
+        return client.post(StoragePaths.BUCKET, body = body).deserialize()
     }
 
     override suspend fun updateBucket(
@@ -132,14 +132,14 @@ internal class StorageClientImpl(
                     allowedMimeTypes = allowedMimeTypes,
                 ),
             )
-        return client.put("/storage/v1/bucket/$id", body = body).deserialize()
+        return client.put("${StoragePaths.BUCKET}/$id", body = body).deserialize()
     }
 
     override suspend fun deleteBucket(id: String): SupabaseResult<Unit> =
-        client.delete("/storage/v1/bucket/$id").map { }
+        client.delete("${StoragePaths.BUCKET}/$id").map { }
 
     override suspend fun emptyBucket(id: String): SupabaseResult<Unit> =
-        client.post("/storage/v1/bucket/$id/empty").map { }
+        client.post("${StoragePaths.BUCKET}/$id/empty").map { }
 
     override suspend fun upload(
         bucket: String,
@@ -153,7 +153,7 @@ internal class StorageClientImpl(
             buildMap {
                 if (upsert) put("x-upsert", "true")
             }
-        val endpoint = withCacheControl("/storage/v1/object/${objectRef(bucket, path)}", cacheControl)
+        val endpoint = withCacheControl("${StoragePaths.OBJECT}/${objectRef(bucket, path)}", cacheControl)
         return client.postRaw(
             url = endpoint,
             body = data,
@@ -174,7 +174,7 @@ internal class StorageClientImpl(
             buildMap {
                 if (upsert) put("x-upsert", "true")
             }
-        val endpoint = withCacheControl("/storage/v1/object/${objectRef(bucket, path)}", cacheControl)
+        val endpoint = withCacheControl("${StoragePaths.OBJECT}/${objectRef(bucket, path)}", cacheControl)
         return client.putRaw(
             url = endpoint,
             body = data,
@@ -206,10 +206,10 @@ internal class StorageClientImpl(
         )
 
     override suspend fun download(bucket: String, path: String): SupabaseResult<String> =
-        client.get("/storage/v1/object/authenticated/${objectRef(bucket, path)}")
+        client.get("${StoragePaths.OBJECT_AUTHENTICATED}/${objectRef(bucket, path)}")
 
     override suspend fun downloadPublic(bucket: String, path: String): SupabaseResult<String> =
-        client.get("/storage/v1/object/public/${objectRef(bucket, path)}")
+        client.get("${StoragePaths.OBJECT_PUBLIC}/${objectRef(bucket, path)}")
 
     override suspend fun download(
         bucket: String,
@@ -217,7 +217,7 @@ internal class StorageClientImpl(
         download: Boolean,
         fileName: String?,
     ): SupabaseResult<String> =
-        client.get("/storage/v1/object/authenticated/${objectRef(bucket, path)}${buildDownloadQuery(download, fileName)}")
+        client.get("${StoragePaths.OBJECT_AUTHENTICATED}/${objectRef(bucket, path)}${buildDownloadQuery(download, fileName)}")
 
     override suspend fun downloadPublic(
         bucket: String,
@@ -225,13 +225,13 @@ internal class StorageClientImpl(
         download: Boolean,
         fileName: String?,
     ): SupabaseResult<String> =
-        client.get("/storage/v1/object/public/${objectRef(bucket, path)}${buildDownloadQuery(download, fileName)}")
+        client.get("${StoragePaths.OBJECT_PUBLIC}/${objectRef(bucket, path)}${buildDownloadQuery(download, fileName)}")
 
     override suspend fun info(bucket: String, path: String): SupabaseResult<FileObject> =
-        client.get("/storage/v1/object/info/${objectRef(bucket, path)}").deserialize()
+        client.get("${StoragePaths.OBJECT_INFO}/${objectRef(bucket, path)}").deserialize()
 
     override suspend fun infoPublic(bucket: String, path: String): SupabaseResult<FileObject> =
-        client.get("/storage/v1/object/info/public/${objectRef(bucket, path)}").deserialize()
+        client.get("${StoragePaths.OBJECT_INFO_PUBLIC}/${objectRef(bucket, path)}").deserialize()
 
     override suspend fun exists(bucket: String, path: String): SupabaseResult<Boolean> =
         when (val result = info(bucket, path)) {
@@ -277,7 +277,7 @@ internal class StorageClientImpl(
                     search = search,
                 ),
             )
-        return client.post("/storage/v1/object/list/$bucket", body = body).deserialize()
+        return client.post("${StoragePaths.OBJECT_LIST}/$bucket", body = body).deserialize()
     }
 
     override suspend fun listV2(
@@ -302,7 +302,7 @@ internal class StorageClientImpl(
                         },
                 ),
             )
-        return client.post("/storage/v1/object/list-v2/$bucket", body = body).deserialize()
+        return client.post("${StoragePaths.OBJECT_LIST_V2}/$bucket", body = body).deserialize()
     }
 
     override suspend fun move(
@@ -320,14 +320,14 @@ internal class StorageClientImpl(
                     destinationBucketId = destinationBucket,
                 ),
             )
-        return client.post("/storage/v1/object/move", body = body).map { }
+        return client.post(StoragePaths.OBJECT_MOVE, body = body).map { }
     }
 
     override suspend fun deleteObject(
         bucket: String,
         path: String,
     ): SupabaseResult<Unit> =
-        client.delete("/storage/v1/object/${objectRef(bucket, path)}").map { }
+        client.delete("${StoragePaths.OBJECT}/${objectRef(bucket, path)}").map { }
 
     override suspend fun copy(
         bucket: String,
@@ -346,7 +346,7 @@ internal class StorageClientImpl(
                     copyMetadata = copyMetadata,
                 ),
             )
-        return client.post("/storage/v1/object/copy", body = body).map { }
+        return client.post(StoragePaths.OBJECT_COPY, body = body).map { }
     }
 
     override suspend fun remove(bucket: String, paths: List<String>): SupabaseResult<Unit> = removeWithResult(bucket, paths).map { }
@@ -358,7 +358,7 @@ internal class StorageClientImpl(
         val body = defaultJson.encodeToString(mapOf("prefixes" to paths))
         return client
             .post(
-                endpoint = "/storage/v1/object/remove/$bucket",
+                endpoint = "${StoragePaths.OBJECT_REMOVE}/$bucket",
                 body = body,
             ).deserialize()
     }
@@ -379,7 +379,7 @@ internal class StorageClientImpl(
                 ),
             )
         return client
-            .post("/storage/v1/object/sign/${objectRef(bucket, path)}", body = body)
+            .post("${StoragePaths.OBJECT_SIGN}/${objectRef(bucket, path)}", body = body)
             .deserialize<SignedUrlResponse>()
             .map { appendDownloadQuery(resolveStorageUrl(it.signedUrl), download, fileName) }
     }
@@ -393,7 +393,7 @@ internal class StorageClientImpl(
     ): SupabaseResult<List<String>> {
         val body = defaultJson.encodeToString(SignedUrlsRequest(paths = paths, expiresIn = expiresIn))
         return client
-            .post("/storage/v1/object/sign/$bucket", body = body)
+            .post("${StoragePaths.OBJECT_SIGN}/$bucket", body = body)
             .deserialize<List<SignedUrlItemResponse>>()
             .map { list -> list.map { appendDownloadQuery(resolveStorageUrl(it.signedUrl), download, fileName) } }
     }
@@ -413,7 +413,7 @@ internal class StorageClientImpl(
     ): SupabaseResult<UploadSignedUrl> =
         client
             .post(
-                endpoint = "/storage/v1/object/upload/sign/${objectRef(bucket, path)}",
+                endpoint = "${StoragePaths.OBJECT_UPLOAD_SIGN}/${objectRef(bucket, path)}",
                 headers = if (upsert) mapOf("x-upsert" to "true") else emptyMap(),
             ).deserialize<UploadSignedUrlResponse>()
             .map { UploadSignedUrl(url = resolveStorageUrl(it.url), token = it.token) }
@@ -437,7 +437,7 @@ internal class StorageClientImpl(
                 cacheControl?.let { add("cacheControl=$it") }
             }.joinToString("&")
         return client.postRaw(
-            url = "/storage/v1/object/upload/sign/${objectRef(bucket, path)}?$qs",
+            url = "${StoragePaths.OBJECT_UPLOAD_SIGN}/${objectRef(bucket, path)}?$qs",
             body = data,
             contentType = contentType,
             headers = headers,
@@ -453,7 +453,7 @@ internal class StorageClientImpl(
     ): String {
         val downloadQuery = buildDownloadQuery(download, fileName)
         val join = if (downloadQuery.isEmpty()) "" else "&${downloadQuery.removePrefix("?")}"
-        return "${client.projectUrl}/storage/v1/object/sign/${objectRef(bucket, path)}?token=${encodeQueryComponent(token)}$join"
+        return "${client.projectUrl}${StoragePaths.OBJECT_SIGN}/${objectRef(bucket, path)}?token=${encodeQueryComponent(token)}$join"
     }
 
     override fun getPublicUrl(
@@ -489,7 +489,7 @@ internal class StorageClientImpl(
         fileName: String?,
         transform: ImageTransformOptions?,
     ): String {
-        val base = "${client.projectUrl}/storage/v1/object/public/${objectRef(bucket, path)}"
+        val base = "${client.projectUrl}${StoragePaths.OBJECT_PUBLIC}/${objectRef(bucket, path)}"
         val queryParts = mutableListOf<String>()
         val transformQuery = transform?.toQueryString()
         if (!transformQuery.isNullOrBlank()) {
@@ -509,7 +509,7 @@ internal class StorageClientImpl(
         fileName: String?,
         transform: ImageTransformOptions?,
     ): String {
-        val base = "${client.projectUrl}/storage/v1/object/authenticated/${objectRef(bucket, path)}"
+        val base = "${client.projectUrl}${StoragePaths.OBJECT_AUTHENTICATED}/${objectRef(bucket, path)}"
         val queryParts = mutableListOf<String>()
         val transformQuery = transform?.toQueryString()
         if (!transformQuery.isNullOrBlank()) {
@@ -527,7 +527,7 @@ internal class StorageClientImpl(
         path: String,
         transform: ImageTransformOptions?,
     ): String {
-        val base = "${client.projectUrl}/storage/v1/render/image/public/${objectRef(bucket, path)}"
+        val base = "${client.projectUrl}${StoragePaths.RENDER_IMAGE_PUBLIC}/${objectRef(bucket, path)}"
         val transformQuery = transform?.toQueryString().orEmpty()
         return if (transformQuery.isBlank()) base else "$base?$transformQuery"
     }
@@ -537,14 +537,14 @@ internal class StorageClientImpl(
         path: String,
         transform: ImageTransformOptions?,
     ): String {
-        val base = "${client.projectUrl}/storage/v1/render/image/authenticated/${objectRef(bucket, path)}"
+        val base = "${client.projectUrl}${StoragePaths.RENDER_IMAGE_AUTHENTICATED}/${objectRef(bucket, path)}"
         val transformQuery = transform?.toQueryString().orEmpty()
         return if (transformQuery.isBlank()) base else "$base?$transformQuery"
     }
 
     override suspend fun createAnalyticsBucket(name: String): SupabaseResult<AnalyticsBucket> {
         val body = defaultJson.encodeToString(AnalyticsBucketCreateRequest(name = name))
-        return client.post("/storage/v1/iceberg/bucket", body = body).deserialize()
+        return client.post("${StoragePaths.ICEBERG}/bucket", body = body).deserialize()
     }
 
     override suspend fun listAnalyticsBuckets(
@@ -564,15 +564,15 @@ internal class StorageClientImpl(
             }
         val endpoint =
             if (query.isEmpty()) {
-                "/storage/v1/iceberg/bucket"
+                "${StoragePaths.ICEBERG}/bucket"
             } else {
-                "/storage/v1/iceberg/bucket?${query.joinToString("&") { (k, v) -> "${encodeQueryComponent(k)}=${encodeQueryComponent(v)}" }}"
+                "${StoragePaths.ICEBERG}/bucket?${query.joinToString("&") { (k, v) -> "${encodeQueryComponent(k)}=${encodeQueryComponent(v)}" }}"
             }
         return client.get(endpoint).deserialize()
     }
 
     override suspend fun deleteAnalyticsBucket(name: String): SupabaseResult<Unit> =
-        client.delete("/storage/v1/iceberg/bucket/$name").map { }
+        client.delete("${StoragePaths.ICEBERG}/bucket/$name").map { }
 
     override fun analyticsCatalog(bucketName: String): AnalyticsCatalogClient {
         validateAnalyticsBucketName(bucketName)
@@ -581,13 +581,13 @@ internal class StorageClientImpl(
 
     override suspend fun createVectorBucket(vectorBucketName: String): SupabaseResult<Unit> {
         val body = defaultJson.encodeToString(VectorBucketCreateRequest(vectorBucketName = vectorBucketName))
-        return client.post("/storage/v1/vector/CreateVectorBucket", body = body).map { }
+        return client.post("${StoragePaths.VECTOR}/CreateVectorBucket", body = body).map { }
     }
 
     override suspend fun getVectorBucket(vectorBucketName: String): SupabaseResult<VectorBucket> {
         val body = defaultJson.encodeToString(VectorBucketRequest(vectorBucketName = vectorBucketName))
         return client
-            .post("/storage/v1/vector/GetVectorBucket", body = body)
+            .post("${StoragePaths.VECTOR}/GetVectorBucket", body = body)
             .deserialize<VectorBucketResponse>()
             .map { it.vectorBucket }
     }
@@ -605,12 +605,12 @@ internal class StorageClientImpl(
                     nextToken = nextToken,
                 ),
             )
-        return client.post("/storage/v1/vector/ListVectorBuckets", body = body).deserialize()
+        return client.post("${StoragePaths.VECTOR}/ListVectorBuckets", body = body).deserialize()
     }
 
     override suspend fun deleteVectorBucket(vectorBucketName: String): SupabaseResult<Unit> {
         val body = defaultJson.encodeToString(VectorBucketRequest(vectorBucketName = vectorBucketName))
-        return client.post("/storage/v1/vector/DeleteVectorBucket", body = body).map { }
+        return client.post("${StoragePaths.VECTOR}/DeleteVectorBucket", body = body).map { }
     }
 
     override suspend fun createVectorIndex(
@@ -632,7 +632,7 @@ internal class StorageClientImpl(
                     metadataConfiguration = metadataConfiguration,
                 ),
             )
-        return client.post("/storage/v1/vector/CreateIndex", body = body).map { }
+        return client.post("${StoragePaths.VECTOR}/CreateIndex", body = body).map { }
     }
 
     override suspend fun getVectorIndex(
@@ -644,7 +644,7 @@ internal class StorageClientImpl(
                 VectorIndexRequest(vectorBucketName = vectorBucketName, indexName = indexName),
             )
         return client
-            .post("/storage/v1/vector/GetIndex", body = body)
+            .post("${StoragePaths.VECTOR}/GetIndex", body = body)
             .deserialize<VectorIndexResponse>()
             .map { it.index }
     }
@@ -664,7 +664,7 @@ internal class StorageClientImpl(
                     nextToken = nextToken,
                 ),
             )
-        return client.post("/storage/v1/vector/ListIndexes", body = body).deserialize()
+        return client.post("${StoragePaths.VECTOR}/ListIndexes", body = body).deserialize()
     }
 
     override suspend fun deleteVectorIndex(
@@ -675,7 +675,7 @@ internal class StorageClientImpl(
             defaultJson.encodeToString(
                 VectorIndexRequest(vectorBucketName = vectorBucketName, indexName = indexName),
             )
-        return client.post("/storage/v1/vector/DeleteIndex", body = body).map { }
+        return client.post("${StoragePaths.VECTOR}/DeleteIndex", body = body).map { }
     }
 
     override suspend fun putVectors(
@@ -688,7 +688,7 @@ internal class StorageClientImpl(
             defaultJson.encodeToString(
                 VectorPutRequest(vectorBucketName = vectorBucketName, indexName = indexName, vectors = vectors),
             )
-        return client.post("/storage/v1/vector/PutVectors", body = body).map { }
+        return client.post("${StoragePaths.VECTOR}/PutVectors", body = body).map { }
     }
 
     override suspend fun getVectors(
@@ -709,7 +709,7 @@ internal class StorageClientImpl(
                 ),
             )
         return client
-            .post("/storage/v1/vector/GetVectors", body = body)
+            .post("${StoragePaths.VECTOR}/GetVectors", body = body)
             .deserialize<VectorMatchesResponse>()
             .map { it.vectors }
     }
@@ -745,7 +745,7 @@ internal class StorageClientImpl(
                     segmentIndex = segmentIndex,
                 ),
             )
-        return client.post("/storage/v1/vector/ListVectors", body = body).deserialize()
+        return client.post("${StoragePaths.VECTOR}/ListVectors", body = body).deserialize()
     }
 
     override suspend fun queryVectors(
@@ -769,7 +769,7 @@ internal class StorageClientImpl(
                     returnMetadata = returnMetadata,
                 ),
             )
-        return client.post("/storage/v1/vector/QueryVectors", body = body).deserialize()
+        return client.post("${StoragePaths.VECTOR}/QueryVectors", body = body).deserialize()
     }
 
     override suspend fun deleteVectors(
@@ -782,7 +782,7 @@ internal class StorageClientImpl(
             defaultJson.encodeToString(
                 VectorDeleteRequest(vectorBucketName = vectorBucketName, indexName = indexName, keys = keys),
             )
-        return client.post("/storage/v1/vector/DeleteVectors", body = body).map { }
+        return client.post("${StoragePaths.VECTOR}/DeleteVectors", body = body).map { }
     }
 
     private fun resolveStorageUrl(pathOrUrl: String): String =
@@ -874,14 +874,14 @@ internal class AnalyticsCatalogClientImpl(
     override suspend fun loadConfig(): SupabaseResult<JsonObject> =
         client
             .get(
-                endpoint = "/storage/v1/iceberg/v1/config",
+                endpoint = "${StoragePaths.ICEBERG}/v1/config",
                 queryParams = listOf("warehouse" to bucketName),
             ).toJsonObject()
 
     override suspend fun loadConfigTyped(): SupabaseResult<IcebergCatalogConfig> =
         client
             .get(
-                endpoint = "/storage/v1/iceberg/v1/config",
+                endpoint = "${StoragePaths.ICEBERG}/v1/config",
                 queryParams = listOf("warehouse" to bucketName),
             ).deserialize()
 
@@ -1158,7 +1158,7 @@ internal class AnalyticsCatalogClientImpl(
                 is SupabaseResult.Success -> config.value.extractIcebergPrefix()
                 is SupabaseResult.Failure -> null
             } ?: bucketName
-        return "/storage/v1/iceberg/v1/$prefix".also { resolvedPrefix = it }
+        return "${StoragePaths.ICEBERG}/v1/$prefix".also { resolvedPrefix = it }
     }
 
     private fun JsonObject.extractIcebergPrefix(): String? =

--- a/supabase-storage/src/commonMain/kotlin/io/github/androidpoet/supabase/storage/StorageClientImpl.kt
+++ b/supabase-storage/src/commonMain/kotlin/io/github/androidpoet/supabase/storage/StorageClientImpl.kt
@@ -183,6 +183,28 @@ internal class StorageClientImpl(
         )
     }
 
+    override fun createResumableUpload(
+        bucket: String,
+        path: String,
+        data: ByteArray,
+        contentType: String,
+        upsert: Boolean,
+        cacheControl: Int?,
+        chunkSize: Int,
+        uploadUrl: String?,
+    ): ResumableUpload =
+        ResumableUploadImpl(
+            client = client,
+            bucket = bucket,
+            path = path,
+            data = data,
+            contentType = contentType,
+            upsert = upsert,
+            cacheControl = cacheControl,
+            chunkSize = chunkSize,
+            initialUploadUrl = uploadUrl,
+        )
+
     override suspend fun download(bucket: String, path: String): SupabaseResult<String> =
         client.get("/storage/v1/object/authenticated/${objectRef(bucket, path)}")
 

--- a/supabase-storage/src/commonMain/kotlin/io/github/androidpoet/supabase/storage/StoragePaths.kt
+++ b/supabase-storage/src/commonMain/kotlin/io/github/androidpoet/supabase/storage/StoragePaths.kt
@@ -1,0 +1,46 @@
+package io.github.androidpoet.supabase.storage
+
+/**
+ * Centralized Supabase Storage endpoint paths.
+ *
+ * The API version and the base segments are factored out so the version lives in
+ * exactly one place and the route prefixes are composed from it, rather than
+ * repeating `/storage/v1/...` literals throughout [StorageClientImpl].
+ *
+ * Constants are full path prefixes; dynamic segments (bucket, object reference,
+ * RPC name, …) are appended at the call site, e.g.
+ * `"${StoragePaths.OBJECT_AUTHENTICATED}/${objectRef(bucket, path)}"`.
+ */
+internal object StoragePaths {
+    const val API_VERSION: String = "v1"
+    const val BASE: String = "/storage/" + API_VERSION
+
+    // Buckets
+    const val BUCKET: String = BASE + "/bucket"
+
+    // Objects
+    const val OBJECT: String = BASE + "/object"
+    const val OBJECT_AUTHENTICATED: String = OBJECT + "/authenticated"
+    const val OBJECT_PUBLIC: String = OBJECT + "/public"
+    const val OBJECT_INFO: String = OBJECT + "/info"
+    const val OBJECT_INFO_PUBLIC: String = OBJECT + "/info/public"
+    const val OBJECT_SIGN: String = OBJECT + "/sign"
+    const val OBJECT_UPLOAD_SIGN: String = OBJECT + "/upload/sign"
+    const val OBJECT_LIST: String = OBJECT + "/list"
+    const val OBJECT_LIST_V2: String = OBJECT + "/list-v2"
+    const val OBJECT_REMOVE: String = OBJECT + "/remove"
+    const val OBJECT_MOVE: String = OBJECT + "/move"
+    const val OBJECT_COPY: String = OBJECT + "/copy"
+
+    // Image render/transform
+    const val RENDER_IMAGE: String = BASE + "/render/image"
+    const val RENDER_IMAGE_AUTHENTICATED: String = RENDER_IMAGE + "/authenticated"
+    const val RENDER_IMAGE_PUBLIC: String = RENDER_IMAGE + "/public"
+
+    // Resumable (TUS) uploads
+    const val RESUMABLE_UPLOAD: String = BASE + "/upload/resumable"
+
+    // Analytics (Iceberg) and S3 Vectors
+    const val ICEBERG: String = BASE + "/iceberg"
+    const val VECTOR: String = BASE + "/vector"
+}

--- a/supabase-storage/src/commonTest/kotlin/io/github/androidpoet/supabase/storage/StorageClientExtTest.kt
+++ b/supabase-storage/src/commonTest/kotlin/io/github/androidpoet/supabase/storage/StorageClientExtTest.kt
@@ -440,6 +440,17 @@ private class FakeStorageClient : StorageClient {
 
     override suspend fun upload(bucket: String, path: String, data: ByteArray, contentType: String, upsert: Boolean, cacheControl: Int?): SupabaseResult<String> = error("not used")
 
+    override fun createResumableUpload(
+        bucket: String,
+        path: String,
+        data: ByteArray,
+        contentType: String,
+        upsert: Boolean,
+        cacheControl: Int?,
+        chunkSize: Int,
+        uploadUrl: String?,
+    ): ResumableUpload = error("not used")
+
     override suspend fun update(bucket: String, path: String, data: ByteArray, contentType: String, upsert: Boolean, cacheControl: Int?): SupabaseResult<String> = error("not used")
 
     override suspend fun download(bucket: String, path: String): SupabaseResult<String> = error("not used")

--- a/supabase-storage/src/commonTest/kotlin/io/github/androidpoet/supabase/storage/StorageClientImplTest.kt
+++ b/supabase-storage/src/commonTest/kotlin/io/github/androidpoet/supabase/storage/StorageClientImplTest.kt
@@ -1,6 +1,8 @@
 package io.github.androidpoet.supabase.storage
 
 import io.github.androidpoet.supabase.client.SupabaseClient
+import io.github.androidpoet.supabase.client.SupabaseHttpMethod
+import io.github.androidpoet.supabase.client.SupabaseHttpResponse
 import io.github.androidpoet.supabase.core.result.SupabaseError
 import io.github.androidpoet.supabase.core.result.SupabaseResult
 import io.github.androidpoet.supabase.storage.models.IcebergCreateNamespaceRequest
@@ -23,6 +25,48 @@ import kotlin.test.assertFailsWith
 import kotlin.test.assertTrue
 
 class StorageClientImplTest {
+    @Test
+    fun test_resumableUpload_chunksAndCompletes() =
+        runTest {
+            val client = FakeSupabaseClient()
+            val sut = StorageClientImpl(client)
+            val data = ByteArray(10) { it.toByte() }
+
+            val upload = sut.createResumableUpload(bucket = "videos", path = "a/b.bin", data = data, chunkSize = 4)
+            val result = upload.await()
+
+            assertTrue(result is SupabaseResult.Success)
+            assertEquals(1, client.resumableCreateCount)
+            assertEquals(listOf(4, 4, 2), client.resumableChunkSizes)
+            assertEquals(10L, upload.progress.value.bytesUploaded)
+            assertTrue(upload.progress.value.isComplete)
+            assertEquals(client.resumableUploadUrl, upload.uploadUrl)
+        }
+
+    @Test
+    fun test_resumableUpload_resumesFromExistingOffset() =
+        runTest {
+            val client = FakeSupabaseClient()
+            client.presetResumableReceived(6L) // server already holds 6 of 10 bytes
+            val sut = StorageClientImpl(client)
+            val data = ByteArray(10) { it.toByte() }
+
+            val upload =
+                sut.createResumableUpload(
+                    bucket = "videos",
+                    path = "a/b.bin",
+                    data = data,
+                    chunkSize = 4,
+                    uploadUrl = client.resumableUploadUrl,
+                )
+            val result = upload.await()
+
+            assertTrue(result is SupabaseResult.Success)
+            assertEquals(0, client.resumableCreateCount) // resumed, did not re-create
+            assertEquals(listOf(4), client.resumableChunkSizes) // only the remaining 4 bytes
+            assertTrue(upload.progress.value.isComplete)
+        }
+
     @Test
     fun test_listBuckets_includesQueryParams() =
         runTest {
@@ -933,6 +977,18 @@ private class FakeSupabaseClient : SupabaseClient {
     var lastPutRawUrl: String? = null
     var lastPutRawHeaders: Map<String, String> = emptyMap()
 
+    // Resumable (TUS) upload simulation state.
+    val resumableUploadUrl: String = "https://example.supabase.co/storage/v1/upload/resumable/upload-1"
+    var resumableCreateCount: Int = 0
+    val resumableChunkSizes: MutableList<Int> = mutableListOf()
+    var resumableMetadata: String? = null
+    var resumableUpsertHeader: String? = null
+    private var resumableReceived: Long = 0L
+
+    fun presetResumableReceived(bytes: Long) {
+        resumableReceived = bytes
+    }
+
     override suspend fun get(
         endpoint: String,
         queryParams: List<Pair<String, String>>,
@@ -1078,6 +1134,37 @@ private class FakeSupabaseClient : SupabaseClient {
         lastPutRawHeaders = headers
         return SupabaseResult.Success("ok")
     }
+
+    override suspend fun rawRequest(
+        method: SupabaseHttpMethod,
+        url: String,
+        body: ByteArray?,
+        contentType: String?,
+        headers: Map<String, String>,
+    ): SupabaseResult<SupabaseHttpResponse> =
+        when (method) {
+            SupabaseHttpMethod.POST -> {
+                resumableCreateCount++
+                resumableReceived = 0L
+                resumableMetadata = headers["Upload-Metadata"]
+                resumableUpsertHeader = headers["x-upsert"]
+                SupabaseResult.Success(
+                    SupabaseHttpResponse(201, mapOf("Location" to resumableUploadUrl), ByteArray(0)),
+                )
+            }
+            SupabaseHttpMethod.HEAD ->
+                SupabaseResult.Success(
+                    SupabaseHttpResponse(200, mapOf("Upload-Offset" to resumableReceived.toString()), ByteArray(0)),
+                )
+            SupabaseHttpMethod.PATCH -> {
+                resumableChunkSizes.add(body?.size ?: 0)
+                resumableReceived += (body?.size ?: 0).toLong()
+                SupabaseResult.Success(
+                    SupabaseHttpResponse(204, mapOf("Upload-Offset" to resumableReceived.toString()), ByteArray(0)),
+                )
+            }
+            else -> SupabaseResult.Failure(SupabaseError("unexpected method $method"))
+        }
 
     override fun setAccessToken(token: String) = Unit
 


### PR DESCRIPTION
## Resumable (TUS) uploads + centralized storage paths

Supersedes #23 (auto-closed when its stacked base `feat/error-layer-network` merged via #22).

### Resumable uploads
Adds TUS-protocol resumable uploads to `supabase-storage` — a genuine headless capability gap vs other Supabase SDKs.

- `ResumableUpload` handle with `uploadUrl`, `progress: StateFlow<ResumableUploadProgress>`, and a cancellable `await()`.
- TUS flow: POST create (`Upload-Metadata` base64), PATCH 6 MiB chunks, HEAD to resume from server offset.
- Pause/resume across app restarts by persisting `uploadUrl`.
- Built on a new `SupabaseClient.rawRequest(...)` (method/url/body/headers → raw response) so storage can speak a non-JSON protocol without bypassing the client.

### Centralized storage paths
- New internal `StoragePaths` object factors the API version and route prefixes into one place; all 44 `/storage/v1/...` literals in `StorageClientImpl` now reference it.

All additive. `apiDump` regenerated for 13 targets; `jvmTest`, `detekt`, `spotlessCheck`, `apiCheck` green locally.
