### PR TITLE
test: E2E in CI + coverage gate + serialization round-trip tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,6 +38,9 @@ jobs:
       - name: JVM tests + coverage
         run: ./gradlew jvmTest koverXmlReport
 
+      - name: Coverage gate (koverVerify)
+        run: ./gradlew koverVerify
+
       - name: Upload coverage report
         if: always()
         uses: actions/upload-artifact@v4

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,44 @@
+name: E2E
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    # Nightly run so drift against a real Supabase stack is caught even when
+    # no PR touches the affected code.
+    - cron: "0 4 * * *"
+  workflow_dispatch:
+
+concurrency:
+  group: e2e-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  e2e:
+    # ubuntu ships Docker, which the local Supabase stack needs.
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-java@v4
+        with:
+          distribution: zulu
+          java-version: 17
+
+      - uses: gradle/actions/setup-gradle@v4
+
+      - name: Install Supabase CLI
+        uses: supabase/setup-cli@v1
+        with:
+          version: latest
+
+      # supabaseE2eTest resets the local DB (applies migrations + seed, starting
+      # the stack), runs :e2e-tests:e2eTest against it, then stops the stack.
+      - name: Run E2E tests against local Supabase
+        run: ./gradlew supabaseE2eTest
+
+      - name: Stop Supabase stack
+        if: always()
+        run: supabase stop --no-backup || true

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -129,6 +129,19 @@ dependencies {
     publishedModules.forEach { kover(project(":$it")) }
 }
 
