### PR TITLE
feat(client): configurable retry + observability hooks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## Unreleased
+
+### Added
+
+- **Configurable retry:** `SupabaseConfigBuilder.retry` takes a `RetryConfig`
+  (max attempts, exponential base/cap delays, retryable status set). Replaces the
+  previously hardcoded transport retry constants; a `Retry-After` header still
+  wins over the computed backoff.
+- **Observability hooks** on `SupabaseConfig`:
+  - `logger: SupabaseLogger?` — route HTTP wire logs into your own logging
+    framework (Timber/OSLog/SLF4J) instead of Ktor's default sink.
+  - `interceptor: SupabaseInterceptor?` — `onRequest` / `onResponse(status,
+    durationMillis)` / `onError(error, durationMillis)` hooks fired around every
+    request, for tracing/metrics. All `suspend`, all default no-ops.
+
 ## 0.4.0
 
 ### Added

--- a/supabase-client/api/android/supabase-client.api
+++ b/supabase-client/api/android/supabase-client.api
@@ -1,3 +1,32 @@
+public final class io/github/androidpoet/supabase/client/RetryConfig {
+	public static final field Companion Lio/github/androidpoet/supabase/client/RetryConfig$Companion;
+	public static final field DEFAULT_BASE_DELAY_MILLIS J
+	public static final field DEFAULT_MAX_DELAY_MILLIS J
+	public static final field DEFAULT_MAX_RETRIES I
+	public fun <init> ()V
+	public fun <init> (IJJLjava/util/Set;)V
+	public synthetic fun <init> (IJJLjava/util/Set;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun backoffMillis (I)J
+	public final fun component1 ()I
+	public final fun component2 ()J
+	public final fun component3 ()J
+	public final fun component4 ()Ljava/util/Set;
+	public final fun copy (IJJLjava/util/Set;)Lio/github/androidpoet/supabase/client/RetryConfig;
+	public static synthetic fun copy$default (Lio/github/androidpoet/supabase/client/RetryConfig;IJJLjava/util/Set;ILjava/lang/Object;)Lio/github/androidpoet/supabase/client/RetryConfig;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getBaseDelayMillis ()J
+	public final fun getMaxDelayMillis ()J
+	public final fun getMaxRetries ()I
+	public final fun getRetryableStatuses ()Ljava/util/Set;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/github/androidpoet/supabase/client/RetryConfig$Companion {
+	public final fun getDEFAULT_RETRYABLE_STATUSES ()Ljava/util/Set;
+	public final fun getDefault ()Lio/github/androidpoet/supabase/client/RetryConfig;
+}
+
 public final class io/github/androidpoet/supabase/client/Supabase {
 	public static final field INSTANCE Lio/github/androidpoet/supabase/client/Supabase;
 	public final fun create (Ljava/lang/String;Ljava/lang/String;Lio/ktor/client/engine/HttpClientEngineFactory;Lkotlin/jvm/functions/Function1;)Lio/github/androidpoet/supabase/client/SupabaseClient;
@@ -37,16 +66,23 @@ public final class io/github/androidpoet/supabase/client/SupabaseClientExtKt {
 }
 
 public final class io/github/androidpoet/supabase/client/SupabaseConfig {
-	public fun <init> (ZLio/ktor/client/plugins/logging/LogLevel;Ljava/util/Map;)V
+	public fun <init> (ZLio/ktor/client/plugins/logging/LogLevel;Ljava/util/Map;Lio/github/androidpoet/supabase/client/RetryConfig;Lio/github/androidpoet/supabase/client/SupabaseLogger;Lio/github/androidpoet/supabase/client/SupabaseInterceptor;)V
+	public synthetic fun <init> (ZLio/ktor/client/plugins/logging/LogLevel;Ljava/util/Map;Lio/github/androidpoet/supabase/client/RetryConfig;Lio/github/androidpoet/supabase/client/SupabaseLogger;Lio/github/androidpoet/supabase/client/SupabaseInterceptor;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Z
 	public final fun component2 ()Lio/ktor/client/plugins/logging/LogLevel;
 	public final fun component3 ()Ljava/util/Map;
-	public final fun copy (ZLio/ktor/client/plugins/logging/LogLevel;Ljava/util/Map;)Lio/github/androidpoet/supabase/client/SupabaseConfig;
-	public static synthetic fun copy$default (Lio/github/androidpoet/supabase/client/SupabaseConfig;ZLio/ktor/client/plugins/logging/LogLevel;Ljava/util/Map;ILjava/lang/Object;)Lio/github/androidpoet/supabase/client/SupabaseConfig;
+	public final fun component4 ()Lio/github/androidpoet/supabase/client/RetryConfig;
+	public final fun component5 ()Lio/github/androidpoet/supabase/client/SupabaseLogger;
+	public final fun component6 ()Lio/github/androidpoet/supabase/client/SupabaseInterceptor;
+	public final fun copy (ZLio/ktor/client/plugins/logging/LogLevel;Ljava/util/Map;Lio/github/androidpoet/supabase/client/RetryConfig;Lio/github/androidpoet/supabase/client/SupabaseLogger;Lio/github/androidpoet/supabase/client/SupabaseInterceptor;)Lio/github/androidpoet/supabase/client/SupabaseConfig;
+	public static synthetic fun copy$default (Lio/github/androidpoet/supabase/client/SupabaseConfig;ZLio/ktor/client/plugins/logging/LogLevel;Ljava/util/Map;Lio/github/androidpoet/supabase/client/RetryConfig;Lio/github/androidpoet/supabase/client/SupabaseLogger;Lio/github/androidpoet/supabase/client/SupabaseInterceptor;ILjava/lang/Object;)Lio/github/androidpoet/supabase/client/SupabaseConfig;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getHeaders ()Ljava/util/Map;
+	public final fun getInterceptor ()Lio/github/androidpoet/supabase/client/SupabaseInterceptor;
 	public final fun getLogLevel ()Lio/ktor/client/plugins/logging/LogLevel;
+	public final fun getLogger ()Lio/github/androidpoet/supabase/client/SupabaseLogger;
 	public final fun getLogging ()Z
+	public final fun getRetry ()Lio/github/androidpoet/supabase/client/RetryConfig;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 }
@@ -54,10 +90,16 @@ public final class io/github/androidpoet/supabase/client/SupabaseConfig {
 public final class io/github/androidpoet/supabase/client/SupabaseConfigBuilder {
 	public fun <init> ()V
 	public final fun getHeaders ()Ljava/util/Map;
+	public final fun getInterceptor ()Lio/github/androidpoet/supabase/client/SupabaseInterceptor;
 	public final fun getLogLevel ()Lio/ktor/client/plugins/logging/LogLevel;
+	public final fun getLogger ()Lio/github/androidpoet/supabase/client/SupabaseLogger;
 	public final fun getLogging ()Z
+	public final fun getRetry ()Lio/github/androidpoet/supabase/client/RetryConfig;
+	public final fun setInterceptor (Lio/github/androidpoet/supabase/client/SupabaseInterceptor;)V
 	public final fun setLogLevel (Lio/ktor/client/plugins/logging/LogLevel;)V
+	public final fun setLogger (Lio/github/androidpoet/supabase/client/SupabaseLogger;)V
 	public final fun setLogging (Z)V
+	public final fun setRetry (Lio/github/androidpoet/supabase/client/RetryConfig;)V
 }
 
 public abstract interface annotation class io/github/androidpoet/supabase/client/SupabaseDsl : java/lang/annotation/Annotation {
@@ -81,6 +123,36 @@ public final class io/github/androidpoet/supabase/client/SupabaseHttpResponse {
 	public final fun getHeaders ()Ljava/util/Map;
 	public final fun getStatus ()I
 	public final fun header (Ljava/lang/String;)Ljava/lang/String;
+}
+
+public abstract interface class io/github/androidpoet/supabase/client/SupabaseInterceptor {
+	public abstract fun onError (Ljava/lang/String;Ljava/lang/String;Lio/github/androidpoet/supabase/core/result/SupabaseError;JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun onRequest (Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun onResponse (Ljava/lang/String;Ljava/lang/String;IJLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class io/github/androidpoet/supabase/client/SupabaseInterceptor$DefaultImpls {
+	public static fun onError (Lio/github/androidpoet/supabase/client/SupabaseInterceptor;Ljava/lang/String;Ljava/lang/String;Lio/github/androidpoet/supabase/core/result/SupabaseError;JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static fun onRequest (Lio/github/androidpoet/supabase/client/SupabaseInterceptor;Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static fun onResponse (Lio/github/androidpoet/supabase/client/SupabaseInterceptor;Ljava/lang/String;Ljava/lang/String;IJLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class io/github/androidpoet/supabase/client/SupabaseLogLevel : java/lang/Enum {
+	public static final field DEBUG Lio/github/androidpoet/supabase/client/SupabaseLogLevel;
+	public static final field ERROR Lio/github/androidpoet/supabase/client/SupabaseLogLevel;
+	public static final field INFO Lio/github/androidpoet/supabase/client/SupabaseLogLevel;
+	public static final field WARN Lio/github/androidpoet/supabase/client/SupabaseLogLevel;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public static fun valueOf (Ljava/lang/String;)Lio/github/androidpoet/supabase/client/SupabaseLogLevel;
+	public static fun values ()[Lio/github/androidpoet/supabase/client/SupabaseLogLevel;
+}
+
+public abstract interface class io/github/androidpoet/supabase/client/SupabaseLogger {
+	public abstract fun log (Lio/github/androidpoet/supabase/client/SupabaseLogLevel;Ljava/lang/String;Ljava/lang/Throwable;)V
+}
+
+public final class io/github/androidpoet/supabase/client/SupabaseLogger$DefaultImpls {
+	public static synthetic fun log$default (Lio/github/androidpoet/supabase/client/SupabaseLogger;Lio/github/androidpoet/supabase/client/SupabaseLogLevel;Ljava/lang/String;Ljava/lang/Throwable;ILjava/lang/Object;)V
 }
 
 public abstract interface class io/github/androidpoet/supabase/client/auth/AuthState {

--- a/supabase-client/api/jvm/supabase-client.api
+++ b/supabase-client/api/jvm/supabase-client.api
@@ -1,3 +1,32 @@
+public final class io/github/androidpoet/supabase/client/RetryConfig {
+	public static final field Companion Lio/github/androidpoet/supabase/client/RetryConfig$Companion;
+	public static final field DEFAULT_BASE_DELAY_MILLIS J
+	public static final field DEFAULT_MAX_DELAY_MILLIS J
+	public static final field DEFAULT_MAX_RETRIES I
+	public fun <init> ()V
+	public fun <init> (IJJLjava/util/Set;)V
+	public synthetic fun <init> (IJJLjava/util/Set;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun backoffMillis (I)J
+	public final fun component1 ()I
+	public final fun component2 ()J
+	public final fun component3 ()J
+	public final fun component4 ()Ljava/util/Set;
+	public final fun copy (IJJLjava/util/Set;)Lio/github/androidpoet/supabase/client/RetryConfig;
+	public static synthetic fun copy$default (Lio/github/androidpoet/supabase/client/RetryConfig;IJJLjava/util/Set;ILjava/lang/Object;)Lio/github/androidpoet/supabase/client/RetryConfig;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getBaseDelayMillis ()J
+	public final fun getMaxDelayMillis ()J
+	public final fun getMaxRetries ()I
+	public final fun getRetryableStatuses ()Ljava/util/Set;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/github/androidpoet/supabase/client/RetryConfig$Companion {
+	public final fun getDEFAULT_RETRYABLE_STATUSES ()Ljava/util/Set;
+	public final fun getDefault ()Lio/github/androidpoet/supabase/client/RetryConfig;
+}
+
 public final class io/github/androidpoet/supabase/client/Supabase {
 	public static final field INSTANCE Lio/github/androidpoet/supabase/client/Supabase;
 	public final fun create (Ljava/lang/String;Ljava/lang/String;Lio/ktor/client/engine/HttpClientEngineFactory;Lkotlin/jvm/functions/Function1;)Lio/github/androidpoet/supabase/client/SupabaseClient;
@@ -37,16 +66,23 @@ public final class io/github/androidpoet/supabase/client/SupabaseClientExtKt {
 }
 
 public final class io/github/androidpoet/supabase/client/SupabaseConfig {
-	public fun <init> (ZLio/ktor/client/plugins/logging/LogLevel;Ljava/util/Map;)V
+	public fun <init> (ZLio/ktor/client/plugins/logging/LogLevel;Ljava/util/Map;Lio/github/androidpoet/supabase/client/RetryConfig;Lio/github/androidpoet/supabase/client/SupabaseLogger;Lio/github/androidpoet/supabase/client/SupabaseInterceptor;)V
+	public synthetic fun <init> (ZLio/ktor/client/plugins/logging/LogLevel;Ljava/util/Map;Lio/github/androidpoet/supabase/client/RetryConfig;Lio/github/androidpoet/supabase/client/SupabaseLogger;Lio/github/androidpoet/supabase/client/SupabaseInterceptor;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Z
 	public final fun component2 ()Lio/ktor/client/plugins/logging/LogLevel;
 	public final fun component3 ()Ljava/util/Map;
-	public final fun copy (ZLio/ktor/client/plugins/logging/LogLevel;Ljava/util/Map;)Lio/github/androidpoet/supabase/client/SupabaseConfig;
-	public static synthetic fun copy$default (Lio/github/androidpoet/supabase/client/SupabaseConfig;ZLio/ktor/client/plugins/logging/LogLevel;Ljava/util/Map;ILjava/lang/Object;)Lio/github/androidpoet/supabase/client/SupabaseConfig;
+	public final fun component4 ()Lio/github/androidpoet/supabase/client/RetryConfig;
+	public final fun component5 ()Lio/github/androidpoet/supabase/client/SupabaseLogger;
+	public final fun component6 ()Lio/github/androidpoet/supabase/client/SupabaseInterceptor;
+	public final fun copy (ZLio/ktor/client/plugins/logging/LogLevel;Ljava/util/Map;Lio/github/androidpoet/supabase/client/RetryConfig;Lio/github/androidpoet/supabase/client/SupabaseLogger;Lio/github/androidpoet/supabase/client/SupabaseInterceptor;)Lio/github/androidpoet/supabase/client/SupabaseConfig;
+	public static synthetic fun copy$default (Lio/github/androidpoet/supabase/client/SupabaseConfig;ZLio/ktor/client/plugins/logging/LogLevel;Ljava/util/Map;Lio/github/androidpoet/supabase/client/RetryConfig;Lio/github/androidpoet/supabase/client/SupabaseLogger;Lio/github/androidpoet/supabase/client/SupabaseInterceptor;ILjava/lang/Object;)Lio/github/androidpoet/supabase/client/SupabaseConfig;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getHeaders ()Ljava/util/Map;
+	public final fun getInterceptor ()Lio/github/androidpoet/supabase/client/SupabaseInterceptor;
 	public final fun getLogLevel ()Lio/ktor/client/plugins/logging/LogLevel;
+	public final fun getLogger ()Lio/github/androidpoet/supabase/client/SupabaseLogger;
 	public final fun getLogging ()Z
+	public final fun getRetry ()Lio/github/androidpoet/supabase/client/RetryConfig;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 }
@@ -54,10 +90,16 @@ public final class io/github/androidpoet/supabase/client/SupabaseConfig {
 public final class io/github/androidpoet/supabase/client/SupabaseConfigBuilder {
 	public fun <init> ()V
 	public final fun getHeaders ()Ljava/util/Map;
+	public final fun getInterceptor ()Lio/github/androidpoet/supabase/client/SupabaseInterceptor;
 	public final fun getLogLevel ()Lio/ktor/client/plugins/logging/LogLevel;
+	public final fun getLogger ()Lio/github/androidpoet/supabase/client/SupabaseLogger;
 	public final fun getLogging ()Z
+	public final fun getRetry ()Lio/github/androidpoet/supabase/client/RetryConfig;
+	public final fun setInterceptor (Lio/github/androidpoet/supabase/client/SupabaseInterceptor;)V
 	public final fun setLogLevel (Lio/ktor/client/plugins/logging/LogLevel;)V
+	public final fun setLogger (Lio/github/androidpoet/supabase/client/SupabaseLogger;)V
 	public final fun setLogging (Z)V
+	public final fun setRetry (Lio/github/androidpoet/supabase/client/RetryConfig;)V
 }
 
 public abstract interface annotation class io/github/androidpoet/supabase/client/SupabaseDsl : java/lang/annotation/Annotation {
@@ -81,6 +123,36 @@ public final class io/github/androidpoet/supabase/client/SupabaseHttpResponse {
 	public final fun getHeaders ()Ljava/util/Map;
 	public final fun getStatus ()I
 	public final fun header (Ljava/lang/String;)Ljava/lang/String;
+}
+
+public abstract interface class io/github/androidpoet/supabase/client/SupabaseInterceptor {
+	public abstract fun onError (Ljava/lang/String;Ljava/lang/String;Lio/github/androidpoet/supabase/core/result/SupabaseError;JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun onRequest (Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun onResponse (Ljava/lang/String;Ljava/lang/String;IJLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class io/github/androidpoet/supabase/client/SupabaseInterceptor$DefaultImpls {
+	public static fun onError (Lio/github/androidpoet/supabase/client/SupabaseInterceptor;Ljava/lang/String;Ljava/lang/String;Lio/github/androidpoet/supabase/core/result/SupabaseError;JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static fun onRequest (Lio/github/androidpoet/supabase/client/SupabaseInterceptor;Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static fun onResponse (Lio/github/androidpoet/supabase/client/SupabaseInterceptor;Ljava/lang/String;Ljava/lang/String;IJLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class io/github/androidpoet/supabase/client/SupabaseLogLevel : java/lang/Enum {
+	public static final field DEBUG Lio/github/androidpoet/supabase/client/SupabaseLogLevel;
+	public static final field ERROR Lio/github/androidpoet/supabase/client/SupabaseLogLevel;
+	public static final field INFO Lio/github/androidpoet/supabase/client/SupabaseLogLevel;
+	public static final field WARN Lio/github/androidpoet/supabase/client/SupabaseLogLevel;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public static fun valueOf (Ljava/lang/String;)Lio/github/androidpoet/supabase/client/SupabaseLogLevel;
+	public static fun values ()[Lio/github/androidpoet/supabase/client/SupabaseLogLevel;
+}
+
+public abstract interface class io/github/androidpoet/supabase/client/SupabaseLogger {
+	public abstract fun log (Lio/github/androidpoet/supabase/client/SupabaseLogLevel;Ljava/lang/String;Ljava/lang/Throwable;)V
+}
+
+public final class io/github/androidpoet/supabase/client/SupabaseLogger$DefaultImpls {
+	public static synthetic fun log$default (Lio/github/androidpoet/supabase/client/SupabaseLogger;Lio/github/androidpoet/supabase/client/SupabaseLogLevel;Ljava/lang/String;Ljava/lang/Throwable;ILjava/lang/Object;)V
 }
 
 public abstract interface class io/github/androidpoet/supabase/client/auth/AuthState {

--- a/supabase-client/api/supabase-client.klib.api
+++ b/supabase-client/api/supabase-client.klib.api
@@ -25,6 +25,19 @@ final enum class io.github.androidpoet.supabase.client/SupabaseHttpMethod : kotl
     final fun values(): kotlin/Array<io.github.androidpoet.supabase.client/SupabaseHttpMethod> // io.github.androidpoet.supabase.client/SupabaseHttpMethod.values|values#static(){}[0]
 }
 
+final enum class io.github.androidpoet.supabase.client/SupabaseLogLevel : kotlin/Enum<io.github.androidpoet.supabase.client/SupabaseLogLevel> { // io.github.androidpoet.supabase.client/SupabaseLogLevel|null[0]
+    enum entry DEBUG // io.github.androidpoet.supabase.client/SupabaseLogLevel.DEBUG|null[0]
+    enum entry ERROR // io.github.androidpoet.supabase.client/SupabaseLogLevel.ERROR|null[0]
+    enum entry INFO // io.github.androidpoet.supabase.client/SupabaseLogLevel.INFO|null[0]
+    enum entry WARN // io.github.androidpoet.supabase.client/SupabaseLogLevel.WARN|null[0]
+
+    final val entries // io.github.androidpoet.supabase.client/SupabaseLogLevel.entries|#static{}entries[0]
+        final fun <get-entries>(): kotlin.enums/EnumEntries<io.github.androidpoet.supabase.client/SupabaseLogLevel> // io.github.androidpoet.supabase.client/SupabaseLogLevel.entries.<get-entries>|<get-entries>#static(){}[0]
+
+    final fun valueOf(kotlin/String): io.github.androidpoet.supabase.client/SupabaseLogLevel // io.github.androidpoet.supabase.client/SupabaseLogLevel.valueOf|valueOf#static(kotlin.String){}[0]
+    final fun values(): kotlin/Array<io.github.androidpoet.supabase.client/SupabaseLogLevel> // io.github.androidpoet.supabase.client/SupabaseLogLevel.values|values#static(){}[0]
+}
+
 abstract interface io.github.androidpoet.supabase.client/SupabaseClient : kotlin/AutoCloseable { // io.github.androidpoet.supabase.client/SupabaseClient|null[0]
     abstract val accessTokenOrNull // io.github.androidpoet.supabase.client/SupabaseClient.accessTokenOrNull|{}accessTokenOrNull[0]
         abstract fun <get-accessTokenOrNull>(): kotlin/String? // io.github.androidpoet.supabase.client/SupabaseClient.accessTokenOrNull.<get-accessTokenOrNull>|<get-accessTokenOrNull>(){}[0]
@@ -44,6 +57,16 @@ abstract interface io.github.androidpoet.supabase.client/SupabaseClient : kotlin
     abstract suspend fun put(kotlin/String, kotlin/String? = ..., kotlin.collections/Map<kotlin/String, kotlin/String> = ...): io.github.androidpoet.supabase.core.result/SupabaseResult<kotlin/String> // io.github.androidpoet.supabase.client/SupabaseClient.put|put(kotlin.String;kotlin.String?;kotlin.collections.Map<kotlin.String,kotlin.String>){}[0]
     abstract suspend fun putRaw(kotlin/String, kotlin/ByteArray, kotlin/String, kotlin.collections/Map<kotlin/String, kotlin/String> = ...): io.github.androidpoet.supabase.core.result/SupabaseResult<kotlin/String> // io.github.androidpoet.supabase.client/SupabaseClient.putRaw|putRaw(kotlin.String;kotlin.ByteArray;kotlin.String;kotlin.collections.Map<kotlin.String,kotlin.String>){}[0]
     abstract suspend fun rawRequest(io.github.androidpoet.supabase.client/SupabaseHttpMethod, kotlin/String, kotlin/ByteArray? = ..., kotlin/String? = ..., kotlin.collections/Map<kotlin/String, kotlin/String> = ...): io.github.androidpoet.supabase.core.result/SupabaseResult<io.github.androidpoet.supabase.client/SupabaseHttpResponse> // io.github.androidpoet.supabase.client/SupabaseClient.rawRequest|rawRequest(io.github.androidpoet.supabase.client.SupabaseHttpMethod;kotlin.String;kotlin.ByteArray?;kotlin.String?;kotlin.collections.Map<kotlin.String,kotlin.String>){}[0]
+}
+
+abstract interface io.github.androidpoet.supabase.client/SupabaseInterceptor { // io.github.androidpoet.supabase.client/SupabaseInterceptor|null[0]
+    open suspend fun onError(kotlin/String, kotlin/String, io.github.androidpoet.supabase.core.result/SupabaseError, kotlin/Long) // io.github.androidpoet.supabase.client/SupabaseInterceptor.onError|onError(kotlin.String;kotlin.String;io.github.androidpoet.supabase.core.result.SupabaseError;kotlin.Long){}[0]
+    open suspend fun onRequest(kotlin/String, kotlin/String) // io.github.androidpoet.supabase.client/SupabaseInterceptor.onRequest|onRequest(kotlin.String;kotlin.String){}[0]
+    open suspend fun onResponse(kotlin/String, kotlin/String, kotlin/Int, kotlin/Long) // io.github.androidpoet.supabase.client/SupabaseInterceptor.onResponse|onResponse(kotlin.String;kotlin.String;kotlin.Int;kotlin.Long){}[0]
+}
+
+abstract interface io.github.androidpoet.supabase.client/SupabaseLogger { // io.github.androidpoet.supabase.client/SupabaseLogger|null[0]
+    abstract fun log(io.github.androidpoet.supabase.client/SupabaseLogLevel, kotlin/String, kotlin/Throwable? = ...) // io.github.androidpoet.supabase.client/SupabaseLogger.log|log(io.github.androidpoet.supabase.client.SupabaseLogLevel;kotlin.String;kotlin.Throwable?){}[0]
 }
 
 sealed interface io.github.androidpoet.supabase.client.auth/AuthState { // io.github.androidpoet.supabase.client.auth/AuthState|null[0]
@@ -80,20 +103,66 @@ sealed interface io.github.androidpoet.supabase.client.auth/AuthState { // io.gi
     }
 }
 
+final class io.github.androidpoet.supabase.client/RetryConfig { // io.github.androidpoet.supabase.client/RetryConfig|null[0]
+    constructor <init>(kotlin/Int = ..., kotlin/Long = ..., kotlin/Long = ..., kotlin.collections/Set<kotlin/Int> = ...) // io.github.androidpoet.supabase.client/RetryConfig.<init>|<init>(kotlin.Int;kotlin.Long;kotlin.Long;kotlin.collections.Set<kotlin.Int>){}[0]
+
+    final val baseDelayMillis // io.github.androidpoet.supabase.client/RetryConfig.baseDelayMillis|{}baseDelayMillis[0]
+        final fun <get-baseDelayMillis>(): kotlin/Long // io.github.androidpoet.supabase.client/RetryConfig.baseDelayMillis.<get-baseDelayMillis>|<get-baseDelayMillis>(){}[0]
+    final val maxDelayMillis // io.github.androidpoet.supabase.client/RetryConfig.maxDelayMillis|{}maxDelayMillis[0]
+        final fun <get-maxDelayMillis>(): kotlin/Long // io.github.androidpoet.supabase.client/RetryConfig.maxDelayMillis.<get-maxDelayMillis>|<get-maxDelayMillis>(){}[0]
+    final val maxRetries // io.github.androidpoet.supabase.client/RetryConfig.maxRetries|{}maxRetries[0]
+        final fun <get-maxRetries>(): kotlin/Int // io.github.androidpoet.supabase.client/RetryConfig.maxRetries.<get-maxRetries>|<get-maxRetries>(){}[0]
+    final val retryableStatuses // io.github.androidpoet.supabase.client/RetryConfig.retryableStatuses|{}retryableStatuses[0]
+        final fun <get-retryableStatuses>(): kotlin.collections/Set<kotlin/Int> // io.github.androidpoet.supabase.client/RetryConfig.retryableStatuses.<get-retryableStatuses>|<get-retryableStatuses>(){}[0]
+
+    final fun backoffMillis(kotlin/Int): kotlin/Long // io.github.androidpoet.supabase.client/RetryConfig.backoffMillis|backoffMillis(kotlin.Int){}[0]
+    final fun component1(): kotlin/Int // io.github.androidpoet.supabase.client/RetryConfig.component1|component1(){}[0]
+    final fun component2(): kotlin/Long // io.github.androidpoet.supabase.client/RetryConfig.component2|component2(){}[0]
+    final fun component3(): kotlin/Long // io.github.androidpoet.supabase.client/RetryConfig.component3|component3(){}[0]
+    final fun component4(): kotlin.collections/Set<kotlin/Int> // io.github.androidpoet.supabase.client/RetryConfig.component4|component4(){}[0]
+    final fun copy(kotlin/Int = ..., kotlin/Long = ..., kotlin/Long = ..., kotlin.collections/Set<kotlin/Int> = ...): io.github.androidpoet.supabase.client/RetryConfig // io.github.androidpoet.supabase.client/RetryConfig.copy|copy(kotlin.Int;kotlin.Long;kotlin.Long;kotlin.collections.Set<kotlin.Int>){}[0]
+    final fun equals(kotlin/Any?): kotlin/Boolean // io.github.androidpoet.supabase.client/RetryConfig.equals|equals(kotlin.Any?){}[0]
+    final fun hashCode(): kotlin/Int // io.github.androidpoet.supabase.client/RetryConfig.hashCode|hashCode(){}[0]
+    final fun toString(): kotlin/String // io.github.androidpoet.supabase.client/RetryConfig.toString|toString(){}[0]
+
+    final object Companion { // io.github.androidpoet.supabase.client/RetryConfig.Companion|null[0]
+        final const val DEFAULT_BASE_DELAY_MILLIS // io.github.androidpoet.supabase.client/RetryConfig.Companion.DEFAULT_BASE_DELAY_MILLIS|{}DEFAULT_BASE_DELAY_MILLIS[0]
+            final fun <get-DEFAULT_BASE_DELAY_MILLIS>(): kotlin/Long // io.github.androidpoet.supabase.client/RetryConfig.Companion.DEFAULT_BASE_DELAY_MILLIS.<get-DEFAULT_BASE_DELAY_MILLIS>|<get-DEFAULT_BASE_DELAY_MILLIS>(){}[0]
+        final const val DEFAULT_MAX_DELAY_MILLIS // io.github.androidpoet.supabase.client/RetryConfig.Companion.DEFAULT_MAX_DELAY_MILLIS|{}DEFAULT_MAX_DELAY_MILLIS[0]
+            final fun <get-DEFAULT_MAX_DELAY_MILLIS>(): kotlin/Long // io.github.androidpoet.supabase.client/RetryConfig.Companion.DEFAULT_MAX_DELAY_MILLIS.<get-DEFAULT_MAX_DELAY_MILLIS>|<get-DEFAULT_MAX_DELAY_MILLIS>(){}[0]
+        final const val DEFAULT_MAX_RETRIES // io.github.androidpoet.supabase.client/RetryConfig.Companion.DEFAULT_MAX_RETRIES|{}DEFAULT_MAX_RETRIES[0]
+            final fun <get-DEFAULT_MAX_RETRIES>(): kotlin/Int // io.github.androidpoet.supabase.client/RetryConfig.Companion.DEFAULT_MAX_RETRIES.<get-DEFAULT_MAX_RETRIES>|<get-DEFAULT_MAX_RETRIES>(){}[0]
+
+        final val DEFAULT_RETRYABLE_STATUSES // io.github.androidpoet.supabase.client/RetryConfig.Companion.DEFAULT_RETRYABLE_STATUSES|{}DEFAULT_RETRYABLE_STATUSES[0]
+            final fun <get-DEFAULT_RETRYABLE_STATUSES>(): kotlin.collections/Set<kotlin/Int> // io.github.androidpoet.supabase.client/RetryConfig.Companion.DEFAULT_RETRYABLE_STATUSES.<get-DEFAULT_RETRYABLE_STATUSES>|<get-DEFAULT_RETRYABLE_STATUSES>(){}[0]
+        final val Default // io.github.androidpoet.supabase.client/RetryConfig.Companion.Default|{}Default[0]
+            final fun <get-Default>(): io.github.androidpoet.supabase.client/RetryConfig // io.github.androidpoet.supabase.client/RetryConfig.Companion.Default.<get-Default>|<get-Default>(){}[0]
+    }
+}
+
 final class io.github.androidpoet.supabase.client/SupabaseConfig { // io.github.androidpoet.supabase.client/SupabaseConfig|null[0]
-    constructor <init>(kotlin/Boolean, io.ktor.client.plugins.logging/LogLevel, kotlin.collections/Map<kotlin/String, kotlin/String>) // io.github.androidpoet.supabase.client/SupabaseConfig.<init>|<init>(kotlin.Boolean;io.ktor.client.plugins.logging.LogLevel;kotlin.collections.Map<kotlin.String,kotlin.String>){}[0]
+    constructor <init>(kotlin/Boolean, io.ktor.client.plugins.logging/LogLevel, kotlin.collections/Map<kotlin/String, kotlin/String>, io.github.androidpoet.supabase.client/RetryConfig = ..., io.github.androidpoet.supabase.client/SupabaseLogger? = ..., io.github.androidpoet.supabase.client/SupabaseInterceptor? = ...) // io.github.androidpoet.supabase.client/SupabaseConfig.<init>|<init>(kotlin.Boolean;io.ktor.client.plugins.logging.LogLevel;kotlin.collections.Map<kotlin.String,kotlin.String>;io.github.androidpoet.supabase.client.RetryConfig;io.github.androidpoet.supabase.client.SupabaseLogger?;io.github.androidpoet.supabase.client.SupabaseInterceptor?){}[0]
 
     final val headers // io.github.androidpoet.supabase.client/SupabaseConfig.headers|{}headers[0]
         final fun <get-headers>(): kotlin.collections/Map<kotlin/String, kotlin/String> // io.github.androidpoet.supabase.client/SupabaseConfig.headers.<get-headers>|<get-headers>(){}[0]
+    final val interceptor // io.github.androidpoet.supabase.client/SupabaseConfig.interceptor|{}interceptor[0]
+        final fun <get-interceptor>(): io.github.androidpoet.supabase.client/SupabaseInterceptor? // io.github.androidpoet.supabase.client/SupabaseConfig.interceptor.<get-interceptor>|<get-interceptor>(){}[0]
     final val logLevel // io.github.androidpoet.supabase.client/SupabaseConfig.logLevel|{}logLevel[0]
         final fun <get-logLevel>(): io.ktor.client.plugins.logging/LogLevel // io.github.androidpoet.supabase.client/SupabaseConfig.logLevel.<get-logLevel>|<get-logLevel>(){}[0]
+    final val logger // io.github.androidpoet.supabase.client/SupabaseConfig.logger|{}logger[0]
+        final fun <get-logger>(): io.github.androidpoet.supabase.client/SupabaseLogger? // io.github.androidpoet.supabase.client/SupabaseConfig.logger.<get-logger>|<get-logger>(){}[0]
     final val logging // io.github.androidpoet.supabase.client/SupabaseConfig.logging|{}logging[0]
         final fun <get-logging>(): kotlin/Boolean // io.github.androidpoet.supabase.client/SupabaseConfig.logging.<get-logging>|<get-logging>(){}[0]
+    final val retry // io.github.androidpoet.supabase.client/SupabaseConfig.retry|{}retry[0]
+        final fun <get-retry>(): io.github.androidpoet.supabase.client/RetryConfig // io.github.androidpoet.supabase.client/SupabaseConfig.retry.<get-retry>|<get-retry>(){}[0]
 
     final fun component1(): kotlin/Boolean // io.github.androidpoet.supabase.client/SupabaseConfig.component1|component1(){}[0]
     final fun component2(): io.ktor.client.plugins.logging/LogLevel // io.github.androidpoet.supabase.client/SupabaseConfig.component2|component2(){}[0]
     final fun component3(): kotlin.collections/Map<kotlin/String, kotlin/String> // io.github.androidpoet.supabase.client/SupabaseConfig.component3|component3(){}[0]
-    final fun copy(kotlin/Boolean = ..., io.ktor.client.plugins.logging/LogLevel = ..., kotlin.collections/Map<kotlin/String, kotlin/String> = ...): io.github.androidpoet.supabase.client/SupabaseConfig // io.github.androidpoet.supabase.client/SupabaseConfig.copy|copy(kotlin.Boolean;io.ktor.client.plugins.logging.LogLevel;kotlin.collections.Map<kotlin.String,kotlin.String>){}[0]
+    final fun component4(): io.github.androidpoet.supabase.client/RetryConfig // io.github.androidpoet.supabase.client/SupabaseConfig.component4|component4(){}[0]
+    final fun component5(): io.github.androidpoet.supabase.client/SupabaseLogger? // io.github.androidpoet.supabase.client/SupabaseConfig.component5|component5(){}[0]
+    final fun component6(): io.github.androidpoet.supabase.client/SupabaseInterceptor? // io.github.androidpoet.supabase.client/SupabaseConfig.component6|component6(){}[0]
+    final fun copy(kotlin/Boolean = ..., io.ktor.client.plugins.logging/LogLevel = ..., kotlin.collections/Map<kotlin/String, kotlin/String> = ..., io.github.androidpoet.supabase.client/RetryConfig = ..., io.github.androidpoet.supabase.client/SupabaseLogger? = ..., io.github.androidpoet.supabase.client/SupabaseInterceptor? = ...): io.github.androidpoet.supabase.client/SupabaseConfig // io.github.androidpoet.supabase.client/SupabaseConfig.copy|copy(kotlin.Boolean;io.ktor.client.plugins.logging.LogLevel;kotlin.collections.Map<kotlin.String,kotlin.String>;io.github.androidpoet.supabase.client.RetryConfig;io.github.androidpoet.supabase.client.SupabaseLogger?;io.github.androidpoet.supabase.client.SupabaseInterceptor?){}[0]
     final fun equals(kotlin/Any?): kotlin/Boolean // io.github.androidpoet.supabase.client/SupabaseConfig.equals|equals(kotlin.Any?){}[0]
     final fun hashCode(): kotlin/Int // io.github.androidpoet.supabase.client/SupabaseConfig.hashCode|hashCode(){}[0]
     final fun toString(): kotlin/String // io.github.androidpoet.supabase.client/SupabaseConfig.toString|toString(){}[0]
@@ -105,12 +174,21 @@ final class io.github.androidpoet.supabase.client/SupabaseConfigBuilder { // io.
     final val headers // io.github.androidpoet.supabase.client/SupabaseConfigBuilder.headers|{}headers[0]
         final fun <get-headers>(): kotlin.collections/MutableMap<kotlin/String, kotlin/String> // io.github.androidpoet.supabase.client/SupabaseConfigBuilder.headers.<get-headers>|<get-headers>(){}[0]
 
+    final var interceptor // io.github.androidpoet.supabase.client/SupabaseConfigBuilder.interceptor|{}interceptor[0]
+        final fun <get-interceptor>(): io.github.androidpoet.supabase.client/SupabaseInterceptor? // io.github.androidpoet.supabase.client/SupabaseConfigBuilder.interceptor.<get-interceptor>|<get-interceptor>(){}[0]
+        final fun <set-interceptor>(io.github.androidpoet.supabase.client/SupabaseInterceptor?) // io.github.androidpoet.supabase.client/SupabaseConfigBuilder.interceptor.<set-interceptor>|<set-interceptor>(io.github.androidpoet.supabase.client.SupabaseInterceptor?){}[0]
     final var logLevel // io.github.androidpoet.supabase.client/SupabaseConfigBuilder.logLevel|{}logLevel[0]
         final fun <get-logLevel>(): io.ktor.client.plugins.logging/LogLevel // io.github.androidpoet.supabase.client/SupabaseConfigBuilder.logLevel.<get-logLevel>|<get-logLevel>(){}[0]
         final fun <set-logLevel>(io.ktor.client.plugins.logging/LogLevel) // io.github.androidpoet.supabase.client/SupabaseConfigBuilder.logLevel.<set-logLevel>|<set-logLevel>(io.ktor.client.plugins.logging.LogLevel){}[0]
+    final var logger // io.github.androidpoet.supabase.client/SupabaseConfigBuilder.logger|{}logger[0]
+        final fun <get-logger>(): io.github.androidpoet.supabase.client/SupabaseLogger? // io.github.androidpoet.supabase.client/SupabaseConfigBuilder.logger.<get-logger>|<get-logger>(){}[0]
+        final fun <set-logger>(io.github.androidpoet.supabase.client/SupabaseLogger?) // io.github.androidpoet.supabase.client/SupabaseConfigBuilder.logger.<set-logger>|<set-logger>(io.github.androidpoet.supabase.client.SupabaseLogger?){}[0]
     final var logging // io.github.androidpoet.supabase.client/SupabaseConfigBuilder.logging|{}logging[0]
         final fun <get-logging>(): kotlin/Boolean // io.github.androidpoet.supabase.client/SupabaseConfigBuilder.logging.<get-logging>|<get-logging>(){}[0]
         final fun <set-logging>(kotlin/Boolean) // io.github.androidpoet.supabase.client/SupabaseConfigBuilder.logging.<set-logging>|<set-logging>(kotlin.Boolean){}[0]
+    final var retry // io.github.androidpoet.supabase.client/SupabaseConfigBuilder.retry|{}retry[0]
+        final fun <get-retry>(): io.github.androidpoet.supabase.client/RetryConfig // io.github.androidpoet.supabase.client/SupabaseConfigBuilder.retry.<get-retry>|<get-retry>(){}[0]
+        final fun <set-retry>(io.github.androidpoet.supabase.client/RetryConfig) // io.github.androidpoet.supabase.client/SupabaseConfigBuilder.retry.<set-retry>|<set-retry>(io.github.androidpoet.supabase.client.RetryConfig){}[0]
 }
 
 final class io.github.androidpoet.supabase.client/SupabaseHttpResponse { // io.github.androidpoet.supabase.client/SupabaseHttpResponse|null[0]

--- a/supabase-client/detekt-baseline.xml
+++ b/supabase-client/detekt-baseline.xml
@@ -2,11 +2,11 @@
 <SmellBaseline>
   <ManuallySuppressedIssues/>
   <CurrentIssues>
-    <ID>ComplexCondition:HttpTransport.kt$HttpTransport$retryEnabled &amp;&amp; retryableMethod &amp;&amp; statusCode.isRetryableStatus() &amp;&amp; attempt &lt; DEFAULT_MAX_RETRIES</ID>
+    <ID>ComplexCondition:HttpTransport.kt$HttpTransport$retryEnabled &amp;&amp; retryableMethod &amp;&amp; statusCode in retry.retryableStatuses &amp;&amp; attempt &lt; retry.maxRetries</ID>
     <ID>InstanceOfCheckForException:HttpTransport.kt$HttpTransport$e is CancellationException</ID>
     <ID>LoopWithTooManyJumpStatements:HttpTransport.kt$HttpTransport$while</ID>
-    <ID>NestedBlockDepth:HttpTransport.kt$HttpTransport$private suspend inline fun execute( retryEnabled: Boolean = false, retryableMethod: Boolean = false, crossinline request: suspend (attempt: Int) -> io.ktor.client.statement.HttpResponse, ): SupabaseResult&lt;String></ID>
-    <ID>ThrowsCount:HttpTransport.kt$HttpTransport$private suspend inline fun execute( retryEnabled: Boolean = false, retryableMethod: Boolean = false, crossinline request: suspend (attempt: Int) -> io.ktor.client.statement.HttpResponse, ): SupabaseResult&lt;String></ID>
+    <ID>NestedBlockDepth:HttpTransport.kt$HttpTransport$private suspend inline fun execute( method: String, url: String, retryEnabled: Boolean = false, retryableMethod: Boolean = false, crossinline request: suspend (attempt: Int) -> io.ktor.client.statement.HttpResponse, ): SupabaseResult&lt;String></ID>
+    <ID>ThrowsCount:HttpTransport.kt$HttpTransport$private suspend inline fun execute( method: String, url: String, retryEnabled: Boolean = false, retryableMethod: Boolean = false, crossinline request: suspend (attempt: Int) -> io.ktor.client.statement.HttpResponse, ): SupabaseResult&lt;String></ID>
     <ID>UnusedPrivateProperty:HttpTransport.kt$HttpTransport$private val projectUrl: String</ID>
   </CurrentIssues>
 </SmellBaseline>

--- a/supabase-client/src/commonMain/kotlin/io/github/androidpoet/supabase/client/RetryConfig.kt
+++ b/supabase-client/src/commonMain/kotlin/io/github/androidpoet/supabase/client/RetryConfig.kt
@@ -1,0 +1,51 @@
+package io.github.androidpoet.supabase.client
+
+/**
+ * Tunable retry policy for transient request failures.
+ *
+ * Retries are still opt-in per call (e.g. PostgREST `select` with `retry = true`,
+ * which is safe for idempotent reads); this config controls *how* a retried call
+ * backs off and which statuses count as transient. A `Retry-After` response
+ * header always takes precedence over the computed backoff.
+ *
+ * Backoff is exponential: `min(maxDelayMillis, baseDelayMillis shl attempt)`.
+ */
+public data class RetryConfig(
+    /** Maximum retry attempts after the initial try (0 disables retries). */
+    val maxRetries: Int = DEFAULT_MAX_RETRIES,
+    /** Base backoff for the first retry; doubles each subsequent attempt. */
+    val baseDelayMillis: Long = DEFAULT_BASE_DELAY_MILLIS,
+    /** Upper bound on a single backoff delay. */
+    val maxDelayMillis: Long = DEFAULT_MAX_DELAY_MILLIS,
+    /** HTTP status codes treated as transient and therefore retryable. */
+    val retryableStatuses: Set<Int> = DEFAULT_RETRYABLE_STATUSES,
+) {
+    init {
+        require(maxRetries >= 0) { "maxRetries must be >= 0 (got $maxRetries)" }
+        require(baseDelayMillis >= 0) { "baseDelayMillis must be >= 0 (got $baseDelayMillis)" }
+        require(maxDelayMillis >= baseDelayMillis) {
+            "maxDelayMillis ($maxDelayMillis) must be >= baseDelayMillis ($baseDelayMillis)"
+        }
+    }
+
+    /** Backoff delay (ms) before the given zero-based retry [attempt]. */
+    public fun backoffMillis(attempt: Int): Long {
+        // shl can overflow for large attempts; clamp the shift then the result.
+        val shift = attempt.coerceIn(0, MAX_SHIFT)
+        val raw = baseDelayMillis shl shift
+        return if (raw < 0) maxDelayMillis else raw.coerceAtMost(maxDelayMillis)
+    }
+
+    public companion object {
+        public const val DEFAULT_MAX_RETRIES: Int = 3
+        public const val DEFAULT_BASE_DELAY_MILLIS: Long = 1_000
+        public const val DEFAULT_MAX_DELAY_MILLIS: Long = 30_000
+        private const val MAX_SHIFT: Int = 16
+
+        /** 429 + the 5xx codes Supabase services return for transient failures. */
+        public val DEFAULT_RETRYABLE_STATUSES: Set<Int> = setOf(429, 500, 502, 503, 504, 520)
+
+        /** Default policy: 3 retries, 1s base, 30s cap. */
+        public val Default: RetryConfig = RetryConfig()
+    }
+}

--- a/supabase-client/src/commonMain/kotlin/io/github/androidpoet/supabase/client/SupabaseConfig.kt
+++ b/supabase-client/src/commonMain/kotlin/io/github/androidpoet/supabase/client/SupabaseConfig.kt
@@ -10,11 +10,23 @@ public class SupabaseConfigBuilder {
     public var logLevel: LogLevel = LogLevel.NONE
     public val headers: MutableMap<String, String> = mutableMapOf()
 
+    /** Retry policy for transient failures. See [RetryConfig]. */
+    public var retry: RetryConfig = RetryConfig.Default
+
+    /** Optional sink for HTTP wire logs (routes Ktor logging into your framework). */
+    public var logger: SupabaseLogger? = null
+
+    /** Optional observation hooks fired around every request. */
+    public var interceptor: SupabaseInterceptor? = null
+
     internal fun build(): SupabaseConfig =
         SupabaseConfig(
             logging = logging,
             logLevel = logLevel,
             headers = headers.toMap(),
+            retry = retry,
+            logger = logger,
+            interceptor = interceptor,
         )
 }
 
@@ -22,4 +34,7 @@ public data class SupabaseConfig(
     val logging: Boolean,
     val logLevel: LogLevel,
     val headers: Map<String, String>,
+    val retry: RetryConfig = RetryConfig.Default,
+    val logger: SupabaseLogger? = null,
+    val interceptor: SupabaseInterceptor? = null,
 )

--- a/supabase-client/src/commonMain/kotlin/io/github/androidpoet/supabase/client/SupabaseInterceptor.kt
+++ b/supabase-client/src/commonMain/kotlin/io/github/androidpoet/supabase/client/SupabaseInterceptor.kt
@@ -1,0 +1,40 @@
+package io.github.androidpoet.supabase.client
+
+import io.github.androidpoet.supabase.core.result.SupabaseError
+
+/**
+ * Observation hooks fired around every HTTP request the SDK makes.
+ *
+ * Use it for telemetry, tracing, and metrics — emit spans, record latency
+ * histograms, count error categories, attach correlation IDs. All methods are
+ * `suspend` (so they may do async work) and default to no-ops, so implement only
+ * what you need. Hooks are observational: they must not throw and cannot alter
+ * the request or its result.
+ *
+ * Exactly one terminal hook fires per call: [onResponse] when an HTTP response
+ * is received (any status, success or error), or [onError] when no response was
+ * obtained (offline, DNS/TLS failure, timeout, cancellation-free exception).
+ */
+public interface SupabaseInterceptor {
+    /** Fired before a request is sent. */
+    public suspend fun onRequest(
+        method: String,
+        url: String,
+    ) {}
+
+    /** Fired when an HTTP response is received, regardless of status. */
+    public suspend fun onResponse(
+        method: String,
+        url: String,
+        statusCode: Int,
+        durationMillis: Long,
+    ) {}
+
+    /** Fired when the request failed without a response (network/transport error). */
+    public suspend fun onError(
+        method: String,
+        url: String,
+        error: SupabaseError,
+        durationMillis: Long,
+    ) {}
+}

--- a/supabase-client/src/commonMain/kotlin/io/github/androidpoet/supabase/client/SupabaseLogger.kt
+++ b/supabase-client/src/commonMain/kotlin/io/github/androidpoet/supabase/client/SupabaseLogger.kt
@@ -1,0 +1,20 @@
+package io.github.androidpoet.supabase.client
+
+/** Severity for [SupabaseLogger] messages. */
+public enum class SupabaseLogLevel { DEBUG, INFO, WARN, ERROR }
+
+/**
+ * Pluggable sink for the SDK's diagnostic output.
+ *
+ * Provide one via `SupabaseConfigBuilder.logger` to route HTTP wire logs into
+ * your app's logging framework (Timber, OSLog, SLF4J, …) instead of relying on
+ * Ktor's default `println`-style logger. Verbosity is still governed by
+ * `logLevel`; this only changes where the lines go.
+ */
+public interface SupabaseLogger {
+    public fun log(
+        level: SupabaseLogLevel,
+        message: String,
+        throwable: Throwable? = null,
+    )
+}

--- a/supabase-client/src/commonMain/kotlin/io/github/androidpoet/supabase/client/transport/HttpTransport.kt
+++ b/supabase-client/src/commonMain/kotlin/io/github/androidpoet/supabase/client/transport/HttpTransport.kt
@@ -1,6 +1,7 @@
 package io.github.androidpoet.supabase.client.transport
 import io.github.androidpoet.supabase.client.SupabaseConfig
 import io.github.androidpoet.supabase.client.SupabaseHttpResponse
+import io.github.androidpoet.supabase.client.SupabaseLogLevel
 import io.github.androidpoet.supabase.core.result.SupabaseError
 import io.github.androidpoet.supabase.core.result.SupabaseErrorCodes
 import io.github.androidpoet.supabase.core.result.SupabaseResult
@@ -32,11 +33,12 @@ import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.contentOrNull
 import kotlin.concurrent.Volatile
+import kotlin.time.TimeSource
+import io.ktor.client.plugins.logging.Logger as KtorLogger
 
 private const val CLIENT_VERSION = "supabase-kmp/0.1.0"
 private const val INTERNAL_RETRY_HEADER = "X-Supabase-Kmp-Retry"
 private const val RETRY_COUNT_HEADER = "X-Retry-Count"
-private const val DEFAULT_MAX_RETRIES = 3
 
 internal class HttpTransport(
     private val config: SupabaseConfig,
@@ -51,6 +53,7 @@ internal class HttpTransport(
     private var accessToken: String? = null
     internal val accessTokenOrNull: String? get() = accessToken
     private val errorJson = Json { ignoreUnknownKeys = true }
+    private val retry = config.retry
     internal val httpClient: HttpClient =
         HttpClient(engineFactory) {
             install(ContentNegotiation) {
@@ -65,6 +68,16 @@ internal class HttpTransport(
             if (config.logging) {
                 install(Logging) {
                     level = config.logLevel
+                    // Route wire logs into the caller's framework when a logger is supplied;
+                    // otherwise fall back to Ktor's default sink.
+                    config.logger?.let { sink ->
+                        logger =
+                            object : KtorLogger {
+                                override fun log(message: String) {
+                                    sink.log(SupabaseLogLevel.DEBUG, message)
+                                }
+                            }
+                    }
                     // Never let credentials reach the log sink. This covers the anon/service
                     // apikey header and every Bearer token (including the auth-admin
                     // service-role key, which flows through this same client).
@@ -88,7 +101,7 @@ internal class HttpTransport(
     ): SupabaseResult<String> {
         val retryEnabled = headers[INTERNAL_RETRY_HEADER]?.toBooleanStrictOrNull() ?: false
         val outgoingHeaders = headers - INTERNAL_RETRY_HEADER
-        return execute(retryEnabled = retryEnabled, retryableMethod = true) { attempt ->
+        return execute(method = "GET", url = url, retryEnabled = retryEnabled, retryableMethod = true) { attempt ->
             httpClient.get(url) {
                 queryParams.forEach { (k, v) -> this.url.parameters.append(k, v) }
                 outgoingHeaders.forEach { (k, v) -> header(k, v) }
@@ -106,7 +119,7 @@ internal class HttpTransport(
         headers: Map<String, String> = emptyMap(),
     ): SupabaseResult<String> {
         val outgoingHeaders = headers - INTERNAL_RETRY_HEADER
-        return execute {
+        return execute(method = "POST", url = url) {
             httpClient.post(url) {
                 contentType(ContentType.Application.Json)
                 body?.let { setBody(it) }
@@ -124,7 +137,7 @@ internal class HttpTransport(
         headers: Map<String, String> = emptyMap(),
     ): SupabaseResult<String> {
         val outgoingHeaders = headers - INTERNAL_RETRY_HEADER
-        return execute {
+        return execute(method = "PUT", url = url) {
             httpClient.put(url) {
                 contentType(ContentType.Application.Json)
                 body?.let { setBody(it) }
@@ -142,7 +155,7 @@ internal class HttpTransport(
         headers: Map<String, String> = emptyMap(),
     ): SupabaseResult<String> {
         val outgoingHeaders = headers - INTERNAL_RETRY_HEADER
-        return execute {
+        return execute(method = "PATCH", url = url) {
             httpClient.patch(url) {
                 contentType(ContentType.Application.Json)
                 body?.let { setBody(it) }
@@ -160,7 +173,7 @@ internal class HttpTransport(
         headers: Map<String, String> = emptyMap(),
     ): SupabaseResult<String> {
         val outgoingHeaders = headers - INTERNAL_RETRY_HEADER
-        return execute {
+        return execute(method = "DELETE", url = url) {
             httpClient.delete(url) {
                 if (body != null) {
                     contentType(ContentType.Application.Json)
@@ -181,7 +194,7 @@ internal class HttpTransport(
         headers: Map<String, String> = emptyMap(),
     ): SupabaseResult<String> {
         val outgoingHeaders = headers - INTERNAL_RETRY_HEADER
-        return execute {
+        return execute(method = "POST", url = url) {
             httpClient.post(url) {
                 contentType(ContentType.parse(contentType))
                 setBody(body)
@@ -200,7 +213,7 @@ internal class HttpTransport(
         headers: Map<String, String> = emptyMap(),
     ): SupabaseResult<String> {
         val outgoingHeaders = headers - INTERNAL_RETRY_HEADER
-        return execute {
+        return execute(method = "PUT", url = url) {
             httpClient.put(url) {
                 contentType(ContentType.parse(contentType))
                 setBody(body)
@@ -218,8 +231,10 @@ internal class HttpTransport(
         body: ByteArray?,
         contentType: String?,
         requestHeaders: Map<String, String>,
-    ): SupabaseResult<SupabaseHttpResponse> =
-        try {
+    ): SupabaseResult<SupabaseHttpResponse> {
+        val mark = TimeSource.Monotonic.markNow()
+        config.interceptor?.onRequest(method, url)
+        return try {
             val response =
                 httpClient.request(url) {
                     this.method = HttpMethod.parse(method)
@@ -231,6 +246,7 @@ internal class HttpTransport(
                     body?.let { setBody(it) }
                 }
             val bytes = response.readRawBytes()
+            config.interceptor?.onResponse(method, url, response.status.value, mark.elapsedNow().inWholeMilliseconds)
             if (response.status.isSuccess()) {
                 val flatHeaders = response.headers.entries().associate { (k, v) -> k to v.joinToString(",") }
                 SupabaseResult.Success(SupabaseHttpResponse(response.status.value, flatHeaders, bytes))
@@ -240,8 +256,11 @@ internal class HttpTransport(
             }
         } catch (e: Throwable) {
             if (e is CancellationException) throw e
-            SupabaseResult.Failure(networkError(throwable = e))
+            val error = networkError(throwable = e)
+            config.interceptor?.onError(method, url, error, mark.elapsedNow().inWholeMilliseconds)
+            SupabaseResult.Failure(error)
         }
+    }
 
     fun setAccessToken(token: String) {
         accessToken = token
@@ -256,20 +275,24 @@ internal class HttpTransport(
     }
 
     private suspend inline fun execute(
+        method: String,
+        url: String,
         retryEnabled: Boolean = false,
         retryableMethod: Boolean = false,
         crossinline request: suspend (attempt: Int) -> io.ktor.client.statement.HttpResponse,
     ): SupabaseResult<String> {
+        val mark = TimeSource.Monotonic.markNow()
+        config.interceptor?.onRequest(method, url)
         return try {
             var attempt = 0
-            while (attempt <= DEFAULT_MAX_RETRIES) {
+            while (attempt <= retry.maxRetries) {
                 val response =
                     try {
                         request(attempt)
                     } catch (e: Throwable) {
                         if (e is CancellationException) throw e
-                        if (retryEnabled && retryableMethod && attempt < DEFAULT_MAX_RETRIES) {
-                            delay(retryDelayMillis(attempt))
+                        if (retryEnabled && retryableMethod && attempt < retry.maxRetries) {
+                            delay(retry.backoffMillis(attempt))
                             attempt++
                             continue
                         }
@@ -278,21 +301,29 @@ internal class HttpTransport(
                 val text = response.bodyAsText()
                 val statusCode = response.status.value
                 if (response.status.isSuccess()) {
+                    config.interceptor?.onResponse(method, url, statusCode, mark.elapsedNow().inWholeMilliseconds)
                     return SupabaseResult.Success(text)
                 }
-                if (retryEnabled && retryableMethod && statusCode.isRetryableStatus() && attempt < DEFAULT_MAX_RETRIES) {
+                if (retryEnabled && retryableMethod &&
+                    statusCode in retry.retryableStatuses && attempt < retry.maxRetries
+                ) {
                     delay(response.retryDelayMillis(attempt))
                     attempt++
                     continue
                 }
                 val retryAfter = response.headers["Retry-After"]?.toLongOrNull()
                 val error = parseError(text, statusCode, retryAfter)
+                config.interceptor?.onResponse(method, url, statusCode, mark.elapsedNow().inWholeMilliseconds)
                 return SupabaseResult.Failure(error)
             }
-            SupabaseResult.Failure(networkError(message = "Retry attempts exhausted"))
+            val exhausted = networkError(message = "Retry attempts exhausted")
+            config.interceptor?.onError(method, url, exhausted, mark.elapsedNow().inWholeMilliseconds)
+            SupabaseResult.Failure(exhausted)
         } catch (e: Throwable) {
             if (e is CancellationException) throw e
-            SupabaseResult.Failure(networkError(throwable = e))
+            val error = networkError(throwable = e)
+            config.interceptor?.onError(method, url, error, mark.elapsedNow().inWholeMilliseconds)
+            SupabaseResult.Failure(error)
         }
     }
 
@@ -317,22 +348,15 @@ internal class HttpTransport(
         )
     }
 
+    // A Retry-After header (seconds) wins over the configured exponential backoff.
     private fun io.ktor.client.statement.HttpResponse.retryDelayMillis(attempt: Int): Long {
         val retryAfterSeconds = headers["Retry-After"]?.toLongOrNull()
-        return if (retryAfterSeconds != null) retryAfterSeconds.coerceAtLeast(0) * 1_000 else retryDelayMillis(attempt)
+        return if (retryAfterSeconds != null) {
+            retryAfterSeconds.coerceAtLeast(0) * 1_000
+        } else {
+            retry.backoffMillis(attempt)
+        }
     }
-
-    private fun retryDelayMillis(attempt: Int): Long =
-        1_000L shl attempt
-
-    private fun Int.isRetryableStatus(): Boolean =
-        this == 429 ||
-            // Too Many Requests — Retry-After is honored above
-            this == 500 ||
-            this == 502 ||
-            this == 503 ||
-            this == 504 ||
-            this == 520
 
     // Supabase services return heterogeneous error bodies: PostgREST uses
     // {code,message,details,hint}; GoTrue uses {error_code,msg} or

--- a/supabase-client/src/commonMain/kotlin/io/github/androidpoet/supabase/client/transport/HttpTransport.kt
+++ b/supabase-client/src/commonMain/kotlin/io/github/androidpoet/supabase/client/transport/HttpTransport.kt
@@ -304,8 +304,10 @@ internal class HttpTransport(
                     config.interceptor?.onResponse(method, url, statusCode, mark.elapsedNow().inWholeMilliseconds)
                     return SupabaseResult.Success(text)
                 }
-                if (retryEnabled && retryableMethod &&
-                    statusCode in retry.retryableStatuses && attempt < retry.maxRetries
+                if (retryEnabled &&
+                    retryableMethod &&
+                    statusCode in retry.retryableStatuses &&
+                    attempt < retry.maxRetries
                 ) {
                     delay(response.retryDelayMillis(attempt))
                     attempt++

--- a/supabase-client/src/commonTest/kotlin/io/github/androidpoet/supabase/client/RetryConfigTest.kt
+++ b/supabase-client/src/commonTest/kotlin/io/github/androidpoet/supabase/client/RetryConfigTest.kt
@@ -1,0 +1,52 @@
+package io.github.androidpoet.supabase.client
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
+
+class RetryConfigTest {
+    @Test
+    fun test_backoff_isExponentialFromBase() {
+        val config = RetryConfig(baseDelayMillis = 1_000, maxDelayMillis = 100_000)
+        assertEquals(1_000, config.backoffMillis(0))
+        assertEquals(2_000, config.backoffMillis(1))
+        assertEquals(4_000, config.backoffMillis(2))
+        assertEquals(8_000, config.backoffMillis(3))
+    }
+
+    @Test
+    fun test_backoff_isCappedAtMaxDelay() {
+        val config = RetryConfig(baseDelayMillis = 1_000, maxDelayMillis = 3_000)
+        assertEquals(1_000, config.backoffMillis(0))
+        assertEquals(2_000, config.backoffMillis(1))
+        assertEquals(3_000, config.backoffMillis(2))
+        assertEquals(3_000, config.backoffMillis(5))
+    }
+
+    @Test
+    fun test_backoff_doesNotOverflowForLargeAttempts() {
+        val config = RetryConfig(baseDelayMillis = 1_000, maxDelayMillis = 30_000)
+        assertEquals(30_000, config.backoffMillis(1_000))
+    }
+
+    @Test
+    fun test_defaults_matchDocumentedValues() {
+        val config = RetryConfig.Default
+        assertEquals(3, config.maxRetries)
+        assertEquals(1_000, config.baseDelayMillis)
+        assertEquals(30_000, config.maxDelayMillis)
+        assertTrue(429 in config.retryableStatuses)
+        assertTrue(503 in config.retryableStatuses)
+        assertTrue(404 !in config.retryableStatuses)
+    }
+
+    @Test
+    fun test_init_rejectsInvalidValues() {
+        assertFailsWith<IllegalArgumentException> { RetryConfig(maxRetries = -1) }
+        assertFailsWith<IllegalArgumentException> { RetryConfig(baseDelayMillis = -1) }
+        assertFailsWith<IllegalArgumentException> {
+            RetryConfig(baseDelayMillis = 5_000, maxDelayMillis = 1_000)
+        }
+    }
+}

--- a/supabase-client/src/commonTest/kotlin/io/github/androidpoet/supabase/client/transport/HttpTransportObservabilityTest.kt
+++ b/supabase-client/src/commonTest/kotlin/io/github/androidpoet/supabase/client/transport/HttpTransportObservabilityTest.kt
@@ -1,0 +1,178 @@
+package io.github.androidpoet.supabase.client.transport
+
+import io.github.androidpoet.supabase.client.RetryConfig
+import io.github.androidpoet.supabase.client.SupabaseConfig
+import io.github.androidpoet.supabase.client.SupabaseInterceptor
+import io.github.androidpoet.supabase.client.SupabaseLogLevel
+import io.github.androidpoet.supabase.client.SupabaseLogger
+import io.github.androidpoet.supabase.core.result.SupabaseError
+import io.ktor.client.engine.mock.respond
+import io.ktor.client.engine.mock.respondError
+import io.ktor.client.plugins.logging.LogLevel
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.headersOf
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+private const val RETRY_HEADER = "X-Supabase-Kmp-Retry"
+
+private class RecordingInterceptor : SupabaseInterceptor {
+    val requests = mutableListOf<Pair<String, String>>()
+    val responses = mutableListOf<Triple<String, String, Int>>()
+    val errors = mutableListOf<Triple<String, String, SupabaseError>>()
+
+    override suspend fun onRequest(method: String, url: String) {
+        requests += method to url
+    }
+
+    override suspend fun onResponse(method: String, url: String, statusCode: Int, durationMillis: Long) {
+        assertTrue(durationMillis >= 0)
+        responses += Triple(method, url, statusCode)
+    }
+
+    override suspend fun onError(method: String, url: String, error: SupabaseError, durationMillis: Long) {
+        assertTrue(durationMillis >= 0)
+        errors += Triple(method, url, error)
+    }
+}
+
+private fun config(
+    retry: RetryConfig = RetryConfig.Default,
+    interceptor: SupabaseInterceptor? = null,
+    logger: SupabaseLogger? = null,
+    logging: Boolean = false,
+    logLevel: LogLevel = LogLevel.NONE,
+) = SupabaseConfig(
+    logging = logging,
+    logLevel = logLevel,
+    headers = emptyMap(),
+    retry = retry,
+    logger = logger,
+    interceptor = interceptor,
+)
+
+private fun transport(
+    config: SupabaseConfig,
+    handler: suspend io.ktor.client.engine.mock.MockRequestHandleScope.(
+        io.ktor.client.request.HttpRequestData,
+    ) -> io.ktor.client.request.HttpResponseData,
+) = HttpTransport(
+    config = config,
+    engineFactory = TestMockEngineFactory(handler),
+    projectUrl = "https://example.supabase.co",
+    apiKey = "anon",
+)
+
+class HttpTransportObservabilityTest {
+    @Test
+    fun test_interceptor_firesRequestAndResponseOnSuccess() =
+        runTest {
+            val spy = RecordingInterceptor()
+            val transport =
+                transport(config(interceptor = spy)) {
+                    respond("{}", HttpStatusCode.OK, headersOf(HttpHeaders.ContentType, "application/json"))
+                }
+
+            transport.get(url = "https://example.supabase.co/rest/v1/messages")
+
+            assertEquals(listOf("GET" to "https://example.supabase.co/rest/v1/messages"), spy.requests)
+            assertEquals(1, spy.responses.size)
+            assertEquals(200, spy.responses.single().third)
+            assertTrue(spy.errors.isEmpty())
+        }
+
+    @Test
+    fun test_interceptor_firesResponseOnHttpError() =
+        runTest {
+            val spy = RecordingInterceptor()
+            val transport =
+                transport(config(interceptor = spy)) {
+                    respondError(HttpStatusCode.NotFound)
+                }
+
+            transport.get(url = "https://example.supabase.co/rest/v1/missing")
+
+            assertEquals(404, spy.responses.single().third)
+            assertTrue(spy.errors.isEmpty(), "HTTP error is a response, not a transport error")
+        }
+
+    @Test
+    fun test_interceptor_firesErrorOnNetworkFailure() =
+        runTest {
+            val spy = RecordingInterceptor()
+            val transport =
+                transport(config(interceptor = spy)) {
+                    throw IllegalStateException("connection refused")
+                }
+
+            val result = transport.get(url = "https://example.supabase.co/rest/v1/messages")
+
+            assertTrue(result.isFailure)
+            assertEquals(1, spy.errors.size)
+            assertTrue(spy.responses.isEmpty())
+        }
+
+    @Test
+    fun test_retry_usesConfiguredRetryableStatusesAndSucceeds() =
+        runTest {
+            var calls = 0
+            val transport =
+                transport(config(retry = RetryConfig(maxRetries = 3, baseDelayMillis = 1, retryableStatuses = setOf(503)))) {
+                    calls++
+                    if (calls < 3) {
+                        respondError(HttpStatusCode.ServiceUnavailable)
+                    } else {
+                        respond("{}", HttpStatusCode.OK, headersOf(HttpHeaders.ContentType, "application/json"))
+                    }
+                }
+
+            val result = transport.get(url = "https://example.supabase.co/rest/v1/x", headers = mapOf(RETRY_HEADER to "true"))
+
+            assertTrue(result.isSuccess)
+            assertEquals(3, calls, "expected 2 retries before success")
+        }
+
+    @Test
+    fun test_retry_doesNotRetryStatusOutsideConfiguredSet() =
+        runTest {
+            var calls = 0
+            val transport =
+                transport(config(retry = RetryConfig(maxRetries = 3, baseDelayMillis = 1, retryableStatuses = setOf(503)))) {
+                    calls++
+                    respondError(HttpStatusCode.InternalServerError)
+                }
+
+            val result =
+                transport.get(
+                    url = "https://example.supabase.co/rest/v1/x",
+                    headers = mapOf(RETRY_HEADER to "true"),
+                )
+
+            assertTrue(result.isFailure)
+            assertEquals(1, calls, "500 is not in the configured retryable set, so no retry")
+            assertEquals(500, result.errorOrNull()?.httpStatus)
+        }
+
+    @Test
+    fun test_logger_receivesWireLogs() =
+        runTest {
+            val lines = mutableListOf<String>()
+            val sink =
+                object : SupabaseLogger {
+                    override fun log(level: SupabaseLogLevel, message: String, throwable: Throwable?) {
+                        lines += message
+                    }
+                }
+            val transport =
+                transport(config(logger = sink, logging = true, logLevel = LogLevel.ALL)) {
+                    respond("{}", HttpStatusCode.OK, headersOf(HttpHeaders.ContentType, "application/json"))
+                }
+
+            transport.get(url = "https://example.supabase.co/rest/v1/messages")
+
+            assertTrue(lines.isNotEmpty(), "expected wire logs routed to the custom sink")
+        }
+}


### PR DESCRIPTION
## Configurable retry + observability hooks

Adds the operability layer production teams need. All additive — existing `SupabaseConfig(...)` callers keep working (new fields default).

### Configurable retry — `RetryConfig`
- `SupabaseConfigBuilder.retry: RetryConfig` with `maxRetries`, `baseDelayMillis`, `maxDelayMillis`, and a `retryableStatuses` set.
- Replaces the hardcoded transport constants (`DEFAULT_MAX_RETRIES`, fixed `1s shl attempt`, fixed status set). Backoff is `min(maxDelay, base shl attempt)` with overflow clamping; a `Retry-After` header still takes precedence. Retries remain opt-in per call (e.g. idempotent `select`).

### Observability hooks
- `SupabaseConfig.logger: SupabaseLogger?` — routes Ktor wire logs into the caller's logging framework (still credential-sanitized).
- `SupabaseConfig.interceptor: SupabaseInterceptor?` — `onRequest` / `onResponse(statusCode, durationMillis)` / `onError(error, durationMillis)`, fired around every request (incl. `rawRequest`) for tracing/metrics. All `suspend` with default no-op bodies, so you implement only what you need. Exactly one terminal hook per call: `onResponse` for any HTTP response, `onError` for transport/network failures.

### Tests
- `RetryConfigTest` (backoff math, cap, overflow, validation, defaults).
- `HttpTransportObservabilityTest` (interceptor request/response/error firing; config-driven retryable-status behavior with retry counting; logger routing).

`jvmTest`, `koverVerify`, `detekt`, `spotlessCheck`, `apiCheck` green locally. `apiDump` regenerated (13 targets). Two pre-existing detekt baseline entries on `execute` refreshed for its new signature.
