### PR TITLE
fix(client): don't send non-JWT project keys in Authorization: Bearer

### DIFF
--- a/supabase-client/src/commonMain/kotlin/io/github/androidpoet/supabase/client/transport/HttpTransport.kt
+++ b/supabase-client/src/commonMain/kotlin/io/github/androidpoet/supabase/client/transport/HttpTransport.kt
@@ -52,6 +52,16 @@ internal class HttpTransport(
     @Volatile
     private var accessToken: String? = null
     internal val accessTokenOrNull: String? get() = accessToken
+
+    // The project key is sent as the `apikey` header on every request and is the
+    // authenticator for anonymous requests. Only a JWT belongs in
+    // `Authorization: Bearer`: a real session token, or a legacy anon/service_role
+    // key (PostgREST derives the DB role from that JWT). The newer non-JWT keys
+    // (`sb_publishable_…`/`sb_secret_…`) must NEVER be sent as a Bearer token —
+    // for those we omit Authorization and let the `apikey` header authorize the
+    // request. JWTs always start with `eyJ` (base64url of `{"alg"…`).
+    private fun bearerTokenOrNull(): String? = accessToken ?: apiKey.takeIf { it.startsWith("eyJ") }
+
     private val errorJson = Json { ignoreUnknownKeys = true }
     private val retry = config.retry
     internal val httpClient: HttpClient =
@@ -107,7 +117,7 @@ internal class HttpTransport(
                 outgoingHeaders.forEach { (k, v) -> header(k, v) }
                 if (attempt > 0) header(RETRY_COUNT_HEADER, attempt.toString())
                 if ("Authorization" !in outgoingHeaders) {
-                    header("Authorization", "Bearer ${accessToken ?: apiKey}")
+                    bearerTokenOrNull()?.let { header("Authorization", "Bearer $it") }
                 }
             }
         }
@@ -125,7 +135,7 @@ internal class HttpTransport(
                 body?.let { setBody(it) }
                 outgoingHeaders.forEach { (k, v) -> header(k, v) }
                 if ("Authorization" !in outgoingHeaders) {
-                    header("Authorization", "Bearer ${accessToken ?: apiKey}")
+                    bearerTokenOrNull()?.let { header("Authorization", "Bearer $it") }
                 }
             }
         }
@@ -143,7 +153,7 @@ internal class HttpTransport(
                 body?.let { setBody(it) }
                 outgoingHeaders.forEach { (k, v) -> header(k, v) }
                 if ("Authorization" !in outgoingHeaders) {
-                    header("Authorization", "Bearer ${accessToken ?: apiKey}")
+                    bearerTokenOrNull()?.let { header("Authorization", "Bearer $it") }
                 }
             }
         }
@@ -161,7 +171,7 @@ internal class HttpTransport(
                 body?.let { setBody(it) }
                 outgoingHeaders.forEach { (k, v) -> header(k, v) }
                 if ("Authorization" !in outgoingHeaders) {
-                    header("Authorization", "Bearer ${accessToken ?: apiKey}")
+                    bearerTokenOrNull()?.let { header("Authorization", "Bearer $it") }
                 }
             }
         }
@@ -181,7 +191,7 @@ internal class HttpTransport(
                 }
                 outgoingHeaders.forEach { (k, v) -> header(k, v) }
                 if ("Authorization" !in outgoingHeaders) {
-                    header("Authorization", "Bearer ${accessToken ?: apiKey}")
+                    bearerTokenOrNull()?.let { header("Authorization", "Bearer $it") }
                 }
             }
         }
@@ -200,7 +210,7 @@ internal class HttpTransport(
                 setBody(body)
                 outgoingHeaders.forEach { (k, v) -> header(k, v) }
                 if ("Authorization" !in outgoingHeaders) {
-                    header("Authorization", "Bearer ${accessToken ?: apiKey}")
+                    bearerTokenOrNull()?.let { header("Authorization", "Bearer $it") }
                 }
             }
         }
@@ -219,7 +229,7 @@ internal class HttpTransport(
                 setBody(body)
                 outgoingHeaders.forEach { (k, v) -> header(k, v) }
                 if ("Authorization" !in outgoingHeaders) {
-                    header("Authorization", "Bearer ${accessToken ?: apiKey}")
+                    bearerTokenOrNull()?.let { header("Authorization", "Bearer $it") }
                 }
             }
         }
