### PR TITLE
docs: add supabase-kmp Agent Skill for AI coding agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -439,6 +439,7 @@ the full workflow.
 - Release notes: [`CHANGELOG.md`](CHANGELOG.md)
 - Contributing: [`CONTRIBUTING.md`](CONTRIBUTING.md)
 - Security policy: [`SECURITY.md`](SECURITY.md)
+- AI Agent Skill (Claude Code / Cursor / Copilot): [`skills/`](skills/)
 - GitBook-ready pages: [`docs/`](docs/)
 - GitBook config: [`.gitbook.yaml`](.gitbook.yaml)
 - Publishing guide: [`docs/guides/gitbook-publishing.md`](docs/guides/gitbook-publishing.md)

--- a/skills/README.md
+++ b/skills/README.md
@@ -1,0 +1,35 @@
+# Agent Skills
+
+AI coding agents have barely seen `supabase-kmp` in training data, so they tend to
+hallucinate **supabase-js** APIs (`.from().select()` chains, thrown errors) that
+don't exist here. The [`supabase-kmp`](./supabase-kmp/SKILL.md) skill teaches an
+agent this SDK's actual surface — `SupabaseResult`, the per-feature clients, the
+typed PostgREST DSL — plus the security rules (anon vs service-role, RLS, session
+storage).
+
+It follows the open [Agent Skills](https://www.anthropic.com/news/skills) format
+(a `SKILL.md` with `name` + `description` frontmatter), so it works with any tool
+that supports the standard.
+
+## Install
+
+**Claude Code** — copy the skill folder into your skills directory:
+
+```bash
+# project-scoped (this repo / a consuming project)
+mkdir -p .claude/skills && cp -r skills/supabase-kmp .claude/skills/
+
+# or user-scoped (all your projects)
+mkdir -p ~/.claude/skills && cp -r skills/supabase-kmp ~/.claude/skills/
+```
+
+The agent loads it automatically when a task matches the `description`.
+
+**Cursor / GitHub Copilot / other agents** — point your rules/instructions at
+[`supabase-kmp/SKILL.md`](./supabase-kmp/SKILL.md) (e.g. reference it from a
+`.cursorrules` / `copilot-instructions.md`), or paste its contents into your
+project's agent-instructions file.
+
+## Feedback
+
+See [`supabase-kmp/skill-feedback.md`](./supabase-kmp/skill-feedback.md).

--- a/skills/supabase-kmp/SKILL.md
+++ b/skills/supabase-kmp/SKILL.md
@@ -1,0 +1,178 @@
+---
+name: supabase-kmp
+description: >-
+  Use when writing or reviewing Kotlin / Kotlin Multiplatform code that talks to
+  Supabase through the supabase-kmp SDK (Maven coordinates
+  io.github.androidpoet:supabase-*) — auth, Postgres/PostgREST, storage, realtime,
+  or edge functions. Covers the SupabaseResult API, the per-feature clients, and
+  the security rules. NOT for supabase-js or other Supabase Kotlin libraries.
+---
+
+# supabase-kmp
+
+A typed, multiplatform Kotlin client for Supabase. **Verify APIs against the docs
+site — https://androidpoet.github.io/supabase-kmp/ — rather than trusting training
+data; the SDK is pre-1.0 and evolving.**
+
+## Don't confuse it with other SDKs
+
+This is **`io.github.androidpoet:supabase-*`**. It is **not**:
+
+- **supabase-js** — there is no `supabase.from("t").select().eq(...)` fluent chain
+  and no thrown errors. Do not write JS-style code.
+- **supabase-kt** (`io.github.jan-tennert.supabase`) — a different library with a
+  different API. Don't mix package names or call conventions.
+
+When unsure of a method name, check the docs site or the module's source, don't
+guess a supabase-js equivalent.
+
+## Setup: one client, many feature clients
+
+```kotlin
+val client = Supabase.create(
+    projectUrl = "https://<ref>.supabase.co",
+    apiKey = "<anon-key>",
+) {
+    // optional config (see "Configuration")
+}
+
+val auth = createAuthClient(client)
+val database = createDatabaseClient(client)
+val storage = createStorageClient(client)
+val realtime = createRealtimeClient(client)
+val functions = createFunctionsClient(client)
+```
+
+There is **no god-object** — create only the feature clients you need. Each module
+is published independently; depend only on what you use
+(`io.github.androidpoet:supabase-client`, `-auth`, `-database`, `-storage`,
+`-realtime`, `-functions`).
+
+## Results: `SupabaseResult<T>`, not exceptions
+
+**Every fallible call returns `SupabaseResult<T>`. The happy path never throws** —
+do not wrap calls in `try/catch`.
+
+```kotlin
+database.selectTyped<Todo>(table = "todos")
+    .onSuccess { todos -> render(todos) }
+    .onUnauthorized { showLogin() }
+    .onNetworkError { showOffline() }   // offline / DNS / timeout
+    .onFailure { e -> log(e.message) }
+```
+
+Terminal/transform ops: `getOrNull()`, `getOrThrow()`, `getOrElse { }`,
+`getOrDefault(v)`, `fold(onSuccess, onFailure)`, `map`, `flatMap`, `mapError`,
+`recover`, `validate`, `zip`, `toFlow()` (success value as a `Flow`). Suspend
+variants exist (`mapSuspend`, `foldSuspend`, …).
+
+Branch on `error.category` (`Conflict`, `NotFound`, `Unauthorized`, `RateLimited`,
+`Validation`, `Internal`, `Network`, `Unknown`) instead of parsing codes; helpers:
+`onConflict`, `onNotFound`, `onUnauthorized`, `onRateLimited`, `onNetworkError`.
+`SupabaseError` exposes `message`, `code`, `httpStatus`, `retryAfterSeconds`,
+`category`.
+
+## Database (PostgREST)
+
+Models are `@Serializable`. Filters go **inside the trailing lambda** and AND
+together — there is no chained builder.
+
+```kotlin
+@Serializable data class Todo(val id: String, val title: String, val done: Boolean)
+
+val todos = database.selectTyped<Todo>(table = "todos") {
+    eq("done", "false")
+    order("created_at", ascending = false)
+    limit(25)
+}
+
+database.insertTyped(table = "todos", value = Todo("1", "Ship", false))
+database.updateTyped(table = "todos", value = patch) { eq("id", "1") }
+database.upsertTyped(table = "todos", value = todo, onConflict = "id")
+database.deleteTyped<Todo>(table = "todos") { eq("id", "1") }
+
+val stats = database.rpcTyped<Req, Stats>(function = "get_stats", params = Req("u1"))
+```
+
+Filter ops: `eq/neq/gt/gte/lt/lte`, `like/ilike`, `is`, `in`, `contains`,
+`textSearch`, `or { }`, `and { }`, `not { }`, `order`, `limit`, `range`. Each
+method has `*Typed` (deserialized), `*TypedMany`, `*Unit`, and a raw-string form.
+
+> Table/column/function names are raw strings — typos surface only at runtime.
+> Keep them exact and matching the DB schema.
+
+## Auth
+
+```kotlin
+auth.signUpWithEmail(email, password)
+auth.signInWithEmail(email, password)
+auth.signInWithOtp(email = email);  auth.verifyOtp(...)
+auth.getUser();  auth.signOut()
+auth.getClaims()   // verifies asymmetric JWTs on-device against the JWKS
+```
+
+Also: `signInWithOAuth`, `signInWithIdToken`, `signInAnonymously`,
+`resetPasswordForEmail`, `updateUser`, `refreshToken`, MFA/passkey methods. Native
+Google/Apple sign-in are optional modules over a pluggable `NativeAuthProvider`.
+
+## Storage
+
+```kotlin
+storage.upload(bucket = "avatars", path = "u1/a.png", data = bytes, contentType = "image/png")
+storage.download("avatars", "u1/a.png")
+storage.createSignedUrl(bucket = "avatars", path = "u1/a.png", expiresIn = 3600)
+
+// Large files / flaky networks — resumable (TUS), with progress + pause/resume:
+storage.uploadResumable(bucket = "videos", path = "u1/clip.mp4", data = bytes)
+```
+
+## Realtime
+
+```kotlin
+val sub = realtime.channel("todos")
+    .onPostgresChange(table = "todos", event = PostgresChangeEvent.INSERT) { row -> }
+    .subscribe()
+realtime.connect()
+// ...
+sub.unsubscribe(); realtime.disconnect()
+```
+
+Also broadcast (`onBroadcast`/`broadcast`) and presence (`onPresence`/`track`).
+Flow variants exist (`postgresInsertsFlow()`, …).
+
+## Edge Functions
+
+```kotlin
+val res = functions.invokeTyped<Req, Resp>(functionName = "hello", body = Req("Ada"))
+```
+
+## Configuration
+
+Inside `Supabase.create { }`: `logging`/`logLevel`, `headers`,
+`retry = RetryConfig(...)` (exponential backoff; reads retry by default),
+`logger = SupabaseLogger` (route wire logs into Timber/OSLog/SLF4J), and
+`interceptor = SupabaseInterceptor` (suspend `onRequest`/`onResponse`/`onError`
+telemetry hooks).
+
+## Security — non-negotiable
+
+- **Use the anon key in client apps. NEVER ship the service-role key** to a
+  client/mobile target. The `supabase-auth-admin` module uses the service-role key
+  and is **server-side only**.
+- **Enable RLS** on tables, and remember RLS policies alone don't grant table
+  privileges — `anon`/`authenticated` roles also need
+  `grant select, insert, ... on <table>`. A "permission denied" with RLS on is
+  usually a missing grant.
+- **Session storage is bring-your-own.** The default keeps tokens in memory only;
+  for persistence wire a secure `SessionStorage` backed by the platform keystore
+  (Keychain / EncryptedSharedPreferences). Do not invent a custom plaintext store.
+
+## Before you finish — checklist
+
+- [ ] No `try/catch` around SDK calls; results handled via `SupabaseResult`.
+- [ ] No supabase-js `.from().select()` chains or thrown-error assumptions.
+- [ ] Per-feature `create*Client(client)` used, not a single mega-client.
+- [ ] Models are `@Serializable`; table/column/function names match the schema.
+- [ ] anon key in clients; service-role / `supabase-auth-admin` only server-side.
+- [ ] RLS considered (policies **and** grants); secure session storage wired.
+- [ ] Unsure of a name? Checked the docs site instead of guessing.

--- a/skills/supabase-kmp/skill-feedback.md
+++ b/skills/supabase-kmp/skill-feedback.md
@@ -1,0 +1,17 @@
+# Skill feedback
+
+Found this skill steering an AI agent toward a wrong or outdated supabase-kmp
+pattern? Help us fix it.
+
+When reporting, include:
+
+- **What the agent produced** (the wrong code or claim).
+- **What's correct** (link to the [docs site](https://androidpoet.github.io/supabase-kmp/)
+  or the relevant source file).
+- **The agent/tool** (Claude Code, Cursor, Copilot, …) and SDK version.
+
+Open an issue: https://github.com/AndroidPoet/supabase-kmp/issues
+
+This skill intentionally teaches agents to **verify against the docs first**
+rather than encode facts that drift — so the highest-value reports are cases
+where the skill itself asserts something the docs contradict.