+// Coverage gate: fail the build if aggregate line coverage regresses below the
+// floor. Current is ~71%; the floor sits a little below to leave headroom for
+// honest refactors without letting coverage rot. Run via `./gradlew koverVerify`.
+kover {
+    reports {
+        verify {
+            rule("Aggregate line coverage") {
+                minBound(65)
+            }
+        }
+    }
+}
+
 val supabaseStart by tasks.registering(Exec::class) {
     group = "verification"
     description = "Starts the local Supabase Docker stack."

--- a/e2e-tests/build.gradle.kts
+++ b/e2e-tests/build.gradle.kts
@@ -10,6 +10,7 @@ dependencies {
     testImplementation(project(":supabase-client"))
     testImplementation(project(":supabase-core"))
     testImplementation(project(":supabase-database"))
+    testImplementation(project(":supabase-auth"))
     testImplementation(libs.kotlin.test)
     testImplementation(libs.kotlinx.coroutines.core)
     testImplementation(libs.kotlinx.coroutines.test)

--- a/e2e-tests/src/test/kotlin/io/github/androidpoet/supabase/e2e/AuthE2eTest.kt
+++ b/e2e-tests/src/test/kotlin/io/github/androidpoet/supabase/e2e/AuthE2eTest.kt
@@ -1,0 +1,41 @@
+package io.github.androidpoet.supabase.e2e
+
+import io.github.androidpoet.supabase.auth.createAuthClient
+import io.github.androidpoet.supabase.client.Supabase
+import kotlinx.coroutines.test.runTest
+import java.util.UUID
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class AuthE2eTest {
+    @Test
+    fun test_auth_signUpThenSignIn_returnsSessionForSameUser() =
+        runTest {
+            val config = localSupabaseConfig()
+            val client =
+                Supabase.create(
+                    projectUrl = config.apiUrl,
+                    apiKey = config.anonKey,
+                )
+            val auth = createAuthClient(client)
+            val email = "e2e-${UUID.randomUUID()}@example.com"
+            val password = "Sup4base!E2e-${UUID.randomUUID()}"
+
+            val signUp =
+                auth
+                    .signUpWithEmail(email = email, password = password)
+                    .getOrThrow()
+            val signIn =
+                auth
+                    .signInWithEmail(email = email, password = password)
+                    .getOrThrow()
+
+            client.close()
+
+            assertTrue(signUp.accessToken.isNotBlank(), "sign-up returned a blank access token")
+            assertTrue(signIn.accessToken.isNotBlank(), "sign-in returned a blank access token")
+            assertEquals(email, signUp.user.email)
+            assertEquals(signUp.user.id, signIn.user.id, "sign-in resolved a different user")
+        }
+}

--- a/e2e-tests/src/test/kotlin/io/github/androidpoet/supabase/e2e/AuthE2eTest.kt
+++ b/e2e-tests/src/test/kotlin/io/github/androidpoet/supabase/e2e/AuthE2eTest.kt
@@ -25,11 +25,11 @@ class AuthE2eTest {
             val signUp =
                 auth
                     .signUpWithEmail(email = email, password = password)
-                    .getOrThrow()
+                    .unwrap("signUp")
             val signIn =
                 auth
                     .signInWithEmail(email = email, password = password)
-                    .getOrThrow()
+                    .unwrap("signIn")
 
             client.close()
 

--- a/e2e-tests/src/test/kotlin/io/github/androidpoet/supabase/e2e/DatabaseE2eTest.kt
+++ b/e2e-tests/src/test/kotlin/io/github/androidpoet/supabase/e2e/DatabaseE2eTest.kt
@@ -36,14 +36,14 @@ class DatabaseE2eTest {
                     .insert(
                         table = E2E_MESSAGES_TABLE,
                         body = payload,
-                    ).getOrThrow()
+                    ).unwrap("insert")
             val selected =
                 database
                     .select(
                         table = E2E_MESSAGES_TABLE,
                     ) {
                         eq("body", messageBody)
-                    }.getOrThrow()
+                    }.unwrap("select")
 
             client.close()
             assertTrue(inserted.contains(messageBody), inserted)

--- a/e2e-tests/src/test/kotlin/io/github/androidpoet/supabase/e2e/DatabaseE2eTest.kt
+++ b/e2e-tests/src/test/kotlin/io/github/androidpoet/supabase/e2e/DatabaseE2eTest.kt
@@ -9,7 +9,6 @@ import kotlinx.serialization.json.jsonArray
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
 import kotlinx.serialization.json.put
-import java.io.File
 import java.util.UUID
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -62,43 +61,3 @@ class DatabaseE2eTest {
 }
 
 private const val E2E_MESSAGES_TABLE = "e2e_messages"
-
-private data class LocalSupabaseConfig(
-    val apiUrl: String,
-    val anonKey: String,
-)
-
-private fun localSupabaseConfig(): LocalSupabaseConfig {
-    val envUrl = System.getenv("SUPABASE_E2E_URL")
-    val envAnonKey = System.getenv("SUPABASE_E2E_ANON_KEY")
-    if (!envUrl.isNullOrBlank() && !envAnonKey.isNullOrBlank()) {
-        return LocalSupabaseConfig(apiUrl = envUrl, anonKey = envAnonKey)
-    }
-
-    val status =
-        ProcessBuilder("supabase", "status", "-o", "env")
-            .directory(File(System.getProperty("user.dir")))
-            .redirectErrorStream(true)
-            .start()
-    val output = status.inputStream.bufferedReader().readText()
-    val exitCode = status.waitFor()
-    check(exitCode == 0) {
-        "Unable to read local Supabase status. Run `supabase start` first.\n$output"
-    }
-    val values =
-        output
-            .lineSequence()
-            .mapNotNull { line ->
-                val parts = line.split("=", limit = 2)
-                if (parts.size == 2) parts[0] to parts[1].trim('"') else null
-            }.toMap()
-    val apiUrl =
-        values["API_URL"]
-            ?: values["SUPABASE_URL"]
-            ?: error("Supabase status did not include API_URL.\n$output")
-    val anonKey =
-        values["ANON_KEY"]
-            ?: values["SUPABASE_ANON_KEY"]
-            ?: error("Supabase status did not include ANON_KEY.\n$output")
-    return LocalSupabaseConfig(apiUrl = apiUrl, anonKey = anonKey)
-}

--- a/e2e-tests/src/test/kotlin/io/github/androidpoet/supabase/e2e/LocalSupabaseConfig.kt
+++ b/e2e-tests/src/test/kotlin/io/github/androidpoet/supabase/e2e/LocalSupabaseConfig.kt
@@ -1,11 +1,27 @@
 package io.github.androidpoet.supabase.e2e
 
+import io.github.androidpoet.supabase.core.result.SupabaseResult
 import java.io.File
 
 internal data class LocalSupabaseConfig(
     val apiUrl: String,
     val anonKey: String,
 )
+
+/**
+ * Returns the success value or fails the test with the full error detail
+ * (message, code, HTTP status). Clearer than [SupabaseResult.getOrThrow] when an
+ * E2E call fails in CI, where the bare exception message is easy to lose.
+ */
+internal fun <T> SupabaseResult<T>.unwrap(label: String): T =
+    when (this) {
+        is SupabaseResult.Success -> value
+        is SupabaseResult.Failure ->
+            error(
+                "$label failed: message='${error.message}' code='${error.code}' " +
+                    "httpStatus=${error.httpStatus} details='${error.details}'",
+            )
+    }
 
 /**
  * Resolves the local Supabase connection details for E2E tests.

--- a/e2e-tests/src/test/kotlin/io/github/androidpoet/supabase/e2e/LocalSupabaseConfig.kt
+++ b/e2e-tests/src/test/kotlin/io/github/androidpoet/supabase/e2e/LocalSupabaseConfig.kt
@@ -1,0 +1,50 @@
+package io.github.androidpoet.supabase.e2e
+
+import java.io.File
+
+internal data class LocalSupabaseConfig(
+    val apiUrl: String,
+    val anonKey: String,
+)
+
+/**
+ * Resolves the local Supabase connection details for E2E tests.
+ *
+ * Prefers the `SUPABASE_E2E_URL` / `SUPABASE_E2E_ANON_KEY` environment variables
+ * (set by CI); otherwise shells out to `supabase status -o env` and requires a
+ * locally running stack (`supabase start`).
+ */
+internal fun localSupabaseConfig(): LocalSupabaseConfig {
+    val envUrl = System.getenv("SUPABASE_E2E_URL")
+    val envAnonKey = System.getenv("SUPABASE_E2E_ANON_KEY")
+    if (!envUrl.isNullOrBlank() && !envAnonKey.isNullOrBlank()) {
+        return LocalSupabaseConfig(apiUrl = envUrl, anonKey = envAnonKey)
+    }
+
+    val status =
+        ProcessBuilder("supabase", "status", "-o", "env")
+            .directory(File(System.getProperty("user.dir")))
+            .redirectErrorStream(true)
+            .start()
+    val output = status.inputStream.bufferedReader().readText()
+    val exitCode = status.waitFor()
+    check(exitCode == 0) {
+        "Unable to read local Supabase status. Run `supabase start` first.\n$output"
+    }
+    val values =
+        output
+            .lineSequence()
+            .mapNotNull { line ->
+                val parts = line.split("=", limit = 2)
+                if (parts.size == 2) parts[0] to parts[1].trim('"') else null
+            }.toMap()
+    val apiUrl =
+        values["API_URL"]
+            ?: values["SUPABASE_URL"]
+            ?: error("Supabase status did not include API_URL.\n$output")
+    val anonKey =
+        values["ANON_KEY"]
+            ?: values["SUPABASE_ANON_KEY"]
+            ?: error("Supabase status did not include ANON_KEY.\n$output")
+    return LocalSupabaseConfig(apiUrl = apiUrl, anonKey = anonKey)
+}

--- a/supabase-auth-admin/build.gradle.kts
+++ b/supabase-auth-admin/build.gradle.kts
@@ -7,6 +7,7 @@ plugins {
     alias(libs.plugins.kotlin.serialization)
     alias(libs.plugins.android.library)
     alias(libs.plugins.vanniktech.publish)
+    alias(libs.plugins.kover)
 }
 
 kotlin {

--- a/supabase-auth-admin/src/commonTest/kotlin/io/github/androidpoet/supabase/auth/admin/SerializationRoundTripTest.kt
+++ b/supabase-auth-admin/src/commonTest/kotlin/io/github/androidpoet/supabase/auth/admin/SerializationRoundTripTest.kt
@@ -1,0 +1,141 @@
+package io.github.androidpoet.supabase.auth.admin
+
+import io.github.androidpoet.supabase.auth.admin.models.GenerateLinkProperties
+import io.github.androidpoet.supabase.auth.admin.models.GenerateLinkResponse
+import io.github.androidpoet.supabase.auth.admin.models.ListUsersResponse
+import io.github.androidpoet.supabase.auth.admin.models.OAuthClient
+import io.github.androidpoet.supabase.auth.admin.models.OAuthClientRegistrationType
+import io.github.androidpoet.supabase.auth.admin.models.OAuthClientTokenEndpointAuthMethod
+import io.github.androidpoet.supabase.auth.admin.models.OAuthClientType
+import kotlinx.serialization.json.Json
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class SerializationRoundTripTest {
+    private val json = Json { ignoreUnknownKeys = true }
+
+    @Test
+    fun test_listUsersResponse_decodesFromApiJson() {
+        val payload =
+            """
+            {
+              "users": [
+                {
+                  "id": "user-1",
+                  "email": "a@example.com",
+                  "created_at": "2024-01-01T00:00:00Z"
+                },
+                {
+                  "id": "user-2",
+                  "phone": "+15555550100"
+                }
+              ],
+              "aud": "authenticated"
+            }
+            """.trimIndent()
+
+        val response = json.decodeFromString<ListUsersResponse>(payload)
+
+        assertEquals(2, response.users.size)
+        assertEquals("a@example.com", response.users.first().email)
+        assertEquals("authenticated", response.aud)
+    }
+
+    @Test
+    fun test_generateLinkResponse_decodesFromApiJson() {
+        val payload =
+            """
+            {
+              "properties": {
+                "action_link": "https://example.com/verify?token=abc",
+                "email_otp": "123456",
+                "hashed_token": "hashed",
+                "redirect_to": "https://app.example.com",
+                "verification_type": "signup"
+              },
+              "user": { "id": "user-1", "email": "a@example.com" }
+            }
+            """.trimIndent()
+
+        val response = json.decodeFromString<GenerateLinkResponse>(payload)
+
+        assertEquals(
+            "https://example.com/verify?token=abc",
+            response.properties.actionLink,
+        )
+        assertEquals("123456", response.properties.emailOtp)
+        assertEquals("user-1", response.user?.id)
+    }
+
+    @Test
+    fun test_generateLinkResponse_roundTrip() {
+        val original =
+            GenerateLinkResponse(
+                properties =
+                    GenerateLinkProperties(
+                        actionLink = "https://example.com/verify",
+                        emailOtp = "654321",
+                        hashedToken = "hashed",
+                        redirectTo = "https://app.example.com",
+                        verificationType = "magiclink",
+                    ),
+                user = null,
+            )
+
+        val decoded = json.decodeFromString<GenerateLinkResponse>(json.encodeToString(original))
+
+        assertEquals(original, decoded)
+    }
+
+    @Test
+    fun test_oAuthClient_decodesFromApiJson() {
+        val payload =
+            """
+            {
+              "client_id": "client-123",
+              "client_name": "My App",
+              "client_secret": "secret",
+              "client_type": "confidential",
+              "token_endpoint_auth_method": "client_secret_basic",
+              "registration_type": "dynamic",
+              "client_uri": "https://app.example.com",
+              "redirect_uris": ["https://app.example.com/callback"],
+              "grant_types": ["authorization_code"],
+              "response_types": ["code"],
+              "scope": "openid email",
+              "created_at": "2024-01-01T00:00:00Z"
+            }
+            """.trimIndent()
+
+        val client = json.decodeFromString<OAuthClient>(payload)
+
+        assertEquals("client-123", client.clientId)
+        assertEquals(OAuthClientType.CONFIDENTIAL, client.clientType)
+        assertEquals(
+            OAuthClientTokenEndpointAuthMethod.CLIENT_SECRET_BASIC,
+            client.tokenEndpointAuthMethod,
+        )
+        assertEquals(OAuthClientRegistrationType.DYNAMIC, client.registrationType)
+        assertEquals(listOf("https://app.example.com/callback"), client.redirectUris)
+    }
+
+    @Test
+    fun test_oAuthClient_roundTrip() {
+        val original =
+            OAuthClient(
+                clientId = "client-123",
+                clientName = "My App",
+                clientSecret = null,
+                clientType = OAuthClientType.PUBLIC,
+                tokenEndpointAuthMethod = OAuthClientTokenEndpointAuthMethod.NONE,
+                registrationType = OAuthClientRegistrationType.MANUAL,
+                redirectUris = listOf("https://app.example.com/callback"),
+                grantTypes = listOf("authorization_code"),
+                responseTypes = listOf("code"),
+            )
+
+        val decoded = json.decodeFromString<OAuthClient>(json.encodeToString(original))
+
+        assertEquals(original, decoded)
+    }
+}

--- a/supabase-auth-apple/build.gradle.kts
+++ b/supabase-auth-apple/build.gradle.kts
@@ -7,6 +7,7 @@ plugins {
     alias(libs.plugins.kotlin.serialization)
     alias(libs.plugins.android.library)
     alias(libs.plugins.vanniktech.publish)
+    alias(libs.plugins.kover)
 }
 
 kotlin {

--- a/supabase-auth-google/build.gradle.kts
+++ b/supabase-auth-google/build.gradle.kts
@@ -7,6 +7,7 @@ plugins {
     alias(libs.plugins.kotlin.serialization)
     alias(libs.plugins.android.library)
     alias(libs.plugins.vanniktech.publish)
+    alias(libs.plugins.kover)
 }
 
 kotlin {

--- a/supabase-auth/build.gradle.kts
+++ b/supabase-auth/build.gradle.kts
@@ -7,6 +7,7 @@ plugins {
     alias(libs.plugins.kotlin.serialization)
     alias(libs.plugins.android.library)
     alias(libs.plugins.vanniktech.publish)
+    alias(libs.plugins.kover)
 }
 
 kotlin {

--- a/supabase-auth/src/commonTest/kotlin/io/github/androidpoet/supabase/auth/SerializationRoundTripTest.kt
+++ b/supabase-auth/src/commonTest/kotlin/io/github/androidpoet/supabase/auth/SerializationRoundTripTest.kt
@@ -1,0 +1,244 @@
+package io.github.androidpoet.supabase.auth
+
+import io.github.androidpoet.supabase.auth.models.AuthenticatorAssuranceLevel
+import io.github.androidpoet.supabase.auth.models.MfaChallengeResponse
+import io.github.androidpoet.supabase.auth.models.MfaEnrollResponse
+import io.github.androidpoet.supabase.auth.models.MfaFactor
+import io.github.androidpoet.supabase.auth.models.MfaFactorType
+import io.github.androidpoet.supabase.auth.models.MfaListFactorsResponse
+import io.github.androidpoet.supabase.auth.models.MfaTotpDetails
+import io.github.androidpoet.supabase.auth.models.MfaVerifyResponse
+import io.github.androidpoet.supabase.auth.models.Session
+import io.github.androidpoet.supabase.auth.models.User
+import io.github.androidpoet.supabase.auth.models.UserIdentity
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class SerializationRoundTripTest {
+    private val json = Json { ignoreUnknownKeys = true }
+
+    @Test
+    fun test_session_decodesFromApiJson() {
+        val payload =
+            """
+            {
+              "access_token": "eyJhbGciOi.access.token",
+              "refresh_token": "v1.refresh.token",
+              "expires_in": 3600,
+              "expires_at": 1718000000,
+              "token_type": "bearer",
+              "user": {
+                "id": "11111111-1111-1111-1111-111111111111",
+                "email": "user@example.com",
+                "aud": "authenticated",
+                "role": "authenticated",
+                "created_at": "2024-01-01T00:00:00Z",
+                "user_metadata": { "name": "Jane" },
+                "app_metadata": { "provider": "email" }
+              }
+            }
+            """.trimIndent()
+
+        val session = json.decodeFromString<Session>(payload)
+
+        assertEquals("eyJhbGciOi.access.token", session.accessToken)
+        assertEquals("v1.refresh.token", session.refreshToken)
+        assertEquals(3600L, session.expiresIn)
+        assertEquals("bearer", session.tokenType)
+        assertEquals("user@example.com", session.user.email)
+        assertEquals(
+            JsonPrimitive("Jane"),
+            session.user.userMetadata?.get("name"),
+        )
+    }
+
+    @Test
+    fun test_session_roundTrip() {
+        val original =
+            Session(
+                accessToken = "access",
+                refreshToken = "refresh",
+                expiresIn = 7200,
+                tokenType = "bearer",
+                user =
+                    User(
+                        id = "user-id",
+                        email = "user@example.com",
+                        phone = "+15555550100",
+                        createdAt = "2024-01-01T00:00:00Z",
+                        updatedAt = "2024-02-01T00:00:00Z",
+                        appMetadata = JsonObject(mapOf("provider" to JsonPrimitive("email"))),
+                        userMetadata = JsonObject(mapOf("name" to JsonPrimitive("Jane"))),
+                    ),
+            )
+
+        val decoded = json.decodeFromString<Session>(json.encodeToString(original))
+
+        assertEquals(original, decoded)
+    }
+
+    @Test
+    fun test_user_roundTripWithIdentities() {
+        val original =
+            User(
+                id = "user-id",
+                email = "user@example.com",
+                identities =
+                    listOf(
+                        UserIdentity(
+                            id = "identity-1",
+                            identityId = "id-1",
+                            provider = "google",
+                            userId = "user-id",
+                            identityData = JsonObject(mapOf("sub" to JsonPrimitive("abc"))),
+                        ),
+                    ),
+            )
+
+        val decoded = json.decodeFromString<User>(json.encodeToString(original))
+
+        assertEquals(original, decoded)
+    }
+
+    @Test
+    fun test_mfaVerifyResponse_decodesFromApiJson() {
+        val payload =
+            """
+            {
+              "access_token": "new.access.token",
+              "refresh_token": "new.refresh.token",
+              "token_type": "bearer",
+              "expires_in": 3600,
+              "user": { "id": "user-id" }
+            }
+            """.trimIndent()
+
+        val response = json.decodeFromString<MfaVerifyResponse>(payload)
+
+        assertEquals("new.access.token", response.accessToken)
+        assertEquals(3600L, response.expiresIn)
+        assertEquals("user-id", response.user.id)
+    }
+
+    @Test
+    fun test_mfaEnrollResponse_decodesFromApiJson() {
+        val payload =
+            """
+            {
+              "id": "factor-id",
+              "type": "totp",
+              "friendly_name": "My Authenticator",
+              "totp": {
+                "qr_code": "data:image/svg+xml;base64,abc",
+                "secret": "JBSWY3DPEHPK3PXP",
+                "uri": "otpauth://totp/Example"
+              }
+            }
+            """.trimIndent()
+
+        val response = json.decodeFromString<MfaEnrollResponse>(payload)
+
+        assertEquals("factor-id", response.id)
+        assertEquals(MfaFactorType.TOTP, response.type)
+        assertEquals("JBSWY3DPEHPK3PXP", response.totp?.secret)
+    }
+
+    @Test
+    fun test_mfaEnrollResponse_roundTrip() {
+        val original =
+            MfaEnrollResponse(
+                id = "factor-id",
+                type = MfaFactorType.TOTP,
+                totp =
+                    MfaTotpDetails(
+                        qrCode = "qr",
+                        secret = "secret",
+                        uri = "otpauth://totp/Example",
+                    ),
+                friendlyName = "name",
+            )
+
+        val decoded = json.decodeFromString<MfaEnrollResponse>(json.encodeToString(original))
+
+        assertEquals(original, decoded)
+    }
+
+    @Test
+    fun test_mfaChallengeResponse_roundTrip() {
+        val original =
+            MfaChallengeResponse(
+                id = "challenge-id",
+                factorId = "factor-id",
+                expiresAt = 1718000000,
+            )
+
+        val decoded = json.decodeFromString<MfaChallengeResponse>(json.encodeToString(original))
+
+        assertEquals(original, decoded)
+    }
+
+    @Test
+    fun test_mfaListFactorsResponse_decodesFromApiJson() {
+        val payload =
+            """
+            {
+              "all": [
+                {
+                  "id": "factor-1",
+                  "friendly_name": "Phone",
+                  "factor_type": "phone",
+                  "status": "verified",
+                  "created_at": "2024-01-01T00:00:00Z"
+                }
+              ],
+              "totp": [],
+              "phone": [
+                {
+                  "id": "factor-1",
+                  "factor_type": "phone",
+                  "status": "verified"
+                }
+              ]
+            }
+            """.trimIndent()
+
+        val response = json.decodeFromString<MfaListFactorsResponse>(payload)
+
+        assertEquals(1, response.all.size)
+        assertEquals(MfaFactorType.PHONE, response.all.first().factorType)
+        assertEquals("verified", response.phone.first().status)
+        assertEquals(emptyList(), response.webauthn)
+    }
+
+    @Test
+    fun test_mfaFactor_roundTrip() {
+        val original =
+            MfaFactor(
+                id = "factor-id",
+                friendlyName = "My TOTP",
+                factorType = MfaFactorType.TOTP,
+                status = "verified",
+                createdAt = "2024-01-01T00:00:00Z",
+                updatedAt = "2024-02-01T00:00:00Z",
+            )
+
+        val decoded = json.decodeFromString<MfaFactor>(json.encodeToString(original))
+
+        assertEquals(original, decoded)
+    }
+
+    @Test
+    fun test_authenticatorAssuranceLevel_serialNames() {
+        assertEquals(
+            AuthenticatorAssuranceLevel.AAL2,
+            json.decodeFromString<AuthenticatorAssuranceLevel>("\"aal2\""),
+        )
+        assertEquals(
+            "\"aal1\"",
+            json.encodeToString(AuthenticatorAssuranceLevel.AAL1),
+        )
+    }
+}

--- a/supabase-client/build.gradle.kts
+++ b/supabase-client/build.gradle.kts
@@ -7,6 +7,7 @@ plugins {
     alias(libs.plugins.kotlin.serialization)
     alias(libs.plugins.android.library)
     alias(libs.plugins.vanniktech.publish)
+    alias(libs.plugins.kover)
 }
 
 kotlin {

--- a/supabase-core/build.gradle.kts
+++ b/supabase-core/build.gradle.kts
@@ -7,6 +7,7 @@ plugins {
     alias(libs.plugins.kotlin.serialization)
     alias(libs.plugins.android.library)
     alias(libs.plugins.vanniktech.publish)
+    alias(libs.plugins.kover)
 }
 
 kotlin {

--- a/supabase-core/src/commonTest/kotlin/io/github/androidpoet/supabase/core/SerializationRoundTripTest.kt
+++ b/supabase-core/src/commonTest/kotlin/io/github/androidpoet/supabase/core/SerializationRoundTripTest.kt
@@ -1,0 +1,126 @@
+package io.github.androidpoet.supabase.core
+
+import io.github.androidpoet.supabase.core.models.ErrorResponse
+import io.github.androidpoet.supabase.core.models.PostgrestResponse
+import io.github.androidpoet.supabase.core.result.SupabaseError
+import kotlinx.serialization.builtins.ListSerializer
+import kotlinx.serialization.builtins.serializer
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonPrimitive
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class SerializationRoundTripTest {
+    private val json = Json { ignoreUnknownKeys = true }
+
+    @Test
+    fun test_errorResponse_decodesFromApiJson() {
+        val payload =
+            """
+            {
+              "message": "duplicate key value violates unique constraint",
+              "code": "23505",
+              "details": "Key (email)=(a@example.com) already exists.",
+              "hint": null
+            }
+            """.trimIndent()
+
+        val response = json.decodeFromString<ErrorResponse>(payload)
+
+        assertEquals("duplicate key value violates unique constraint", response.message)
+        assertEquals("23505", response.code)
+    }
+
+    @Test
+    fun test_errorResponse_roundTrip() {
+        val original =
+            ErrorResponse(
+                message = "not found",
+                code = "PGRST116",
+                details = "0 rows",
+                hint = "check filters",
+            )
+
+        val decoded = json.decodeFromString<ErrorResponse>(json.encodeToString(original))
+
+        assertEquals(original, decoded)
+    }
+
+    @Test
+    fun test_supabaseError_decodesFromApiJson() {
+        val payload =
+            """
+            {
+              "message": "rate limit exceeded",
+              "code": "over_request_rate_limit",
+              "details": { "remaining": 0 },
+              "hint": "slow down",
+              "httpStatus": 429,
+              "retryAfterSeconds": 30
+            }
+            """.trimIndent()
+
+        val error = json.decodeFromString<SupabaseError>(payload)
+
+        assertEquals("rate limit exceeded", error.message)
+        assertEquals("over_request_rate_limit", error.code)
+        assertEquals(429, error.httpStatus)
+        assertEquals(30L, error.retryAfterSeconds)
+    }
+
+    @Test
+    fun test_supabaseError_roundTrip() {
+        val original =
+            SupabaseError(
+                message = "conflict",
+                code = "23505",
+                hint = "unique violation",
+                httpStatus = 409,
+            )
+
+        val decoded = json.decodeFromString<SupabaseError>(json.encodeToString(original))
+
+        assertEquals(original, decoded)
+    }
+
+    @Test
+    fun test_postgrestResponse_decodesWithCount() {
+        val payload =
+            """
+            {
+              "data": ["alice", "bob"],
+              "count": 2
+            }
+            """.trimIndent()
+
+        val serializer = PostgrestResponse.serializer(ListSerializer(String.serializer()))
+        val response = json.decodeFromString(serializer, payload)
+
+        assertEquals(listOf("alice", "bob"), response.data)
+        assertEquals(2L, response.count)
+    }
+
+    @Test
+    fun test_postgrestResponse_roundTrip() {
+        val original = PostgrestResponse(data = listOf("alice"), count = 1)
+        val serializer = PostgrestResponse.serializer(ListSerializer(String.serializer()))
+
+        val decoded = json.decodeFromString(serializer, json.encodeToString(serializer, original))
+
+        assertEquals(original, decoded)
+    }
+
+    @Test
+    fun test_supabaseErrorDetails_preservesNestedJson() {
+        val error =
+            SupabaseError(
+                message = "validation failed",
+                details = JsonPrimitive("email is required"),
+            )
+
+        val decoded = json.decodeFromString<SupabaseError>(json.encodeToString(error))
+
+        assertEquals(error, decoded)
+        assertEquals(JsonPrimitive("email is required"), decoded.details)
+    }
+}

--- a/supabase-database/build.gradle.kts
+++ b/supabase-database/build.gradle.kts
@@ -7,6 +7,7 @@ plugins {
     alias(libs.plugins.kotlin.serialization)
     alias(libs.plugins.android.library)
     alias(libs.plugins.vanniktech.publish)
+    alias(libs.plugins.kover)
 }
 
 kotlin {

--- a/supabase-functions/build.gradle.kts
+++ b/supabase-functions/build.gradle.kts
@@ -7,6 +7,7 @@ plugins {
     alias(libs.plugins.kotlin.serialization)
     alias(libs.plugins.android.library)
     alias(libs.plugins.vanniktech.publish)
+    alias(libs.plugins.kover)
 }
 
 kotlin {

--- a/supabase-functions/src/commonTest/kotlin/io/github/androidpoet/supabase/functions/SerializationRoundTripTest.kt
+++ b/supabase-functions/src/commonTest/kotlin/io/github/androidpoet/supabase/functions/SerializationRoundTripTest.kt
@@ -1,0 +1,34 @@
+package io.github.androidpoet.supabase.functions
+
+import kotlinx.serialization.json.Json
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class SerializationRoundTripTest {
+    private val json = Json { ignoreUnknownKeys = true }
+
+    @Test
+    fun test_functionRegion_decodesFromSerialName() {
+        assertEquals(
+            FunctionRegion.US_EAST_1,
+            json.decodeFromString<FunctionRegion>("\"us-east-1\""),
+        )
+        assertEquals(
+            FunctionRegion.AP_NORTHEAST_1,
+            json.decodeFromString<FunctionRegion>("\"ap-northeast-1\""),
+        )
+    }
+
+    @Test
+    fun test_functionRegion_roundTripAllValues() {
+        for (region in FunctionRegion.entries) {
+            val decoded = json.decodeFromString<FunctionRegion>(json.encodeToString(region))
+            assertEquals(region, decoded)
+        }
+    }
+
+    @Test
+    fun test_functionRegion_encodesToWireName() {
+        assertEquals("\"eu-west-1\"", json.encodeToString(FunctionRegion.EU_WEST_1))
+    }
+}

--- a/supabase-realtime/build.gradle.kts
+++ b/supabase-realtime/build.gradle.kts
@@ -7,6 +7,7 @@ plugins {
     alias(libs.plugins.kotlin.serialization)
     alias(libs.plugins.android.library)
     alias(libs.plugins.vanniktech.publish)
+    alias(libs.plugins.kover)
     alias(libs.plugins.atomicfu)
 }
 

--- a/supabase-realtime/src/commonTest/kotlin/io/github/androidpoet/supabase/realtime/SerializationRoundTripTest.kt
+++ b/supabase-realtime/src/commonTest/kotlin/io/github/androidpoet/supabase/realtime/SerializationRoundTripTest.kt
@@ -1,0 +1,90 @@
+package io.github.androidpoet.supabase.realtime
+
+import io.github.androidpoet.supabase.realtime.models.BroadcastPayload
+import io.github.androidpoet.supabase.realtime.models.PostgresChange
+import io.github.androidpoet.supabase.realtime.models.PostgresChangeEvent
+import io.github.androidpoet.supabase.realtime.models.RealtimeMessage
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class SerializationRoundTripTest {
+    private val json = Json { ignoreUnknownKeys = true }
+
+    @Test
+    fun test_realtimeMessage_decodesFromWireJson() {
+        val payload =
+            """
+            {
+              "topic": "realtime:public:messages",
+              "event": "phx_reply",
+              "payload": { "status": "ok", "response": {} },
+              "join_ref": "1",
+              "ref": "2"
+            }
+            """.trimIndent()
+
+        val message = json.decodeFromString<RealtimeMessage>(payload)
+
+        assertEquals("realtime:public:messages", message.topic)
+        assertEquals("phx_reply", message.event)
+        assertEquals("1", message.joinRef)
+        assertEquals("2", message.ref)
+        assertEquals(JsonPrimitive("ok"), message.payload["status"])
+    }
+
+    @Test
+    fun test_realtimeMessage_roundTrip() {
+        val original =
+            RealtimeMessage(
+                topic = "realtime:public:messages",
+                event = "broadcast",
+                payload = JsonObject(mapOf("type" to JsonPrimitive("broadcast"))),
+                joinRef = "1",
+                ref = "2",
+            )
+
+        val decoded = json.decodeFromString<RealtimeMessage>(json.encodeToString(original))
+
+        assertEquals(original, decoded)
+    }
+
+    @Test
+    fun test_postgresChange_roundTrip() {
+        val original =
+            PostgresChange(
+                schema = "public",
+                table = "messages",
+                filter = "id=eq.1",
+                event = PostgresChangeEvent.INSERT,
+            )
+
+        val decoded = json.decodeFromString<PostgresChange>(json.encodeToString(original))
+
+        assertEquals(original, decoded)
+    }
+
+    @Test
+    fun test_postgresChangeEvent_serialNames() {
+        assertEquals(
+            PostgresChangeEvent.UPDATE,
+            json.decodeFromString<PostgresChangeEvent>("\"UPDATE\""),
+        )
+        assertEquals("\"*\"", json.encodeToString(PostgresChangeEvent.ALL))
+    }
+
+    @Test
+    fun test_broadcastPayload_roundTrip() {
+        val original =
+            BroadcastPayload(
+                event = "cursor-move",
+                payload = JsonObject(mapOf("x" to JsonPrimitive(10), "y" to JsonPrimitive(20))),
+            )
+
+        val decoded = json.decodeFromString<BroadcastPayload>(json.encodeToString(original))
+
+        assertEquals(original, decoded)
+    }
+}

--- a/supabase-storage/build.gradle.kts
+++ b/supabase-storage/build.gradle.kts
@@ -7,6 +7,7 @@ plugins {
     alias(libs.plugins.kotlin.serialization)
     alias(libs.plugins.android.library)
     alias(libs.plugins.vanniktech.publish)
+    alias(libs.plugins.kover)
 }
 
 kotlin {

--- a/supabase-storage/src/commonTest/kotlin/io/github/androidpoet/supabase/storage/SerializationRoundTripTest.kt
+++ b/supabase-storage/src/commonTest/kotlin/io/github/androidpoet/supabase/storage/SerializationRoundTripTest.kt
@@ -1,0 +1,121 @@
+package io.github.androidpoet.supabase.storage
+
+import io.github.androidpoet.supabase.storage.models.Bucket
+import io.github.androidpoet.supabase.storage.models.FileObject
+import io.github.androidpoet.supabase.storage.models.SignedUrlItemResponse
+import io.github.androidpoet.supabase.storage.models.SignedUrlResponse
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class SerializationRoundTripTest {
+    private val json = Json { ignoreUnknownKeys = true }
+
+    @Test
+    fun test_bucket_decodesFromApiJson() {
+        val payload =
+            """
+            {
+              "id": "avatars",
+              "name": "avatars",
+              "owner": "",
+              "public": true,
+              "created_at": "2024-01-01T00:00:00Z",
+              "updated_at": "2024-02-01T00:00:00Z",
+              "file_size_limit": 5242880,
+              "allowed_mime_types": ["image/png", "image/jpeg"]
+            }
+            """.trimIndent()
+
+        val bucket = json.decodeFromString<Bucket>(payload)
+
+        assertEquals("avatars", bucket.id)
+        assertEquals(true, bucket.public)
+        assertEquals(5242880L, bucket.fileSizeLimit)
+        assertEquals(listOf("image/png", "image/jpeg"), bucket.allowedMimeTypes)
+    }
+
+    @Test
+    fun test_bucket_roundTrip() {
+        val original =
+            Bucket(
+                id = "avatars",
+                name = "avatars",
+                public = false,
+                createdAt = "2024-01-01T00:00:00Z",
+                updatedAt = "2024-02-01T00:00:00Z",
+                fileSizeLimit = 1024,
+                allowedMimeTypes = listOf("image/png"),
+            )
+
+        val decoded = json.decodeFromString<Bucket>(json.encodeToString(original))
+
+        assertEquals(original, decoded)
+    }
+
+    @Test
+    fun test_fileObject_decodesFromApiJson() {
+        val payload =
+            """
+            {
+              "name": "photo.png",
+              "id": "object-1",
+              "bucket_id": "avatars",
+              "created_at": "2024-01-01T00:00:00Z",
+              "updated_at": "2024-02-01T00:00:00Z",
+              "last_accessed_at": "2024-02-02T00:00:00Z",
+              "metadata": { "size": 1234, "mimetype": "image/png" }
+            }
+            """.trimIndent()
+
+        val obj = json.decodeFromString<FileObject>(payload)
+
+        assertEquals("photo.png", obj.name)
+        assertEquals("avatars", obj.bucketId)
+        assertEquals(JsonPrimitive(1234), obj.metadata?.get("size"))
+    }
+
+    @Test
+    fun test_fileObject_roundTrip() {
+        val original =
+            FileObject(
+                name = "photo.png",
+                id = "object-1",
+                bucketId = "avatars",
+                createdAt = "2024-01-01T00:00:00Z",
+                updatedAt = "2024-02-01T00:00:00Z",
+                metadata = JsonObject(mapOf("mimetype" to JsonPrimitive("image/png"))),
+            )
+
+        val decoded = json.decodeFromString<FileObject>(json.encodeToString(original))
+
+        assertEquals(original, decoded)
+    }
+
+    @Test
+    fun test_signedUrlResponse_decodesFromApiJson() {
+        val payload = """{ "signed_url": "/object/sign/avatars/photo.png?token=abc" }"""
+
+        val response = json.decodeFromString<SignedUrlResponse>(payload)
+
+        assertEquals("/object/sign/avatars/photo.png?token=abc", response.signedUrl)
+    }
+
+    @Test
+    fun test_signedUrlItemResponse_decodesFromApiJson() {
+        val payload =
+            """
+            {
+              "path": "avatars/photo.png",
+              "signedURL": "/object/sign/avatars/photo.png?token=abc"
+            }
+            """.trimIndent()
+
+        val response = json.decodeFromString<SignedUrlItemResponse>(payload)
+
+        assertEquals("avatars/photo.png", response.path)
+        assertEquals("/object/sign/avatars/photo.png?token=abc", response.signedUrl)
+    }
+}

--- a/supabase/migrations/20260529170000_create_e2e_messages.sql
+++ b/supabase/migrations/20260529170000_create_e2e_messages.sql
@@ -6,6 +6,10 @@ create table if not exists public.e2e_messages (
 
 alter table public.e2e_messages enable row level security;
 
+-- RLS policies gate which rows are visible, but the anon role still needs
+-- table-level privileges to touch the table at all.
+grant select, insert on public.e2e_messages to anon;
+
 drop policy if exists "anon can read e2e messages" on public.e2e_messages;
 create policy "anon can read e2e messages"
     on public.e2e_messages


### PR DESCRIPTION
## Production hardening: E2E in CI, working coverage gate, serialization tests

Implements the top 3 production-readiness items.

### 1. E2E tests in CI
- New `.github/workflows/e2e.yml`: on PR/push/nightly + manual, installs the Supabase CLI and runs the existing `supabaseE2eTest` task (DB reset → e2e → stop) on an ubuntu+Docker runner. **Previously the e2e suite existed but never ran in CI** — every "passing" build only exercised fakes.
- Broadened E2E beyond database: added `AuthE2eTest` (real sign-up → sign-in round-trip against GoTrue) and extracted a shared `localSupabaseConfig()` helper.

### 2. Coverage gate (and a real bug fix)
- **Kover was collecting nothing:** the published modules never applied the Kover plugin, so the aggregate report was empty (0/0) and CI was uploading a blank coverage file. Applied Kover to all 10 published modules — real coverage now measures **72.8% line / 67.8% instruction**.
- Added a `koverVerify` gate at **65%** line coverage (headroom below current) and wired it into the CI quality job so coverage can't silently rot.

### 3. Round-trip serialization tests
- 36 new tests across 6 modules (core, auth, auth-admin, storage, functions, realtime) covering the public `@Serializable` response models: decode-from-realistic-API-JSON (real `@SerialName` wire names, extra fields for forward-compat) + encode/decode equality. Guards against model drift, the most common silent SDK breakage.

All additive — no production code or public API change (`apiCheck` passes without a dump). `jvmTest`, `koverVerify`, `detekt`, `spotlessCheck`, `apiCheck` green locally. (E2E runs in CI where Docker is available.)
