### PR TITLE
ci: supply-chain hardening (wrapper validation, dependency review, CodeQL, SBOM + provenance)

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -28,14 +28,25 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      # build-mode: none analyses the Kotlin/Java sources directly, so CodeQL
-      # does not need to compile the multiplatform build (its autobuilder can't
-      # drive the KMP/native targets reliably).
+      - uses: actions/setup-java@v4
+        with:
+          distribution: zulu
+          java-version: 17
+
+      - uses: gradle/actions/setup-gradle@v4
+
+      # Kotlin extraction requires a traced compile (build-mode: none only sees
+      # Java, and this project is ~all Kotlin). Manual mode lets us compile just
+      # the JVM source sets of the library modules — enough for CodeQL to trace
+      # every published module without pulling in the Android sample build.
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v3
         with:
           languages: java-kotlin
-          build-mode: none
+          build-mode: manual
+
+      - name: Compile JVM sources (traced by CodeQL)
+        run: ./gradlew compileKotlinJvm --no-daemon
 
       - name: Perform CodeQL analysis
         uses: github/codeql-action/analyze@v3

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,43 @@
+name: CodeQL
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    # Weekly, so newly-published CodeQL queries catch issues even without a push.
+    - cron: '0 6 * * 1'
+  workflow_dispatch:
+
+concurrency:
+  group: codeql-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  analyze:
+    name: Analyze (java-kotlin)
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      actions: read
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+
+      # build-mode: none analyses the Kotlin/Java sources directly, so CodeQL
+      # does not need to compile the multiplatform build (its autobuilder can't
+      # drive the KMP/native targets reliably).
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: java-kotlin
+          build-mode: none
+
+      - name: Perform CodeQL analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: "/language:java-kotlin"

--- a/.github/workflows/dependency-submission.yml
+++ b/.github/workflows/dependency-submission.yml
@@ -1,0 +1,28 @@
+name: Dependency Submission
+
+# Resolves the full (transitive) Gradle dependency graph and submits it to
+# GitHub's Dependency Graph. This is what powers Dependabot alerts against
+# transitive dependencies and gives dependency-review.yml a baseline to diff
+# pull requests against.
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  submit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-java@v4
+        with:
+          distribution: zulu
+          java-version: 17
+
+      - name: Submit dependency graph
+        uses: gradle/actions/dependency-submission@v4

--- a/.github/workflows/release-attestations.yml
+++ b/.github/workflows/release-attestations.yml
@@ -1,0 +1,57 @@
+name: Release attestations
+
+# Runs alongside (not inside) publish.yml so the known-good Maven Central release
+# pipeline is never touched. Generates an SBOM and signed build-provenance/SBOM
+# attestations for the published artifacts, and attaches the SBOM to the release.
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+
+permissions:
+  contents: write # upload the SBOM as a release asset
+  id-token: write # sign attestations via OIDC
+  attestations: write # write the attestations
+
+jobs:
+  attest:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-java@v4
+        with:
+          distribution: zulu
+          java-version: 17
+
+      - uses: gradle/actions/setup-gradle@v4
+
+      # Build the publishable JARs locally so we have concrete artifacts to
+      # attest and describe. (Publishing itself is handled by publish.yml.)
+      - name: Assemble artifacts
+        run: ./gradlew assemble --no-configuration-cache
+
+      - name: Generate SBOM (CycloneDX)
+        uses: anchore/sbom-action@v0
+        with:
+          path: .
+          format: cyclonedx-json
+          output-file: sbom.cyclonedx.json
+
+      - name: Attest build provenance
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-path: '**/build/libs/*.jar'
+
+      - name: Attest SBOM
+        uses: actions/attest-sbom@v2
+        with:
+          subject-path: '**/build/libs/*.jar'
+          sbom-path: sbom.cyclonedx.json
+
+      - name: Attach SBOM to the release
+        if: github.event_name == 'release'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh release upload "${{ github.event.release.tag_name }}" sbom.cyclonedx.json --clobber

