### PR TITLE
refactor: centralize endpoint paths across auth/database/functions

### DIFF
--- a/supabase-auth-admin/src/commonMain/kotlin/io/github/androidpoet/supabase/auth/admin/AuthAdminClientImpl.kt
+++ b/supabase-auth-admin/src/commonMain/kotlin/io/github/androidpoet/supabase/auth/admin/AuthAdminClientImpl.kt
@@ -43,7 +43,7 @@ internal class AuthAdminClientImpl(
     ): SupabaseResult<Unit> =
         client
             .post(
-                endpoint = "/auth/v1/logout?scope=${scope.name.lowercase()}",
+                endpoint = "${AuthAdminPaths.LOGOUT}?scope=${scope.name.lowercase()}",
                 headers = mapOf("Authorization" to "Bearer $jwt"),
             ).map { }
 
@@ -55,7 +55,7 @@ internal class AuthAdminClientImpl(
         val body = defaultJson.encodeToString(InviteUserRequest(email = email, data = data))
         return client
             .post(
-                endpoint = withRedirectTo("/auth/v1/invite", redirectTo),
+                endpoint = withRedirectTo(AuthAdminPaths.INVITE, redirectTo),
                 body = body,
                 headers = adminHeaders,
             ).deserializeUserResponse()
@@ -65,7 +65,7 @@ internal class AuthAdminClientImpl(
         val body = defaultJson.encodeToString(request)
         return client
             .post(
-                endpoint = withRedirectTo("/auth/v1/admin/generate_link", request.redirectTo),
+                endpoint = withRedirectTo(AuthAdminPaths.ADMIN_GENERATE_LINK, request.redirectTo),
                 body = body,
                 headers = adminHeaders,
             ).deserialize()
@@ -75,7 +75,7 @@ internal class AuthAdminClientImpl(
         val body = defaultJson.encodeToString(attributes)
         return client
             .post(
-                endpoint = "/auth/v1/admin/users",
+                endpoint = AuthAdminPaths.ADMIN_USERS,
                 body = body,
                 headers = adminHeaders,
             ).deserializeUserResponse()
@@ -92,7 +92,7 @@ internal class AuthAdminClientImpl(
             }
         return client
             .get(
-                endpoint = "/auth/v1/admin/users",
+                endpoint = AuthAdminPaths.ADMIN_USERS,
                 queryParams = queryParams,
                 headers = adminHeaders,
             ).deserialize()
@@ -101,7 +101,7 @@ internal class AuthAdminClientImpl(
     override suspend fun getUserById(userId: String): SupabaseResult<User> =
         client
             .get(
-                endpoint = "/auth/v1/admin/users/$userId",
+                endpoint = "${AuthAdminPaths.ADMIN_USERS}/$userId",
                 headers = adminHeaders,
             ).deserializeUserResponse()
 
@@ -112,7 +112,7 @@ internal class AuthAdminClientImpl(
         val body = defaultJson.encodeToString(attributes)
         return client
             .put(
-                endpoint = "/auth/v1/admin/users/$userId",
+                endpoint = "${AuthAdminPaths.ADMIN_USERS}/$userId",
                 body = body,
                 headers = adminHeaders,
             ).deserializeUserResponse()
@@ -125,7 +125,7 @@ internal class AuthAdminClientImpl(
         val body = defaultJson.encodeToString(UserDeleteRequest(shouldSoftDelete = shouldSoftDelete))
         return client
             .delete(
-                endpoint = "/auth/v1/admin/users/$userId",
+                endpoint = "${AuthAdminPaths.ADMIN_USERS}/$userId",
                 body = body,
                 headers = adminHeaders,
             ).map { }
@@ -134,7 +134,7 @@ internal class AuthAdminClientImpl(
     override suspend fun listFactors(userId: String): SupabaseResult<MfaAdminListFactorsResponse> =
         client
             .get(
-                endpoint = "/auth/v1/admin/users/$userId/factors",
+                endpoint = "${AuthAdminPaths.ADMIN_USERS}/$userId/factors",
                 headers = adminHeaders,
             ).deserialize()
 
@@ -144,7 +144,7 @@ internal class AuthAdminClientImpl(
     ): SupabaseResult<MfaAdminDeleteFactorResponse> =
         client
             .delete(
-                endpoint = "/auth/v1/admin/users/$userId/factors/$factorId",
+                endpoint = "${AuthAdminPaths.ADMIN_USERS}/$userId/factors/$factorId",
                 headers = adminHeaders,
             ).deserialize()
 
@@ -159,7 +159,7 @@ internal class AuthAdminClientImpl(
             }
         return client
             .get(
-                endpoint = "/auth/v1/admin/oauth/clients",
+                endpoint = AuthAdminPaths.ADMIN_OAUTH_CLIENTS,
                 queryParams = queryParams,
                 headers = adminHeaders,
             ).deserialize()
@@ -169,7 +169,7 @@ internal class AuthAdminClientImpl(
         val body = defaultJson.encodeToString(request)
         return client
             .post(
-                endpoint = "/auth/v1/admin/oauth/clients",
+                endpoint = AuthAdminPaths.ADMIN_OAUTH_CLIENTS,
                 body = body,
                 headers = adminHeaders,
             ).deserialize()
@@ -178,7 +178,7 @@ internal class AuthAdminClientImpl(
     override suspend fun getOAuthClient(clientId: String): SupabaseResult<OAuthClient> =
         client
             .get(
-                endpoint = "/auth/v1/admin/oauth/clients/$clientId",
+                endpoint = "${AuthAdminPaths.ADMIN_OAUTH_CLIENTS}/$clientId",
                 headers = adminHeaders,
             ).deserialize()
 
@@ -189,7 +189,7 @@ internal class AuthAdminClientImpl(
         val body = defaultJson.encodeToString(request)
         return client
             .put(
-                endpoint = "/auth/v1/admin/oauth/clients/$clientId",
+                endpoint = "${AuthAdminPaths.ADMIN_OAUTH_CLIENTS}/$clientId",
                 body = body,
                 headers = adminHeaders,
             ).deserialize()
@@ -198,14 +198,14 @@ internal class AuthAdminClientImpl(
     override suspend fun deleteOAuthClient(clientId: String): SupabaseResult<Unit> =
         client
             .delete(
-                endpoint = "/auth/v1/admin/oauth/clients/$clientId",
+                endpoint = "${AuthAdminPaths.ADMIN_OAUTH_CLIENTS}/$clientId",
                 headers = adminHeaders,
             ).map { }
 
     override suspend fun regenerateOAuthClientSecret(clientId: String): SupabaseResult<OAuthClient> =
         client
             .post(
-                endpoint = "/auth/v1/admin/oauth/clients/$clientId/regenerate_secret",
+                endpoint = "${AuthAdminPaths.ADMIN_OAUTH_CLIENTS}/$clientId/regenerate_secret",
                 headers = adminHeaders,
             ).deserialize()
 
@@ -216,7 +216,7 @@ internal class AuthAdminClientImpl(
             }
         return client
             .get(
-                endpoint = "/auth/v1/admin/custom-providers",
+                endpoint = AuthAdminPaths.ADMIN_CUSTOM_PROVIDERS,
                 queryParams = queryParams,
                 headers = adminHeaders,
             ).deserialize()
@@ -226,7 +226,7 @@ internal class AuthAdminClientImpl(
         val body = defaultJson.encodeToString(request)
         return client
             .post(
-                endpoint = "/auth/v1/admin/custom-providers",
+                endpoint = AuthAdminPaths.ADMIN_CUSTOM_PROVIDERS,
                 body = body,
                 headers = adminHeaders,
             ).deserialize()
@@ -235,7 +235,7 @@ internal class AuthAdminClientImpl(
     override suspend fun getCustomProvider(identifier: String): SupabaseResult<CustomProvider> =
         client
             .get(
-                endpoint = "/auth/v1/admin/custom-providers/$identifier",
+                endpoint = "${AuthAdminPaths.ADMIN_CUSTOM_PROVIDERS}/$identifier",
                 headers = adminHeaders,
             ).deserialize()
 
@@ -246,7 +246,7 @@ internal class AuthAdminClientImpl(
         val body = defaultJson.encodeToString(request)
         return client
             .put(
-                endpoint = "/auth/v1/admin/custom-providers/$identifier",
+                endpoint = "${AuthAdminPaths.ADMIN_CUSTOM_PROVIDERS}/$identifier",
                 body = body,
                 headers = adminHeaders,
             ).deserialize()
@@ -255,14 +255,14 @@ internal class AuthAdminClientImpl(
     override suspend fun deleteCustomProvider(identifier: String): SupabaseResult<Unit> =
         client
             .delete(
-                endpoint = "/auth/v1/admin/custom-providers/$identifier",
+                endpoint = "${AuthAdminPaths.ADMIN_CUSTOM_PROVIDERS}/$identifier",
                 headers = adminHeaders,
             ).map { }
 
     override suspend fun listPasskeys(userId: String): SupabaseResult<List<Passkey>> =
         client
             .get(
-                endpoint = "/auth/v1/admin/users/$userId/passkeys",
+                endpoint = "${AuthAdminPaths.ADMIN_USERS}/$userId/passkeys",
                 headers = adminHeaders,
             ).deserialize()
 
@@ -272,7 +272,7 @@ internal class AuthAdminClientImpl(
     ): SupabaseResult<Unit> =
         client
             .delete(
-                endpoint = "/auth/v1/admin/users/$userId/passkeys/$passkeyId",
+                endpoint = "${AuthAdminPaths.ADMIN_USERS}/$userId/passkeys/$passkeyId",
                 headers = adminHeaders,
             ).map { }
 

--- a/supabase-auth-admin/src/commonMain/kotlin/io/github/androidpoet/supabase/auth/admin/AuthAdminPaths.kt
+++ b/supabase-auth-admin/src/commonMain/kotlin/io/github/androidpoet/supabase/auth/admin/AuthAdminPaths.kt
@@ -1,0 +1,26 @@
+package io.github.androidpoet.supabase.auth.admin
+
+/**
+ * Centralized Supabase Auth admin endpoint paths.
+ *
+ * The API version lives in exactly one place and the route prefixes are
+ * composed from it, rather than repeating `/auth/v1/admin/...` literals
+ * throughout [AuthAdminClientImpl]. Dynamic segments (user id, client id, …) are
+ * appended at the call site, e.g. `"${AuthAdminPaths.ADMIN_USERS}/$userId"`.
+ *
+ * Mirrors `supabase-auth`'s internal `AuthPaths`; the two can't share a constant
+ * because module-internal symbols are not visible across module boundaries.
+ */
+internal object AuthAdminPaths {
+    const val API_VERSION: String = "v1"
+    const val BASE: String = "/auth/" + API_VERSION
+
+    const val INVITE: String = BASE + "/invite"
+    const val LOGOUT: String = BASE + "/logout"
+
+    const val ADMIN: String = BASE + "/admin"
+    const val ADMIN_USERS: String = ADMIN + "/users"
+    const val ADMIN_CUSTOM_PROVIDERS: String = ADMIN + "/custom-providers"
+    const val ADMIN_GENERATE_LINK: String = ADMIN + "/generate_link"
+    const val ADMIN_OAUTH_CLIENTS: String = ADMIN + "/oauth/clients"
+}

--- a/supabase-auth/src/commonMain/kotlin/io/github/androidpoet/supabase/auth/AuthClientImpl.kt
+++ b/supabase-auth/src/commonMain/kotlin/io/github/androidpoet/supabase/auth/AuthClientImpl.kt
@@ -65,7 +65,7 @@ internal class AuthClientImpl(
     ): SupabaseResult<Session> {
         require(email.isNotBlank()) { "email must not be blank" }
         val body = defaultJson.encodeToString(SignUpRequest(email = email, password = password, data = data))
-        return client.post("/auth/v1/signup", body = body).deserialize()
+        return client.post(AuthPaths.SIGNUP, body = body).deserialize()
     }
 
     override suspend fun signUpWithPhone(
@@ -75,7 +75,7 @@ internal class AuthClientImpl(
     ): SupabaseResult<Session> {
         require(phone.isNotBlank()) { "phone must not be blank" }
         val body = defaultJson.encodeToString(SignUpRequest(phone = phone, password = password, data = data))
-        return client.post("/auth/v1/signup", body = body).deserialize()
+        return client.post(AuthPaths.SIGNUP, body = body).deserialize()
     }
 
     override suspend fun signInWithEmail(
@@ -83,7 +83,7 @@ internal class AuthClientImpl(
         password: String,
     ): SupabaseResult<Session> {
         val body = defaultJson.encodeToString(SignInRequest(email = email, password = password))
-        return client.post("/auth/v1/token?grant_type=password", body = body).deserialize()
+        return client.post("${AuthPaths.TOKEN}?grant_type=password", body = body).deserialize()
     }
 
     override suspend fun signInAnonymously(
@@ -97,7 +97,7 @@ internal class AuthClientImpl(
                     captchaToken = captchaToken,
                 ),
             )
-        return client.post("/auth/v1/signup", body = body).deserialize()
+        return client.post(AuthPaths.SIGNUP, body = body).deserialize()
     }
 
     override suspend fun signInWithPhone(
@@ -105,7 +105,7 @@ internal class AuthClientImpl(
         password: String,
     ): SupabaseResult<Session> {
         val body = defaultJson.encodeToString(SignInRequest(phone = phone, password = password))
-        return client.post("/auth/v1/token?grant_type=password", body = body).deserialize()
+        return client.post("${AuthPaths.TOKEN}?grant_type=password", body = body).deserialize()
     }
 
     override suspend fun signInWithIdToken(
@@ -125,7 +125,7 @@ internal class AuthClientImpl(
                     captchaToken = captchaToken,
                 ),
             )
-        return client.post("/auth/v1/token?grant_type=id_token", body = body).deserialize()
+        return client.post("${AuthPaths.TOKEN}?grant_type=id_token", body = body).deserialize()
     }
 
     override suspend fun signInWithWeb3(
@@ -143,7 +143,7 @@ internal class AuthClientImpl(
                     captchaToken = captchaToken,
                 ),
             )
-        return client.post("/auth/v1/token?grant_type=web3", body = body).deserialize()
+        return client.post("${AuthPaths.TOKEN}?grant_type=web3", body = body).deserialize()
     }
 
     override suspend fun signInWithOtp(
@@ -163,7 +163,7 @@ internal class AuthClientImpl(
                     emailRedirectTo = emailRedirectTo,
                 ),
             )
-        return client.post("/auth/v1/otp", body = body).map { }
+        return client.post(AuthPaths.OTP, body = body).map { }
     }
 
     override suspend fun verifyOtp(
@@ -183,7 +183,7 @@ internal class AuthClientImpl(
                     captchaToken = captchaToken,
                 ),
             )
-        return client.post("/auth/v1/verify", body = body).deserialize()
+        return client.post(AuthPaths.VERIFY, body = body).deserialize()
     }
 
     override suspend fun verifyOtpWithTokenHash(
@@ -199,7 +199,7 @@ internal class AuthClientImpl(
                     captchaToken = captchaToken,
                 ),
             )
-        return client.post("/auth/v1/verify", body = body).deserialize()
+        return client.post(AuthPaths.VERIFY, body = body).deserialize()
     }
 
     override suspend fun verifyOtpWithResult(
@@ -219,7 +219,7 @@ internal class AuthClientImpl(
                     captchaToken = captchaToken,
                 ),
             )
-        return verifyOtpResultFromRawResponse(client.post("/auth/v1/verify", body = body))
+        return verifyOtpResultFromRawResponse(client.post(AuthPaths.VERIFY, body = body))
     }
 
     override suspend fun verifyOtpWithTokenHashWithResult(
@@ -235,7 +235,7 @@ internal class AuthClientImpl(
                     captchaToken = captchaToken,
                 ),
             )
-        return verifyOtpResultFromRawResponse(client.post("/auth/v1/verify", body = body))
+        return verifyOtpResultFromRawResponse(client.post(AuthPaths.VERIFY, body = body))
     }
 
     override suspend fun resendEmailOtp(
@@ -253,7 +253,7 @@ internal class AuthClientImpl(
                     redirectTo = redirectTo,
                 ),
             )
-        return client.post("/auth/v1/resend", body = body).map { }
+        return client.post(AuthPaths.RESEND, body = body).map { }
     }
 
     override suspend fun resendPhoneOtp(
@@ -269,7 +269,7 @@ internal class AuthClientImpl(
                     captchaToken = captchaToken,
                 ),
             )
-        return client.post("/auth/v1/resend", body = body).map { }
+        return client.post(AuthPaths.RESEND, body = body).map { }
     }
 
     override suspend fun resetPasswordForEmail(
@@ -287,7 +287,7 @@ internal class AuthClientImpl(
             )
         val endpoint =
             buildString {
-                append("/auth/v1/recover")
+                append(AuthPaths.RECOVER)
                 if (redirectTo != null) {
                     append("?redirect_to=")
                     append(urlEncode(redirectTo))
@@ -299,23 +299,23 @@ internal class AuthClientImpl(
     override suspend fun reauthenticate(accessToken: String): SupabaseResult<Unit> =
         client
             .get(
-                endpoint = "/auth/v1/reauthenticate",
+                endpoint = AuthPaths.REAUTHENTICATE,
                 headers = bearerHeaders(accessToken),
             ).map { }
 
     override suspend fun refreshToken(refreshToken: String): SupabaseResult<Session> {
         val body = defaultJson.encodeToString(RefreshTokenRequest(refreshToken = refreshToken))
-        return client.post("/auth/v1/token?grant_type=refresh_token", body = body).deserialize()
+        return client.post("${AuthPaths.TOKEN}?grant_type=refresh_token", body = body).deserialize()
     }
 
     override suspend fun getUser(accessToken: String): SupabaseResult<User> =
         client
             .get(
-                endpoint = "/auth/v1/user",
+                endpoint = AuthPaths.USER,
                 headers = bearerHeaders(accessToken),
             ).deserialize()
 
-    override suspend fun fetchJwks(): SupabaseResult<String> = client.get(endpoint = "/auth/v1/.well-known/jwks.json")
+    override suspend fun fetchJwks(): SupabaseResult<String> = client.get(endpoint = AuthPaths.JWKS)
 
     override suspend fun getUserIdentities(accessToken: String): SupabaseResult<List<UserIdentity>> =
         when (val result = getUser(accessToken = accessToken)) {
@@ -330,7 +330,7 @@ internal class AuthClientImpl(
         val body = defaultJson.encodeToString(updates)
         return client
             .patch(
-                endpoint = "/auth/v1/user",
+                endpoint = AuthPaths.USER,
                 body = body,
                 headers = bearerHeaders(accessToken),
             ).deserialize()
@@ -345,7 +345,7 @@ internal class AuthClientImpl(
     ): SupabaseResult<Unit> =
         client
             .post(
-                endpoint = "/auth/v1/logout?scope=${scope.name.lowercase()}",
+                endpoint = "${AuthPaths.LOGOUT}?scope=${scope.name.lowercase()}",
                 headers = bearerHeaders(accessToken),
             ).map { }
 
@@ -358,7 +358,7 @@ internal class AuthClientImpl(
     ): SupabaseResult<LinkIdentityResponse> {
         val endpoint =
             buildString {
-                append("/auth/v1/user/identities/authorize?provider=")
+                append("${AuthPaths.USER_IDENTITIES_AUTHORIZE}?provider=")
                 append(provider.value)
                 if (redirectTo != null) {
                     append("&redirect_to=")
@@ -397,7 +397,7 @@ internal class AuthClientImpl(
             )
         return client
             .post(
-                endpoint = "/auth/v1/token?grant_type=id_token",
+                endpoint = "${AuthPaths.TOKEN}?grant_type=id_token",
                 body = body,
                 headers = bearerHeaders(accessToken),
             ).deserialize()
@@ -409,7 +409,7 @@ internal class AuthClientImpl(
     ): SupabaseResult<Unit> =
         client
             .delete(
-                endpoint = "/auth/v1/user/identities/$identityId",
+                endpoint = "${AuthPaths.USER_IDENTITIES}/$identityId",
                 headers = bearerHeaders(accessToken),
             ).map { }
 
@@ -433,7 +433,7 @@ internal class AuthClientImpl(
             )
         return client
             .post(
-                endpoint = "/auth/v1/sso",
+                endpoint = AuthPaths.SSO,
                 body = body,
                 headers = accessToken?.let(::bearerHeaders).orEmpty(),
             ).deserialize()
@@ -449,7 +449,7 @@ internal class AuthClientImpl(
     ): String =
         buildString {
             append(client.projectUrl)
-            append("/auth/v1/authorize?provider=")
+            append("${AuthPaths.AUTHORIZE}?provider=")
             append(provider.value)
             if (redirectTo != null) {
                 append("&redirect_to=")
@@ -533,7 +533,7 @@ internal class AuthClientImpl(
             defaultJson.encodeToString(
                 ExchangeCodeRequest(authCode = authCode, codeVerifier = codeVerifier),
             )
-        return client.post("/auth/v1/token?grant_type=pkce", body = body).deserialize()
+        return client.post("${AuthPaths.TOKEN}?grant_type=pkce", body = body).deserialize()
     }
 
     override suspend fun mfaEnroll(
@@ -554,7 +554,7 @@ internal class AuthClientImpl(
             )
         return client
             .post(
-                endpoint = "/auth/v1/factors",
+                endpoint = AuthPaths.FACTORS,
                 body = body,
                 headers = bearerHeaders(accessToken),
             ).deserialize()
@@ -566,7 +566,7 @@ internal class AuthClientImpl(
     ): SupabaseResult<MfaChallengeResponse> =
         client
             .post(
-                endpoint = "/auth/v1/factors/$factorId/challenge",
+                endpoint = "${AuthPaths.FACTORS}/$factorId/challenge",
                 headers = bearerHeaders(accessToken),
             ).deserialize()
 
@@ -586,7 +586,7 @@ internal class AuthClientImpl(
             )
         return client
             .post(
-                endpoint = "/auth/v1/factors/$factorId/verify",
+                endpoint = "${AuthPaths.FACTORS}/$factorId/verify",
                 body = body,
                 headers = bearerHeaders(accessToken),
             ).deserialize()
@@ -598,7 +598,7 @@ internal class AuthClientImpl(
     ): SupabaseResult<MfaUnenrollResponse> =
         client
             .delete(
-                endpoint = "/auth/v1/factors/$factorId",
+                endpoint = "${AuthPaths.FACTORS}/$factorId",
                 headers = bearerHeaders(accessToken),
             ).deserialize()
 
@@ -608,7 +608,7 @@ internal class AuthClientImpl(
         val userResult: SupabaseResult<User> =
             client
                 .get(
-                    endpoint = "/auth/v1/user",
+                    endpoint = AuthPaths.USER,
                     headers = bearerHeaders(accessToken),
                 ).deserialize()
         return when (userResult) {
@@ -633,7 +633,7 @@ internal class AuthClientImpl(
         val userResult: SupabaseResult<User> =
             client
                 .get(
-                    endpoint = "/auth/v1/user",
+                    endpoint = AuthPaths.USER,
                     headers = bearerHeaders(accessToken),
                 ).deserialize()
         return when (userResult) {
@@ -657,7 +657,7 @@ internal class AuthClientImpl(
     ): SupabaseResult<PasskeyRegistrationOptionsResponse> =
         client
             .post(
-                endpoint = "/auth/v1/passkeys/registration/options",
+                endpoint = AuthPaths.PASSKEYS_REG_OPTIONS,
                 body = "{}",
                 headers = bearerHeaders(accessToken),
             ).deserialize()
@@ -673,7 +673,7 @@ internal class AuthClientImpl(
             )
         return client
             .post(
-                endpoint = "/auth/v1/passkeys/registration/verify",
+                endpoint = AuthPaths.PASSKEYS_REG_VERIFY,
                 body = body,
                 headers = bearerHeaders(accessToken),
             ).deserialize()
@@ -685,7 +685,7 @@ internal class AuthClientImpl(
         val body = defaultJson.encodeToString(PasskeyAuthenticationOptionsRequest(captchaToken = captchaToken))
         return client
             .post(
-                endpoint = "/auth/v1/passkeys/authentication/options",
+                endpoint = AuthPaths.PASSKEYS_AUTH_OPTIONS,
                 body = body,
             ).deserialize()
     }
@@ -700,7 +700,7 @@ internal class AuthClientImpl(
             )
         return client
             .post(
-                endpoint = "/auth/v1/passkeys/authentication/verify",
+                endpoint = AuthPaths.PASSKEYS_AUTH_VERIFY,
                 body = body,
             ).deserialize()
     }
@@ -710,7 +710,7 @@ internal class AuthClientImpl(
     ): SupabaseResult<List<Passkey>> =
         client
             .get(
-                endpoint = "/auth/v1/passkeys",
+                endpoint = AuthPaths.PASSKEYS,
                 headers = bearerHeaders(accessToken),
             ).deserialize()
 
@@ -722,7 +722,7 @@ internal class AuthClientImpl(
         val body = defaultJson.encodeToString(PasskeyUpdateRequest(friendlyName = friendlyName))
         return client
             .patch(
-                endpoint = "/auth/v1/passkeys/$passkeyId",
+                endpoint = "${AuthPaths.PASSKEYS}/$passkeyId",
                 body = body,
                 headers = bearerHeaders(accessToken),
             ).deserialize()
@@ -734,7 +734,7 @@ internal class AuthClientImpl(
     ): SupabaseResult<Unit> =
         client
             .delete(
-                endpoint = "/auth/v1/passkeys/$passkeyId",
+                endpoint = "${AuthPaths.PASSKEYS}/$passkeyId",
                 headers = bearerHeaders(accessToken),
             ).map { }
 
@@ -744,7 +744,7 @@ internal class AuthClientImpl(
     ): SupabaseResult<OAuthAuthorizationDetails> =
         client
             .get(
-                endpoint = "/auth/v1/oauth/authorizations/$authorizationId",
+                endpoint = "${AuthPaths.OAUTH_AUTHORIZATIONS}/$authorizationId",
                 headers = bearerHeaders(accessToken),
             ).deserialize()
 
@@ -765,7 +765,7 @@ internal class AuthClientImpl(
     ): SupabaseResult<List<OAuthGrant>> =
         client
             .get(
-                endpoint = "/auth/v1/user/oauth/grants",
+                endpoint = AuthPaths.USER_OAUTH_GRANTS,
                 headers = bearerHeaders(accessToken),
             ).deserialize()
 
@@ -775,7 +775,7 @@ internal class AuthClientImpl(
     ): SupabaseResult<Unit> =
         client
             .delete(
-                endpoint = "/auth/v1/user/oauth/grants?client_id=${urlEncode(clientId)}",
+                endpoint = "${AuthPaths.USER_OAUTH_GRANTS}?client_id=${urlEncode(clientId)}",
                 headers = bearerHeaders(accessToken),
             ).map { }
 
@@ -787,7 +787,7 @@ internal class AuthClientImpl(
         val body = defaultJson.encodeToString(OAuthConsentRequest(action = action))
         return client
             .post(
-                endpoint = "/auth/v1/oauth/authorizations/$authorizationId/consent",
+                endpoint = "${AuthPaths.OAUTH_AUTHORIZATIONS}/$authorizationId/consent",
                 body = body,
                 headers = bearerHeaders(accessToken),
             ).deserialize()

--- a/supabase-auth/src/commonMain/kotlin/io/github/androidpoet/supabase/auth/AuthPaths.kt
+++ b/supabase-auth/src/commonMain/kotlin/io/github/androidpoet/supabase/auth/AuthPaths.kt
@@ -1,0 +1,42 @@
+package io.github.androidpoet.supabase.auth
+
+/**
+ * Centralized Supabase Auth (GoTrue) endpoint paths.
+ *
+ * The API version lives in exactly one place and the route prefixes are
+ * composed from it, rather than repeating `/auth/v1/...` literals throughout
+ * [AuthClientImpl]. Constants are static path prefixes; dynamic segments (factor
+ * id, identity id, …) and query strings (`?grant_type=…`, `?provider=…`) are
+ * appended at the call site, e.g. `"${AuthPaths.FACTORS}/$factorId/verify"`.
+ */
+internal object AuthPaths {
+    const val API_VERSION: String = "v1"
+    const val BASE: String = "/auth/" + API_VERSION
+
+    const val SIGNUP: String = BASE + "/signup"
+    const val TOKEN: String = BASE + "/token"
+    const val OTP: String = BASE + "/otp"
+    const val VERIFY: String = BASE + "/verify"
+    const val RESEND: String = BASE + "/resend"
+    const val RECOVER: String = BASE + "/recover"
+    const val REAUTHENTICATE: String = BASE + "/reauthenticate"
+    const val LOGOUT: String = BASE + "/logout"
+    const val SSO: String = BASE + "/sso"
+    const val AUTHORIZE: String = BASE + "/authorize"
+    const val JWKS: String = BASE + "/.well-known/jwks.json"
+
+    const val USER: String = BASE + "/user"
+    const val USER_IDENTITIES: String = USER + "/identities"
+    const val USER_IDENTITIES_AUTHORIZE: String = USER_IDENTITIES + "/authorize"
+    const val USER_OAUTH_GRANTS: String = USER + "/oauth/grants"
+
+    const val OAUTH_AUTHORIZATIONS: String = BASE + "/oauth/authorizations"
+
+    const val FACTORS: String = BASE + "/factors"
+
+    const val PASSKEYS: String = BASE + "/passkeys"
+    const val PASSKEYS_AUTH_OPTIONS: String = PASSKEYS + "/authentication/options"
+    const val PASSKEYS_AUTH_VERIFY: String = PASSKEYS + "/authentication/verify"
+    const val PASSKEYS_REG_OPTIONS: String = PASSKEYS + "/registration/options"
+    const val PASSKEYS_REG_VERIFY: String = PASSKEYS + "/registration/verify"
+}

--- a/supabase-database/src/commonMain/kotlin/io/github/androidpoet/supabase/database/DatabaseClientImpl.kt
+++ b/supabase-database/src/commonMain/kotlin/io/github/androidpoet/supabase/database/DatabaseClientImpl.kt
@@ -44,7 +44,7 @@ internal class DatabaseClientImpl(
         if (head) {
             val result =
                 client.get(
-                    endpoint = "/rest/v1/$safeTable",
+                    endpoint = "${DatabasePaths.BASE}/$safeTable",
                     queryParams = queryParams,
                     headers = headersWithSchema + ("Accept" to acceptHeader(single, csv, stripNulls, explain, geojson)),
                 )
@@ -54,7 +54,7 @@ internal class DatabaseClientImpl(
             }
         }
         return client.get(
-            endpoint = "/rest/v1/$safeTable",
+            endpoint = "${DatabasePaths.BASE}/$safeTable",
             queryParams = queryParams,
             headers = headersWithSchema + ("Accept" to acceptHeader(single, csv, stripNulls, explain, geojson)),
         )
@@ -78,7 +78,7 @@ internal class DatabaseClientImpl(
         val safeTable = validatePathSegment(table, "table")
         val safeSchema = schema?.let { validatePathSegment(it, "schema") }
         val endpoint =
-            buildEndpoint("/rest/v1/$safeTable") {
+            buildEndpoint("${DatabasePaths.BASE}/$safeTable") {
                 if (onConflict != null) add("on_conflict" to onConflict)
                 if (!columns.isNullOrEmpty()) add("columns" to columns.joinToString(","))
             }
@@ -118,7 +118,7 @@ internal class DatabaseClientImpl(
         val safeTable = validatePathSegment(table, "table")
         val safeSchema = schema?.let { validatePathSegment(it, "schema") }
         val filterParams = FilterBuilder().apply(filters).build()
-        val endpoint = buildEndpoint("/rest/v1/$safeTable", filterParams)
+        val endpoint = buildEndpoint("${DatabasePaths.BASE}/$safeTable", filterParams)
         val requestHeaders =
             headers +
                 buildPreferHeader {
@@ -156,7 +156,7 @@ internal class DatabaseClientImpl(
         val safeTable = validatePathSegment(table, "table")
         val safeSchema = schema?.let { validatePathSegment(it, "schema") }
         val filterParams = FilterBuilder().apply(filters).build()
-        val endpoint = buildEndpoint("/rest/v1/$safeTable", filterParams)
+        val endpoint = buildEndpoint("${DatabasePaths.BASE}/$safeTable", filterParams)
         val requestHeaders =
             headers +
                 buildPreferHeader {
@@ -208,7 +208,7 @@ internal class DatabaseClientImpl(
         if (head) {
             val result =
                 client.post(
-                    endpoint = "/rest/v1/rpc/$safeFunction",
+                    endpoint = "${DatabasePaths.RPC}/$safeFunction",
                     body = params,
                     headers =
                         addSchemaHeaders(requestHeaders, safeSchema, isReadRequest = true) +
@@ -220,7 +220,7 @@ internal class DatabaseClientImpl(
             }
         }
         return client.post(
-            endpoint = "/rest/v1/rpc/$safeFunction",
+            endpoint = "${DatabasePaths.RPC}/$safeFunction",
             body = params,
             headers =
                 addSchemaHeaders(requestHeaders, safeSchema, isReadRequest = false) +
@@ -252,7 +252,7 @@ internal class DatabaseClientImpl(
                     count?.let { add("count=${it.headerValue}") }
                 } + retryHeader(retry)
         val readHeaders = addSchemaHeaders(requestHeaders, safeSchema, isReadRequest = true)
-        val endpoint = buildEndpoint("/rest/v1/rpc/$safeFunction", queryParams)
+        val endpoint = buildEndpoint("${DatabasePaths.RPC}/$safeFunction", queryParams)
         if (head) {
             val result =
                 client.get(

--- a/supabase-database/src/commonMain/kotlin/io/github/androidpoet/supabase/database/DatabasePaths.kt
+++ b/supabase-database/src/commonMain/kotlin/io/github/androidpoet/supabase/database/DatabasePaths.kt
@@ -1,0 +1,15 @@
+package io.github.androidpoet.supabase.database
+
+/**
+ * Centralized Supabase PostgREST (database) endpoint paths.
+ *
+ * The API version lives in exactly one place and the route prefixes are
+ * composed from it, rather than repeating `/rest/v1/...` literals throughout
+ * [DatabaseClientImpl]. The table name or RPC function is appended at the call
+ * site, e.g. `"${DatabasePaths.BASE}/$table"` or `"${DatabasePaths.RPC}/$fn"`.
+ */
+internal object DatabasePaths {
+    const val API_VERSION: String = "v1"
+    const val BASE: String = "/rest/" + API_VERSION
+    const val RPC: String = BASE + "/rpc"
+}

--- a/supabase-functions/src/commonMain/kotlin/io/github/androidpoet/supabase/functions/FunctionsClientImpl.kt
+++ b/supabase-functions/src/commonMain/kotlin/io/github/androidpoet/supabase/functions/FunctionsClientImpl.kt
@@ -19,7 +19,7 @@ internal class FunctionsClientImpl(
     ): SupabaseResult<String> {
         val merged = buildHeaders(headers, region)
         return client.post(
-            endpoint = "/functions/v1/$functionName",
+            endpoint = "${FunctionsPaths.BASE}/$functionName",
             body = body,
             headers = merged,
         )
@@ -36,7 +36,7 @@ internal class FunctionsClientImpl(
         // postRaw already prepends projectUrl (see SupabaseClientImpl.postRaw);
         // pass a relative path or the project URL is duplicated.
         return client.postRaw(
-            url = "/functions/v1/$functionName",
+            url = "${FunctionsPaths.BASE}/$functionName",
             body = body,
             contentType = contentType,
             headers = merged,

--- a/supabase-functions/src/commonMain/kotlin/io/github/androidpoet/supabase/functions/FunctionsPaths.kt
+++ b/supabase-functions/src/commonMain/kotlin/io/github/androidpoet/supabase/functions/FunctionsPaths.kt
@@ -1,0 +1,14 @@
+package io.github.androidpoet.supabase.functions
+
+/**
+ * Centralized Supabase Edge Functions endpoint paths.
+ *
+ * The API version lives in exactly one place and the route prefix is composed
+ * from it, rather than repeating `/functions/v1/...` literals throughout
+ * [FunctionsClientImpl]. The function name is appended at the call site, e.g.
+ * `"${FunctionsPaths.BASE}/$functionName"`.
+ */
+internal object FunctionsPaths {
+    const val API_VERSION: String = "v1"
+    const val BASE: String = "/functions/" + API_VERSION
+}


### PR DESCRIPTION
## Centralize endpoint paths in auth / auth-admin / database / functions

Extends the `StoragePaths` pattern (#24) to the remaining modules so the API version (`v1`) and route prefixes live in exactly one place per module instead of being repeated across ~77 raw string literals.

- **`AuthPaths`** (supabase-auth) — `/auth/v1` base + all GoTrue routes (signup, token, otp, verify, resend, recover, reauthenticate, logout, sso, authorize, jwks, user/identities, oauth grants, factors, passkeys). 44 literals migrated.
- **`AuthAdminPaths`** (supabase-auth-admin) — `/auth/v1/admin` base + users/custom-providers/generate_link/oauth clients, plus invite/logout. 23 literals migrated. Separate object because module-internal symbols aren't visible across module boundaries.
- **`DatabasePaths`** (supabase-database) — `/rest/v1` base + `/rpc`. 8 literals migrated.
- **`FunctionsPaths`** (supabase-functions) — `/functions/v1` base. 2 literals migrated.

All objects are `internal`; dynamic segments and query strings stay at the call site. **No public API change** — `apiCheck` passes without a dump. Endpoint correctness verified by the existing per-module tests (they assert exact request paths); `jvmTest`, `detekt`, `spotlessCheck`, `apiCheck` green locally.

After this + #24, every module's endpoint URLs are centralized and the `v1` version is defined once per module.