@@ -240,7 +250,7 @@ internal class HttpTransport(
                     this.method = HttpMethod.parse(method)
                     requestHeaders.forEach { (k, v) -> header(k, v) }
                     if ("Authorization" !in requestHeaders) {
-                        header("Authorization", "Bearer ${accessToken ?: apiKey}")
+                        bearerTokenOrNull()?.let { header("Authorization", "Bearer $it") }
                     }
                     contentType?.let { contentType(ContentType.parse(it)) }
                     body?.let { setBody(it) }

--- a/supabase-client/src/commonTest/kotlin/io/github/androidpoet/supabase/client/transport/HttpTransportAuthHeaderTest.kt
+++ b/supabase-client/src/commonTest/kotlin/io/github/androidpoet/supabase/client/transport/HttpTransportAuthHeaderTest.kt
@@ -1,0 +1,86 @@
+package io.github.androidpoet.supabase.client.transport
+
+import io.github.androidpoet.supabase.client.SupabaseConfig
+import io.ktor.client.engine.mock.respond
+import io.ktor.client.request.HttpRequestData
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.headersOf
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+private const val LEGACY_ANON_JWT = "eyJhbGciOiJIUzI1NiJ9.eyJyb2xlIjoiYW5vbiJ9.sig"
+private const val MODERN_PUBLISHABLE = "sb_publishable_abc123"
+
+private fun config() =
+    SupabaseConfig(
+        logging = false,
+        logLevel = io.ktor.client.plugins.logging.LogLevel.NONE,
+        headers = emptyMap(),
+    )
+
+private fun transport(
+    apiKey: String,
+    captured: MutableList<HttpRequestData>,
+) = HttpTransport(
+    config = config(),
+    engineFactory =
+        TestMockEngineFactory { request ->
+            captured += request
+            respond("{}", HttpStatusCode.OK, headersOf(HttpHeaders.ContentType, "application/json"))
+        },
+    projectUrl = "https://example.supabase.co",
+    apiKey = apiKey,
+)
+
+class HttpTransportAuthHeaderTest {
+    @Test
+    fun test_apikeyHeader_isAlwaysSent() =
+        runTest {
+            val seen = mutableListOf<HttpRequestData>()
+            transport(MODERN_PUBLISHABLE, seen).get(url = "https://example.supabase.co/rest/v1/x")
+            assertEquals(MODERN_PUBLISHABLE, seen.single().headers["apikey"])
+        }
+
+    @Test
+    fun test_legacyJwtKey_anonymous_goesIntoBearer() =
+        runTest {
+            val seen = mutableListOf<HttpRequestData>()
+            transport(LEGACY_ANON_JWT, seen).get(url = "https://example.supabase.co/rest/v1/x")
+            assertEquals("Bearer $LEGACY_ANON_JWT", seen.single().headers[HttpHeaders.Authorization])
+        }
+
+    @Test
+    fun test_modernKey_anonymous_omitsAuthorization() =
+        runTest {
+            val seen = mutableListOf<HttpRequestData>()
+            transport(MODERN_PUBLISHABLE, seen).get(url = "https://example.supabase.co/rest/v1/x")
+            // Modern publishable keys must NOT be sent as a Bearer token; the apikey
+            // header authorizes the request instead.
+            assertNull(seen.single().headers[HttpHeaders.Authorization])
+            assertEquals(MODERN_PUBLISHABLE, seen.single().headers["apikey"])
+        }
+
+    @Test
+    fun test_sessionToken_overridesKey_evenForModernKey() =
+        runTest {
+            val seen = mutableListOf<HttpRequestData>()
+            val transport = transport(MODERN_PUBLISHABLE, seen)
+            transport.setAccessToken("user-session-jwt")
+            transport.get(url = "https://example.supabase.co/rest/v1/x")
+            assertEquals("Bearer user-session-jwt", seen.single().headers[HttpHeaders.Authorization])
+        }
+
+    @Test
+    fun test_clearAccessToken_revertsToKeyRules() =
+        runTest {
+            val seen = mutableListOf<HttpRequestData>()
+            val transport = transport(MODERN_PUBLISHABLE, seen)
+            transport.setAccessToken("user-session-jwt")
+            transport.clearAccessToken()
+            transport.get(url = "https://example.supabase.co/rest/v1/x")
+            assertNull(seen.single().headers[HttpHeaders.Authorization])
+        }
+}


### PR DESCRIPTION
## Problem
Supabase's **new API keys** (`sb_publishable_…` / `sb_secret_…`) are **not JWTs** and per [the docs](https://supabase.com/docs/guides/api/api-keys) "cannot be sent in `Authorization: Bearer` headers" — the `apikey` header is what authorizes the request. Our transport defaulted `Authorization: Bearer ${accessToken ?: apiKey}`, so a brand-new project's publishable key ended up in the Bearer header. It currently "works" only because the gateway authorizes off `apikey` and tolerates the bad Bearer — a latent break if the gateway tightens.

I verified the mature **supabase-kt** (v3.6.0) does the exact same `keyAsFallback` thing and relies on the same leniency — so this is an industry-wide rough edge, not just ours.

## Fix
Only put a **JWT** in `Authorization: Bearer`:
- a real **session token** (user logged in), or
- a **legacy `anon`/`service_role` key** (`eyJ…` — PostgREST derives the DB role from that JWT).

For **modern non-JWT keys with no session**, omit `Authorization` entirely and let the `apikey` header authorize. This:
- fixes modern publishable keys (spec-compliant),
- **preserves legacy `anon` behavior** (apikey still authorizes anon), and
- **preserves `service_role`/`supabase-auth-admin`** (its `eyJ…` key still goes in Bearer so RLS bypass still works).

Centralized into one `bearerTokenOrNull()` helper, applied at all 8 request sites.

## Verification
5 new MockEngine tests (`HttpTransportAuthHeaderTest`):
- `apikey` header always sent
- legacy JWT key, anonymous → `Authorization: Bearer <jwt>`
- modern publishable key, anonymous → **no** `Authorization` header
- session token wins even with a modern key
- `clearAccessToken()` reverts to key rules

`jvmTest`, `detekt`, `spotlessCheck`, `apiCheck` all green. Internal-only change — no public API impact.