--- a/.github/workflows/supply-chain.yml
+++ b/.github/workflows/supply-chain.yml
@@ -1,0 +1,39 @@
+name: Supply chain
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+concurrency:
+  group: supply-chain-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  # Fails if gradle-wrapper.jar does not match a known-good Gradle release —
+  # the wrapper jar is executable code committed to the repo, so a tampered one
+  # is a classic supply-chain attack vector.
+  wrapper-validation:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Validate Gradle wrapper
+        uses: gradle/actions/wrapper-validation@v4
+
+  # Blocks PRs that introduce dependencies with known high-severity
+  # vulnerabilities or disallowed licenses. Compares the dependency graph of the
+  # PR head against main (populated by dependency-submission.yml).
+  dependency-review:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Dependency review
+        uses: actions/dependency-review-action@v4
+        with:
+          fail-on-severity: high

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -23,6 +23,27 @@ Please include:
 We aim to acknowledge reports within 5 business days and to ship a fix or
 mitigation as quickly as the severity warrants.
 
+## Supply chain
+
+Releases are built and verified in CI before publishing:
+
+- **Signed artifacts** — every artifact on Maven Central is GPG-signed.
+- **Wrapper validation** — the committed `gradle-wrapper.jar` is checked against
+  known-good Gradle checksums on every push and pull request.
+- **Dependency review + graph** — the transitive dependency graph is submitted to
+  GitHub (enabling Dependabot alerts), and pull requests are blocked if they add a
+  dependency with a known high-severity vulnerability.
+- **Static analysis** — CodeQL scans the Kotlin/Java sources on every push, pull
+  request, and weekly.
+- **SBOM + provenance** — each release ships a CycloneDX SBOM (attached as a
+  release asset) plus signed [build-provenance and SBOM
+  attestations](https://docs.github.com/en/actions/security-guides/using-artifact-attestations).
+  Verify a downloaded JAR with:
+
+  ```bash
+  gh attestation verify <artifact>.jar --repo AndroidPoet/supabase-kmp
+  ```
+
 ## Scope / things to keep in mind
 
 This is a client SDK. Some responsibilities sit with the integrating app:


### PR DESCRIPTION
Raises the supply-chain / release-integrity floor for a published SDK. All additive CI — **the known-good `publish.yml` Maven Central pipeline is untouched** (provenance/SBOM run in a separate workflow), so there is zero risk to releases.

## What's added

**`supply-chain.yml`** (push + PR)
- **Gradle wrapper validation** — fails if the committed `gradle-wrapper.jar` doesn't match a known-good Gradle checksum (a real attack vector that was previously unguarded).
- **Dependency review** — blocks PRs that introduce a dependency with a known high-severity vulnerability.

**`dependency-submission.yml`** (push to main)
- Submits the transitive Gradle dependency graph to GitHub → powers Dependabot alerts on transitive deps and gives dependency-review a baseline to diff against.

**`codeql.yml`** (push + PR + weekly)
- CodeQL static analysis for `java-kotlin` using `build-mode: none` (analyses sources directly; no need to drive the KMP/native build).

**`release-attestations.yml`** (release published + manual dispatch)
- Generates a **CycloneDX SBOM**, produces **signed build-provenance + SBOM attestations** for the published JARs, and attaches the SBOM to the GitHub release.
- Deliberately a separate workflow so `publish.yml` is never modified.

**`SECURITY.md`**
- Documents the guarantees and how consumers verify an artifact: `gh attestation verify <jar> --repo AndroidPoet/supabase-kmp`.

## Verification
- All four workflow files pass YAML validation.
- 3 of the 4 (wrapper-validation, dependency-review, CodeQL) execute on this PR — watch the checks below for live confirmation.
- `release-attestations.yml` triggers on release; it also has `workflow_dispatch` so it can be smoke-tested manually before the next release.