### PR DESCRIPTION
AI coding agents have barely seen `supabase-kmp` in training data, so they default to **supabase-js** patterns (`.from().select()` chains, thrown errors) that don't exist here. This adds an **Agent Skill** that teaches agents the SDK's real surface — mirroring what RevenueCat (ai-toolkit) and Kotzilla (Koin AI-fix prompts) both did at the AI layer.

## What's added
- **`skills/supabase-kmp/SKILL.md`** — open [Agent Skills](https://www.anthropic.com/news/skills) format (`name` + `description` frontmatter). Covers:
  - "This is `io.github.androidpoet:supabase-*`, not supabase-js / supabase-kt" — don't guess JS equivalents
  - `SupabaseResult<T>` — no exceptions on the happy path, error categories, `on*` helpers
  - Per-feature `create*Client(client)` (no god-object), typed PostgREST DSL, auth, storage (incl. resumable), realtime, functions, config (retry/logger/interceptor)
  - **Security rules**: anon vs service-role, RLS needs grants too, BYO secure session storage
  - A docs-first "verify, don't guess" philosophy + an end-of-task checklist
- **`skills/supabase-kmp/skill-feedback.md`** and **`skills/README.md`** (Claude Code / Cursor / Copilot install steps)
- README pointer under Documentation

## Verification
- Every API name (`signInWithEmail`, `selectTyped`, `uploadResumable`, `invokeTyped`, `getClaims`, `RetryConfig`/`SupabaseLogger`/`SupabaseInterceptor`, `PostgresChangeEvent`, …) checked against the docs site and module sources.
- `SKILL.md` frontmatter validates as YAML.

Docs/markdown only — no code or build impact.