### PR TITLE
chore: release 0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,48 @@
 # Changelog
 
-## 0.3.5
+## 0.4.0
+
+### Added
+
+- **Storage:** resumable (TUS) uploads via `createResumableUpload(...)`. The
+  returned `ResumableUpload` exposes `uploadUrl`, a `progress: StateFlow`, and a
+  cancellable `await()`; cancel to pause and resume later (even across app
+  restarts) by persisting `uploadUrl`. Uploads in 6 MiB chunks with server-side
+  offset tracking.
+- **Client:** `SupabaseClient.rawRequest(method, url, body, contentType, headers)`
+  for issuing raw, non-JSON requests through the configured client (powers the
+  resumable upload protocol).
+- **Errors:** network-aware error handling — `SupabaseError.httpStatus` and
+  `retryAfterSeconds`, a `SupabaseErrorCategory.Network` category,
+  `SupabaseErrorCategory.isRetryable`, `SupabaseError.isNetworkError()`, and an
+  `onNetworkError { }` result handler. Transport now classifies timeouts and
+  connection failures into `SupabaseErrorCodes.Client` codes so categorization
+  works offline.
+- **Result operators:** `validate(predicate, lazyError)` (turn a failing
+  `Success` into a `Failure`), `flatMapError`/`flatMapErrorSuspend` (failure-side
+  recovery chains), and `zip(other) { a, b -> … }` (combine two results).
+- **Database:** GeoJSON responses via `selectGeoJson(...)` / the `geojson` flag
+  on `select` (`Accept: application/geo+json`).
+- **Realtime:** `RealtimeSubscription.presenceState()` for the current
+  cumulative presence snapshot.
+- `SupabaseClient` now implements `AutoCloseable`.
+- `KeyValueStore` + `KeyValueSessionStorage` for easy persistent, serialized
+  session storage backed by the platform keystore.
+- Input validation on `Supabase.create` (non-blank api key, http(s) project URL).
+- Tooling: detekt, binary-compatibility-validator (JVM + Android + native klib
+  ABI dumps), Kover coverage, Dokka API docs, a multiplatform CI matrix,
+  Dependabot, and CONTRIBUTING/SECURITY/CODE_OF_CONDUCT.
+- Internal: shared `urlEncode` in `supabase-core` (deduplicated from auth /
+  auth-admin); Functions now uses the live session token (falls back to the
+  client's current token instead of only a pinned one).
+
+### Changed
+
+- Internal: every module's endpoint URLs are now centralized — `StoragePaths`,
+  `AuthPaths`, `AuthAdminPaths`, `DatabasePaths`, and `FunctionsPaths` factor the
+  `v1` API version and route prefixes into one place per module instead of
+  repeating `/storage/v1/...`, `/auth/v1/...`, `/rest/v1/...`, and
+  `/functions/v1/...` string literals across the codebase. No public API change.
 
 ### Security
 
@@ -40,19 +82,6 @@
   callbacks now receive the full cumulative state on diffs.
 - Cross-thread visibility hardening for the access token, session refresh state,
   and realtime connection fields (`@Volatile`).
-
-### Added
-
-- `SupabaseClient` now implements `AutoCloseable`.
-- `KeyValueStore` + `KeyValueSessionStorage` for easy persistent, serialized
-  session storage backed by the platform keystore.
-- Input validation on `Supabase.create` (non-blank api key, http(s) project URL).
-- Tooling: detekt, binary-compatibility-validator (JVM + Android + native klib
-  ABI dumps), Kover coverage, Dokka API docs, a multiplatform CI matrix,
-  Dependabot, and CONTRIBUTING/SECURITY/CODE_OF_CONDUCT.
-- Internal: shared `urlEncode` in `supabase-core` (deduplicated from auth /
-  auth-admin); Functions now uses the live session token (falls back to the
-  client's current token instead of only a pinned one).
 
 ## 0.3.2
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Add the dependencies you need to your `build.gradle.kts`:
 
 ```kotlin
 [versions]
-supabase-kmp = "0.3.5"
+supabase-kmp = "0.4.0"
 
 [libraries]
 supabase-core = { module = "io.github.androidpoet:supabase-core", version.ref = "supabase-kmp" }

--- a/buildSrc/src/main/kotlin/io/github/androidpoet/supabase/Configuration.kt
+++ b/buildSrc/src/main/kotlin/io/github/androidpoet/supabase/Configuration.kt
@@ -2,7 +2,7 @@ package io.github.androidpoet.supabase
 
 object Configuration {
     const val GROUP = "io.github.androidpoet"
-    const val VERSION = "0.3.5"
+    const val VERSION = "0.4.0"
     const val COMPILE_SDK = 35
     const val MIN_SDK = 21
 }


### PR DESCRIPTION
## Release 0.4.0

Version bump + changelog for the 0.4.0 feature release. Folds the previously-unreleased 0.3.5 work into 0.4.0 (last released tag was v0.4.0's predecessor v0.3.4).

Highlights since v0.3.4:
- Network-aware error layer (`httpStatus`/`retryAfterSeconds`, `Network` category, `isRetryable`, `onNetworkError`, `rawRequest`) — #22
- Resumable (TUS) uploads — #24
- Result operators `validate` / `flatMapError` / `zip` — #25
- Centralized endpoint paths across all modules — #24/#26
- GeoJSON select + `presenceState()`

- `Configuration.VERSION` → `0.4.0`
- `README.md` version-catalog snippet → `0.4.0`
- `CHANGELOG.md` 0.4.0 section

`apiCheck`, `detekt`, `jvmTest`, `spotlessCheck` green on the merged main + this branch.

Merging this, then publishing GitHub Release `v0.4.0` triggers `publishAndReleaseToMavenCentral`.
