### PR TITLE
docs: document 0.4.0 features + add Configuration page

### DIFF
--- a/website/pages/_meta.jsx
+++ b/website/pages/_meta.jsx
@@ -1,6 +1,7 @@
 export default {
   index: 'Introduction',
   'getting-started': 'Getting Started',
+  configuration: 'Configuration',
   'results-and-errors': 'Results & Errors',
   auth: 'Authentication',
   database: 'Database',

--- a/website/pages/configuration.mdx
+++ b/website/pages/configuration.mdx
@@ -1,0 +1,113 @@
+---
+title: Configuration
+---
+
+import { Callout } from 'nextra/components'
+
+# Configuration
+
+Every client is created from `Supabase.create`. The trailing `configure { }`
+lambda is a `SupabaseConfigBuilder` — it tunes logging, retries, custom headers,
+and observability hooks. All options have sensible defaults, so you only set what
+you need.
+
+```kotlin
+val client = Supabase.create(
+    projectUrl = "https://your-project.supabase.co",
+    apiKey = "your-anon-key",
+) {
+    logging = true
+    logLevel = LogLevel.HEADERS
+    headers["X-App-Version"] = "1.4.0"
+    retry = RetryConfig(maxRetries = 5)
+    logger = MyTimberLogger()
+    interceptor = MyTelemetryInterceptor()
+}
+```
+
+| Option | Type | Default | Purpose |
+| --- | --- | --- | --- |
+| `logging` | `Boolean` | `false` | Enable HTTP wire logging. |
+| `logLevel` | `LogLevel` | `NONE` | Ktor verbosity: `NONE`, `INFO`, `HEADERS`, `BODY`, `ALL`. |
+| `headers` | `MutableMap` | empty | Extra headers sent on every request. |
+| `retry` | `RetryConfig` | `RetryConfig.Default` | Backoff policy for transient failures. |
+| `logger` | `SupabaseLogger?` | `null` | Route wire logs into your logging framework. |
+| `interceptor` | `SupabaseInterceptor?` | `null` | Telemetry hooks around every request. |
+
+## Retries
+
+Retries are **opt-in per call** — read methods like PostgREST `select` default to
+`retry = true` because reads are idempotent; mutations don't retry unless you ask.
+`RetryConfig` controls *how* a retried call backs off and which statuses count as
+transient.
+
+```kotlin
+retry = RetryConfig(
+    maxRetries = 3,                                  // attempts after the initial try
+    baseDelayMillis = 1_000,                         // first backoff; doubles each retry
+    maxDelayMillis = 30_000,                         // cap on a single delay
+    retryableStatuses = setOf(429, 500, 502, 503, 504, 520),
+)
+```
+
+Backoff is exponential — `min(maxDelayMillis, baseDelayMillis shl attempt)` — so
+with the defaults a retried call waits ~1s, 2s, then 4s. A `Retry-After` response
+header always wins over the computed delay.
+
+<Callout type="info">
+  `RetryConfig.Default` is 3 retries, 1s base, 30s cap, retrying `429` and the
+  transient `5xx` codes. The constructor validates its inputs (non-negative
+  delays, `maxDelayMillis >= baseDelayMillis`).
+</Callout>
+
+## Logging
+
+Set `logging = true` and pick a `logLevel` to see requests on the console. To send
+those lines somewhere structured — Timber on Android, OSLog on iOS, SLF4J on the
+JVM — provide a `SupabaseLogger`. Verbosity is still governed by `logLevel`; the
+logger only changes *where* the lines go.
+
+```kotlin
+class TimberLogger : SupabaseLogger {
+    override fun log(level: SupabaseLogLevel, message: String, throwable: Throwable?) {
+        when (level) {
+            SupabaseLogLevel.DEBUG -> Timber.d(throwable, message)
+            SupabaseLogLevel.INFO  -> Timber.i(throwable, message)
+            SupabaseLogLevel.WARN  -> Timber.w(throwable, message)
+            SupabaseLogLevel.ERROR -> Timber.e(throwable, message)
+        }
+    }
+}
+```
+
+## Observability
+
+A `SupabaseInterceptor` gives you telemetry hooks around every request — emit
+spans, record latency histograms, count error categories, attach correlation IDs.
+All methods are `suspend` (so they may do async work) and default to no-ops, so
+you implement only what you need.
+
+```kotlin
+class TelemetryInterceptor : SupabaseInterceptor {
+    override suspend fun onRequest(method: String, url: String) {
+        tracer.startSpan("$method $url")
+    }
+
+    override suspend fun onResponse(method: String, url: String, statusCode: Int, durationMillis: Long) {
+        metrics.recordLatency(url, durationMillis, statusCode)
+    }
+
+    override suspend fun onError(method: String, url: String, error: SupabaseError, durationMillis: Long) {
+        metrics.countError(error.category)
+    }
+}
+```
+
+Exactly one terminal hook fires per call: `onResponse` when an HTTP response is
+received (**any** status — a `404` is a response, not an error), or `onError` when
+no response was obtained (offline, DNS/TLS failure, timeout).
+
+<Callout type="warning">
+  Hooks are observational — they must not throw, and they cannot alter the request
+  or its result. Keep them fast; they run on the request path.
+</Callout>

--- a/website/pages/database.mdx
+++ b/website/pages/database.mdx
@@ -37,7 +37,8 @@ val todos: SupabaseResult<List<Todo>> = database.selectTyped<Todo>(table = "todo
 | `select(table, …) { … }` | `String` (raw JSON) | escape hatch |
 
 `columns` accepts PostgREST projection syntax — `"*"`, `"id,title"`, or embedded
-relations like `"*,author(*)"`. All read methods accept an optional `schema`.
+relations like `"*,author(*)"`. All read methods accept an optional `schema`, and
+`geojson = true` returns PostGIS rows as a GeoJSON `FeatureCollection`.
 
 ## Insert, Update, Upsert, Delete
 

--- a/website/pages/getting-started.mdx
+++ b/website/pages/getting-started.mdx
@@ -13,7 +13,7 @@ version and the modules you need to your version catalog.
 
 ```toml filename="gradle/libs.versions.toml"
 [versions]
-supabase-kmp = "0.3.5"
+supabase-kmp = "0.4.0"
 
 [libraries]
 supabase-client = { module = "io.github.androidpoet:supabase-client", version.ref = "supabase-kmp" }
@@ -69,6 +69,9 @@ val functions = createFunctionsClient(client)
   `supabase-auth-admin` module uses the service-role key and is for trusted
   server-side contexts only.
 </Callout>
+
+The `configure { }` block tunes logging, retries, custom headers, and
+observability hooks. See [Configuration](/configuration) for the full surface.
 
 ## Next steps
 

--- a/website/pages/index.mdx
+++ b/website/pages/index.mdx
@@ -23,6 +23,7 @@ val session = auth.signInWithEmail("user@example.com", "secure-password")
 - **One codebase, every platform** — share auth, data and realtime logic across mobile, desktop and web.
 - **Local JWT verification** — `getClaims()` verifies asymmetric tokens on-device against the JWKS, no server round-trip.
 - **Native sign-in, your way** — optional Google & Apple modules built on a pluggable `NativeAuthProvider`; bring your own for anything else.
+- **Built for production** — configurable retry with exponential backoff, a `Network` error category for offline UI, and `suspend` observability hooks for tracing and metrics.
 - **Bring-your-own everything** — pluggable session storage, HTTP engine and crypto. Nothing heavy is bundled behind your back.
 
 ## Explore

--- a/website/pages/results-and-errors.mdx
+++ b/website/pages/results-and-errors.mdx
@@ -44,10 +44,22 @@ result
 | `map { value -> … }` | transform the success value |
 | `flatMap { value -> SupabaseResult<R> }` | chain another fallible call |
 | `mapError { error -> … }` | rewrite the error |
+| `flatMapError { error -> SupabaseResult<T> }` | recover via another fallible call |
 | `recover { error -> value }` | turn a failure into a success |
+| `validate(lazyError) { value -> Boolean }` | fail a success that breaks an invariant |
+| `zip(other) { a, b -> … }` | combine two results, short-circuiting on the first failure |
+
+```kotlin
+// Guard a success value, then combine two independent reads:
+val profile = database.selectSingleTyped<Profile>(table = "profiles") { eq("id", uid) }
+    .validate(lazyError = { SupabaseError("Profile is incomplete") }) { it.isComplete }
+
+val dashboard = profile.zip(loadSettings()) { p, settings -> Dashboard(p, settings) }
+```
 
 Suspending variants exist for async transforms: `mapSuspend`, `foldSuspend`,
-`recoverSuspend`, `onSuccessSuspend`, `onFailureSuspend`.
+`recoverSuspend`, `flatMapErrorSuspend`, `onSuccessSuspend`, `onFailureSuspend`,
+`onFailureCategorySuspend`.
 
 ### Side-effects
 
@@ -56,12 +68,13 @@ auth.signInWithEmail(email, password)
     .onSuccess { sessionManager.saveSession(it) }
     .onUnauthorized { showInvalidCredentials() }
     .onRateLimited { showTryLater() }
+    .onNetworkError { showOfflineBanner() }
     .onFailure { logUnexpected(it) }
 ```
 
 `onSuccess`, `onFailure`, `onConflict`, `onNotFound`, `onUnauthorized`,
-`onRateLimited`, and `onFailureCategory(category) { … }` all return the result
-so you can keep chaining.
+`onRateLimited`, `onNetworkError`, and `onFailureCategory(category) { … }` all
+return the result so you can keep chaining.
 
 ### Wrapping your own code
 
@@ -79,8 +92,14 @@ public data class SupabaseError(
     val code: String? = null,
     val details: JsonElement? = null,
     val hint: String? = null,
+    val httpStatus: Int? = null,        // HTTP status, even when the body carries no code
+    val retryAfterSeconds: Long? = null, // parsed from a Retry-After header (429/503)
 )
 ```
+
+`httpStatus` is always captured when a response was received — so a `404` or a
+GoTrue error body without a machine code still categorizes correctly instead of
+collapsing to `Unknown`.
 
 ### Categories
 
@@ -92,10 +111,21 @@ when (result.errorOrNull()?.category) {
     SupabaseErrorCategory.NotFound -> /* 404 */
     SupabaseErrorCategory.Unauthorized -> /* 401 / 403 */
     SupabaseErrorCategory.RateLimited -> /* 429 */
-    SupabaseErrorCategory.Validation -> /* 422 */
+    SupabaseErrorCategory.Validation -> /* 400 / 422 */
     SupabaseErrorCategory.Internal -> /* 5xx */
+    SupabaseErrorCategory.Network -> /* offline, DNS/TLS, timeout — no response */
     SupabaseErrorCategory.Unknown, null -> /* fallback */
 }
+```
+
+`Network` is distinct from `Unknown` so you can show offline/retry UI when no
+response was received at all. Two helpers make the common branches terse:
+
+```kotlin
+error.isNetworkError()           // category == Network
+error.category.isRetryable       // true for RateLimited, Internal, Network
+
+result.onNetworkError { showOfflineBanner() }   // chainable, like onRateLimited
 ```
 
 ### Predicates

--- a/website/pages/storage.mdx
+++ b/website/pages/storage.mdx
@@ -47,6 +47,49 @@ val bytes: SupabaseResult<ByteArray> = storage.download("avatars", "user-123/pho
 | `remove(bucket, paths)` / `removeWithResult(…)` | delete one or many |
 | `info(bucket, path)` / `exists(bucket, path)` | metadata / existence |
 
+## Resumable uploads
+
+For large files or flaky networks, upload in chunks over the **TUS** protocol. The
+server tracks the offset, so an interrupted transfer resumes from where it stopped
+instead of restarting.
+
+```kotlin
+// One-shot — suspends until done:
+storage.uploadResumable(
+    bucket = "videos",
+    path = "user-123/clip.mp4",
+    data = bytes,
+    contentType = "video/mp4",
+)
+```
+
+For progress and pause/resume, create the handle directly and observe its
+`progress` flow:
+
+```kotlin
+val upload = storage.createResumableUpload(
+    bucket = "videos",
+    path = "user-123/clip.mp4",
+    data = bytes,
+    contentType = "video/mp4",
+)
+
+scope.launch {
+    upload.progress.collect { p -> render(p.fraction) }   // 0f..1f
+}
+
+val job = scope.launch { upload.await() }   // runs to completion
+```
+
+<Callout type="info">
+  **Pause / resume across restarts.** Cancelling the coroutine running `await()`
+  pauses the upload, leaving uploaded bytes on the server. Persist
+  `upload.uploadUrl`; later, recreate the handle with `createResumableUpload(…,
+  uploadUrl = saved)` and call `await()` again — it `HEAD`s the server for the
+  current offset and continues. Chunks default to 6 MiB
+  (`RESUMABLE_DEFAULT_CHUNK_SIZE`), the size Supabase requires.
+</Callout>
+
 ## Listing
 
 ```kotlin


### PR DESCRIPTION
Brings the docs site up to date with everything that shipped in 0.4.0 and the post-0.4.0 production-hardening work (retry + observability), which were previously undocumented.

## What changed

**New page — Configuration** (`configuration.mdx`, added to nav)
- `Supabase.create { }` builder reference table
- Retry policy: `RetryConfig` (backoff, retryable statuses, `Retry-After` precedence)
- Logging: routing wire logs through a `SupabaseLogger` (Timber/OSLog/SLF4J)
- Observability: `SupabaseInterceptor` hooks (`onRequest`/`onResponse`/`onError`), with the "exactly one terminal hook; 404 is a response not an error" semantics

**Results & Errors**
- `SupabaseError` now shows `httpStatus` / `retryAfterSeconds`
- New `Network` category + `isNetworkError()` / `category.isRetryable` / chainable `onNetworkError`
- New result operators: `flatMapError`, `validate`, `zip` (+ `flatMapErrorSuspend`, `onFailureCategorySuspend`)

**Storage**
- New "Resumable uploads" section: `uploadResumable` one-shot, `createResumableUpload` with `progress` flow, and pause/resume-across-restarts via persisted `uploadUrl`

**Database**
- Document the `geojson = true` select option

**Getting Started / Home**
- Bump catalog version `0.3.5` → `0.4.0`, link to the new Configuration page
- Home: add a "Built for production" bullet (retry / Network category / observability)

## Verification
- `pnpm build` succeeds; all 16 routes prerender, including the new `/configuration`.
- All documented symbols verified against the current `main` source (RetryConfig, SupabaseLogger, SupabaseInterceptor, ResumableUpload, SupabaseError fields, result operators).