### PR TITLE
test: docs-grounded conformance suite + tolerant error-code parsing

### DIFF
--- a/supabase-client/src/commonMain/kotlin/io/github/androidpoet/supabase/client/transport/HttpTransport.kt
+++ b/supabase-client/src/commonMain/kotlin/io/github/androidpoet/supabase/client/transport/HttpTransport.kt
@@ -391,7 +391,12 @@ internal class HttpTransport(
         val message =
             str("message", "msg", "error_description", "error_message", "error")
                 ?: body.ifBlank { "HTTP $statusCode" }
-        val code = str("code", "error_code", "statusCode")
+        // Prefer the textual machine code. Legacy GoTrue puts the numeric HTTP
+        // status in `code` and the real string code in `error_code`, so reading
+        // `error_code` first surfaces e.g. "weak_password" instead of "400".
+        // PostgREST (only `code`, the SQLSTATE) and new GoTrue/Storage (string
+        // `code`) are unaffected since they don't send `error_code`.
+        val code = str("error_code", "code", "statusCode")
 
         return SupabaseError(
             message = message,

--- a/supabase-client/src/commonTest/kotlin/io/github/androidpoet/supabase/client/transport/ErrorParsingConformanceTest.kt
+++ b/supabase-client/src/commonTest/kotlin/io/github/androidpoet/supabase/client/transport/ErrorParsingConformanceTest.kt
@@ -1,0 +1,163 @@
+package io.github.androidpoet.supabase.client.transport
+
+import io.github.androidpoet.supabase.client.SupabaseConfig
+import io.github.androidpoet.supabase.core.result.SupabaseErrorCategory
+import io.github.androidpoet.supabase.core.result.SupabaseResult
+import io.github.androidpoet.supabase.core.result.category
+import io.github.androidpoet.supabase.core.result.isRetryable
+import io.ktor.client.engine.mock.respond
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.headersOf
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * Conformance tests for error-body parsing across the heterogeneous shapes the
+ * Supabase services actually return. The transport must parse all of them and
+ * always categorize by HTTP status even when the body has no usable code.
+ *
+ * Error-shape references:
+ *  - PostgREST: {code,message,details,hint} — https://docs.postgrest.org/en/v12/references/errors.html
+ *  - GoTrue legacy {code:<int>,error_code,msg} vs new {code:<string>,message}
+ *    and OAuth {error,error_description} —
+ *    https://supabase.com/docs/guides/auth/debugging/error-codes
+ *  - Storage {code,message} — https://supabase.com/docs/guides/storage/debugging/error-codes
+ */
+class ErrorParsingConformanceTest {
+    private fun transportReturning(
+        status: HttpStatusCode,
+        body: String,
+        retryAfter: String? = null,
+    ): HttpTransport {
+        val headers =
+            if (retryAfter != null) {
+                headersOf("Retry-After", retryAfter)
+            } else {
+                headersOf("Content-Type", "application/json")
+            }
+        return HttpTransport(
+            config = SupabaseConfig(logging = false, logLevel = io.ktor.client.plugins.logging.LogLevel.NONE, headers = emptyMap()),
+            engineFactory = TestMockEngineFactory { respond(content = body, status = status, headers = headers) },
+            projectUrl = "https://example.supabase.co",
+            apiKey = "anon",
+        )
+    }
+
+    private suspend fun errorFor(
+        status: HttpStatusCode,
+        body: String,
+        retryAfter: String? = null,
+    ) = (transportReturning(status, body, retryAfter).get(url = "https://example.supabase.co/rest/v1/x") as SupabaseResult.Failure).error
+
+    @Test
+    fun test_postgrest_uniqueViolation_parsesCodeAndMapsConflict() =
+        runTest {
+            val error =
+                errorFor(
+                    HttpStatusCode.Conflict,
+                    """{"code":"23505","message":"duplicate key violates unique constraint","details":"Key exists.","hint":null}""",
+                )
+            assertEquals("23505", error.code)
+            assertEquals("duplicate key violates unique constraint", error.message)
+            assertEquals(409, error.httpStatus)
+            assertEquals(SupabaseErrorCategory.Conflict, error.category)
+        }
+
+    @Test
+    fun test_gotrue_legacyShape_prefersStringErrorCodeOverNumericCode() =
+        runTest {
+            // Legacy GoTrue: `code` is the numeric HTTP status; `error_code` is the
+            // real machine code, and the message is under `msg`.
+            val error =
+                errorFor(
+                    HttpStatusCode.UnprocessableEntity,
+                    """{"code":422,"error_code":"weak_password","msg":"Password is too weak"}""",
+                )
+            assertEquals("weak_password", error.code)
+            assertEquals("Password is too weak", error.message)
+            assertEquals(422, error.httpStatus)
+            assertEquals(SupabaseErrorCategory.Validation, error.category)
+        }
+
+    @Test
+    fun test_gotrue_newShape_parsesStringCodeAndMessage() =
+        runTest {
+            val error =
+                errorFor(
+                    HttpStatusCode.BadRequest,
+                    """{"code":"weak_password","message":"Password should be at least 6 characters"}""",
+                )
+            assertEquals("weak_password", error.code)
+            assertEquals("Password should be at least 6 characters", error.message)
+            assertEquals(SupabaseErrorCategory.Validation, error.category)
+        }
+
+    @Test
+    fun test_gotrue_oauthShape_usesErrorDescriptionAsMessage() =
+        runTest {
+            // OAuth endpoints always return {error, error_description} with HTTP 400.
+            val error =
+                errorFor(
+                    HttpStatusCode.BadRequest,
+                    """{"error":"invalid_grant","error_description":"Invalid login credentials"}""",
+                )
+            assertEquals("Invalid login credentials", error.message)
+            assertEquals(SupabaseErrorCategory.Validation, error.category)
+        }
+
+    @Test
+    fun test_storage_notFound_parsesCodeAndMapsNotFound() =
+        runTest {
+            val error =
+                errorFor(
+                    HttpStatusCode.NotFound,
+                    """{"code":"NoSuchKey","message":"Object not found"}""",
+                )
+            assertEquals("NoSuchKey", error.code)
+            assertEquals("Object not found", error.message)
+            assertEquals(SupabaseErrorCategory.NotFound, error.category)
+        }
+
+    @Test
+    fun test_rateLimited_capturesRetryAfterAndIsRetryable() =
+        runTest {
+            val error =
+                errorFor(
+                    HttpStatusCode.TooManyRequests,
+                    """{"message":"rate limit exceeded"}""",
+                    retryAfter = "30",
+                )
+            assertEquals(30, error.retryAfterSeconds)
+            assertEquals(SupabaseErrorCategory.RateLimited, error.category)
+            assertTrue(error.category.isRetryable)
+        }
+
+    @Test
+    fun test_unauthorized_status401_mapsUnauthorized() =
+        runTest {
+            val error = errorFor(HttpStatusCode.Unauthorized, """{"message":"JWT expired"}""")
+            assertEquals(401, error.httpStatus)
+            assertEquals(SupabaseErrorCategory.Unauthorized, error.category)
+        }
+
+    @Test
+    fun test_serverError_emptyBody_fallsBackToStatusMessageAndInternalCategory() =
+        runTest {
+            val error = errorFor(HttpStatusCode.InternalServerError, "")
+            assertEquals("HTTP 500", error.message)
+            assertEquals(500, error.httpStatus)
+            assertEquals(SupabaseErrorCategory.Internal, error.category)
+            assertTrue(error.category.isRetryable)
+        }
+
+    @Test
+    fun test_nonJsonBody_usedAsMessageVerbatim() =
+        runTest {
+            val error = errorFor(HttpStatusCode.BadGateway, "upstream connection error")
+            assertEquals("upstream connection error", error.message)
+            assertEquals(502, error.httpStatus)
+            assertEquals(SupabaseErrorCategory.Internal, error.category)
+        }
+}

--- a/supabase-core/src/commonTest/kotlin/io/github/androidpoet/supabase/core/FiltersTest.kt
+++ b/supabase-core/src/commonTest/kotlin/io/github/androidpoet/supabase/core/FiltersTest.kt
@@ -43,6 +43,65 @@ class FiltersTest {
         assertEquals(listOf("verified" to "is.true"), result)
     }
 
+    // --- Value quoting / injection safety -------------------------------------
+    // PostgREST treats comma, parentheses and double-quote as structural in a
+    // filter value; an unquoted value containing one would change the query's
+    // meaning. These lock the quoting/escaping so filter values can't be used to
+    // inject query structure.
+
+    @Test
+    fun test_eq_valueWithComma_isDoubleQuoted() {
+        assertEquals(listOf("tag" to """eq."a,b""""), filters { eq("tag", "a,b") })
+    }
+
+    @Test
+    fun test_eq_valueWithParentheses_isDoubleQuoted() {
+        assertEquals(listOf("note" to """eq."f(x)""""), filters { eq("note", "f(x)") })
+    }
+
+    @Test
+    fun test_eq_valueWithDoubleQuote_isEscapedAndQuoted() {
+        assertEquals(listOf("name" to """eq."a\"b""""), filters { eq("name", "a\"b") })
+    }
+
+    @Test
+    fun test_eq_valueWithBackslash_isEscapedAndQuoted() {
+        assertEquals(listOf("path" to """eq."a\\b""""), filters { eq("path", "a\\b") })
+    }
+
+    @Test
+    fun test_eq_emptyValue_isQuoted() {
+        assertEquals(listOf("name" to """eq."""""), filters { eq("name", "") })
+    }
+
+    @Test
+    fun test_eq_plainValue_isNotQuoted() {
+        assertEquals(listOf("status" to "eq.active"), filters { eq("status", "active") })
+    }
+
+    @Test
+    fun test_in_quotesElementsContainingSeparators() {
+        assertEquals(
+            listOf("tag" to """in.("a,b",plain)"""),
+            filters { `in`("tag", listOf("a,b", "plain")) },
+        )
+    }
+
+    @Test
+    fun test_nested_and_within_or_combinesCorrectly() {
+        val result =
+            filters {
+                or {
+                    eq("status", "active")
+                    and {
+                        gte("age", "18")
+                        lt("age", "65")
+                    }
+                }
+            }
+        assertEquals(listOf("or" to "(status.eq.active,and.(age.gte.18,age.lt.65))"), result)
+    }
+
     @Test
     fun test_gt_producesCorrectParam() {
         val result = filters { gt("age", "18") }

--- a/supabase-database/src/commonTest/kotlin/io/github/androidpoet/supabase/database/PostgrestConformanceTest.kt
+++ b/supabase-database/src/commonTest/kotlin/io/github/androidpoet/supabase/database/PostgrestConformanceTest.kt
@@ -1,0 +1,308 @@
+package io.github.androidpoet.supabase.database
+
+import io.github.androidpoet.supabase.client.SupabaseClient
+import io.github.androidpoet.supabase.client.SupabaseHttpMethod
+import io.github.androidpoet.supabase.client.SupabaseHttpResponse
+import io.github.androidpoet.supabase.core.result.SupabaseError
+import io.github.androidpoet.supabase.core.result.SupabaseResult
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * Conformance tests that lock the exact PostgREST wire format the SDK emits —
+ * the `Prefer`/`Accept` headers, schema profile headers, and query string —
+ * against the documented PostgREST contract. These guard against silent
+ * regressions in request building that would only surface against a live server.
+ *
+ * References:
+ *  - PostgREST Prefer header: https://postgrest.org/en/stable/references/api/preferences.html
+ *  - PostgREST resource representation / count / Accept media types:
+ *    https://postgrest.org/en/stable/references/api/tables_views.html
+ *  - PostgREST schema selection (Accept-Profile / Content-Profile):
+ *    https://postgrest.org/en/stable/references/api/schemas.html
+ */
+class PostgrestConformanceTest {
+    // --- Prefer header ---------------------------------------------------------
+
+    @Test
+    fun test_insert_default_prefersReturnRepresentation() =
+        runTest {
+            val client = RecordingClient()
+            DatabaseClientImpl(client).insert(table = "todos", body = "{}")
+            assertEquals("return=representation", client.postHeaders["Prefer"])
+        }
+
+    @Test
+    fun test_insert_upsertWithCountAndMissingAndRollback_combinesPreferDirectivesInOrder() =
+        runTest {
+            val client = RecordingClient()
+            DatabaseClientImpl(client).insert(
+                table = "todos",
+                body = "{}",
+                upsert = true,
+                upsertResolution = UpsertResolution.MERGE_DUPLICATES,
+                defaultToNull = false,
+                count = CountOption.EXACT,
+                rollback = true,
+            )
+            assertEquals(
+                "return=representation, count=exact, resolution=merge-duplicates, missing=default, tx=rollback",
+                client.postHeaders["Prefer"],
+            )
+        }
+
+    @Test
+    fun test_insert_ignoreDuplicates_usesIgnoreResolution() =
+        runTest {
+            val client = RecordingClient()
+            DatabaseClientImpl(client).insert(
+                table = "todos",
+                body = "{}",
+                upsert = true,
+                upsertResolution = UpsertResolution.IGNORE_DUPLICATES,
+            )
+            assertEquals("return=representation, resolution=ignore-duplicates", client.postHeaders["Prefer"])
+        }
+
+    @Test
+    fun test_update_maxAffected_addsStrictHandlingDirectives() =
+        runTest {
+            val client = RecordingClient()
+            DatabaseClientImpl(client).update(
+                table = "todos",
+                body = "{}",
+                maxAffected = 5,
+            ) {}
+            assertEquals("return=representation, handling=strict, max-affected=5", client.patchHeaders["Prefer"])
+        }
+
+    @Test
+    fun test_update_minimalReturn_prefersReturnMinimal() =
+        runTest {
+            val client = RecordingClient()
+            DatabaseClientImpl(client).update(
+                table = "todos",
+                body = "{}",
+                returning = ReturnOption.MINIMAL,
+            ) {}
+            assertEquals("return=minimal", client.patchHeaders["Prefer"])
+        }
+
+    @Test
+    fun test_select_countExact_prefersCount() =
+        runTest {
+            val client = RecordingClient()
+            DatabaseClientImpl(client).select(table = "todos", count = CountOption.EXACT) {}
+            assertEquals("count=exact", client.getHeaders["Prefer"])
+        }
+
+    @Test
+    fun test_select_noPreferences_omitsPreferHeader() =
+        runTest {
+            val client = RecordingClient()
+            DatabaseClientImpl(client).select(table = "todos") {}
+            assertEquals(null, client.getHeaders["Prefer"])
+        }
+
+    // --- Accept header ---------------------------------------------------------
+
+    @Test
+    fun test_select_single_usesObjectMediaType() =
+        runTest {
+            val client = RecordingClient()
+            DatabaseClientImpl(client).select(table = "todos", single = true) {}
+            assertEquals("application/vnd.pgrst.object+json", client.getHeaders["Accept"])
+        }
+
+    @Test
+    fun test_select_singleStripNulls_appendsNullsStripped() =
+        runTest {
+            val client = RecordingClient()
+            DatabaseClientImpl(client).select(table = "todos", single = true, stripNulls = true) {}
+            assertEquals("application/vnd.pgrst.object+json;nulls=stripped", client.getHeaders["Accept"])
+        }
+
+    @Test
+    fun test_select_arrayStripNulls_usesArrayMediaTypeWithNullsStripped() =
+        runTest {
+            val client = RecordingClient()
+            DatabaseClientImpl(client).select(table = "todos", stripNulls = true) {}
+            assertEquals("application/vnd.pgrst.array+json;nulls=stripped", client.getHeaders["Accept"])
+        }
+
+    @Test
+    fun test_select_csv_usesTextCsv() =
+        runTest {
+            val client = RecordingClient()
+            DatabaseClientImpl(client).select(table = "todos", csv = true) {}
+            assertEquals("text/csv", client.getHeaders["Accept"])
+        }
+
+    @Test
+    fun test_select_geojson_usesGeoJsonMediaType() =
+        runTest {
+            val client = RecordingClient()
+            DatabaseClientImpl(client).select(table = "todos", geojson = true) {}
+            assertEquals("application/geo+json", client.getHeaders["Accept"])
+        }
+
+    @Test
+    fun test_select_explain_usesPlanMediaTypeWithOptions() =
+        runTest {
+            val client = RecordingClient()
+            DatabaseClientImpl(client).select(
+                table = "todos",
+                explain = ExplainOptions(analyze = true, verbose = true, format = ExplainFormat.TEXT),
+            ) {}
+            assertEquals(
+                "application/vnd.pgrst.plan+text; for=\"application/json\"; options=analyze|verbose;",
+                client.getHeaders["Accept"],
+            )
+        }
+
+    // --- Schema profile headers ------------------------------------------------
+
+    @Test
+    fun test_select_withSchema_usesAcceptProfile() =
+        runTest {
+            val client = RecordingClient()
+            DatabaseClientImpl(client).select(table = "todos", schema = "analytics") {}
+            assertEquals("analytics", client.getHeaders["Accept-Profile"])
+            assertEquals(null, client.getHeaders["Content-Profile"])
+        }
+
+    @Test
+    fun test_insert_withSchema_usesContentProfile() =
+        runTest {
+            val client = RecordingClient()
+            DatabaseClientImpl(client).insert(table = "todos", schema = "analytics", body = "{}")
+            assertEquals("analytics", client.postHeaders["Content-Profile"])
+            assertEquals(null, client.postHeaders["Accept-Profile"])
+        }
+
+    // --- Query string ----------------------------------------------------------
+
+    @Test
+    fun test_select_emitsSelectAndFilterQueryParams() =
+        runTest {
+            val client = RecordingClient()
+            DatabaseClientImpl(client).select(table = "todos", columns = "id,title") {
+                eq("status", "active")
+                order("created_at", ascending = false)
+                limit(10)
+            }
+            assertEquals(
+                "/rest/v1/todos?select=id,title&status=eq.active&order=created_at.desc&limit=10",
+                client.getEndpoint,
+            )
+        }
+
+    @Test
+    fun test_select_filterValueWithComma_isQuotedInQueryString() =
+        runTest {
+            // PostgREST treats comma as a structural separator, so a value containing
+            // one must be double-quoted to keep its meaning.
+            val client = RecordingClient()
+            DatabaseClientImpl(client).select(table = "todos") {
+                eq("tag", "a,b")
+            }
+            assertEquals("""/rest/v1/todos?select=*&tag=eq."a,b"""", client.getEndpoint)
+        }
+
+    @Test
+    fun test_insert_jsonContentTypeHeaderSet() =
+        runTest {
+            val client = RecordingClient()
+            DatabaseClientImpl(client).insert(table = "todos", body = "{}")
+            assertEquals("application/json", client.postHeaders["Content-Type"])
+        }
+}
+
+private class RecordingClient : SupabaseClient {
+    override val projectUrl: String = "https://example.supabase.co"
+    override val apiKey: String = "anon"
+    override val accessTokenOrNull: String? = null
+
+    var getEndpoint: String? = null
+    var getHeaders: Map<String, String> = emptyMap()
+    var postHeaders: Map<String, String> = emptyMap()
+    var patchHeaders: Map<String, String> = emptyMap()
+    var deleteHeaders: Map<String, String> = emptyMap()
+
+    override suspend fun get(
+        endpoint: String,
+        queryParams: List<Pair<String, String>>,
+        headers: Map<String, String>,
+    ): SupabaseResult<String> {
+        getEndpoint =
+            if (queryParams.isEmpty()) {
+                endpoint
+            } else {
+                "$endpoint?${queryParams.joinToString("&") { "${it.first}=${it.second}" }}"
+            }
+        getHeaders = headers
+        return SupabaseResult.Success("[]")
+    }
+
+    override suspend fun post(
+        endpoint: String,
+        body: String?,
+        headers: Map<String, String>,
+    ): SupabaseResult<String> {
+        postHeaders = headers
+        return SupabaseResult.Success("[]")
+    }
+
+    override suspend fun patch(
+        endpoint: String,
+        body: String?,
+        headers: Map<String, String>,
+    ): SupabaseResult<String> {
+        patchHeaders = headers
+        return SupabaseResult.Success("[]")
+    }
+
+    override suspend fun delete(
+        endpoint: String,
+        body: String?,
+        headers: Map<String, String>,
+    ): SupabaseResult<String> {
+        deleteHeaders = headers
+        return SupabaseResult.Success("[]")
+    }
+
+    override suspend fun put(
+        endpoint: String,
+        body: String?,
+        headers: Map<String, String>,
+    ): SupabaseResult<String> = SupabaseResult.Success("[]")
+
+    override suspend fun postRaw(
+        url: String,
+        body: ByteArray,
+        contentType: String,
+        headers: Map<String, String>,
+    ): SupabaseResult<String> = SupabaseResult.Success("[]")
+
+    override suspend fun putRaw(
+        url: String,
+        body: ByteArray,
+        contentType: String,
+        headers: Map<String, String>,
+    ): SupabaseResult<String> = SupabaseResult.Success("[]")
+
+    override suspend fun rawRequest(
+        method: SupabaseHttpMethod,
+        url: String,
+        body: ByteArray?,
+        contentType: String?,
+        headers: Map<String, String>,
+    ): SupabaseResult<SupabaseHttpResponse> = SupabaseResult.Failure(SupabaseError("not used"))
+
+    override fun setAccessToken(token: String) = Unit
+
+    override fun clearAccessToken() = Unit
+
+    override fun close() = Unit
+}

--- a/supabase-realtime/src/commonTest/kotlin/io/github/androidpoet/supabase/realtime/PostgresChangesConformanceTest.kt
+++ b/supabase-realtime/src/commonTest/kotlin/io/github/androidpoet/supabase/realtime/PostgresChangesConformanceTest.kt
@@ -1,0 +1,139 @@
+package io.github.androidpoet.supabase.realtime
+
+import io.github.androidpoet.supabase.client.SupabaseClient
+import io.github.androidpoet.supabase.client.SupabaseHttpMethod
+import io.github.androidpoet.supabase.client.SupabaseHttpResponse
+import io.github.androidpoet.supabase.core.result.SupabaseError
+import io.github.androidpoet.supabase.core.result.SupabaseResult
+import io.github.androidpoet.supabase.realtime.models.PostgresChangeEvent
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.Serializable
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+@Serializable
+private data class Message(
+    val id: Int,
+    val roomId: Int,
+    val body: String,
+)
+
+/**
+ * Conformance tests for the `postgres_changes` binding config the SDK puts in the
+ * `phx_join` payload. The Realtime protocol expects each binding to carry
+ * `event` / `schema` / `table` / `filter`, where the filter is a single
+ * `column=operator.value` string limited to the operators eq, neq, gt, gte, lt,
+ * lte, in.
+ *
+ * Reference: https://supabase.com/docs/guides/realtime/protocol and
+ * https://supabase.com/docs/guides/realtime/postgres-changes
+ */
+class PostgresChangesConformanceTest {
+    private fun realtime() = RealtimeClientImpl(FakeClient(), RealtimeConfig(autoReconnect = false))
+
+    @Test
+    fun test_typedChange_withRealtimeFilter_propagatesBindingConfig() =
+        runTest {
+            val subscription =
+                realtime()
+                    .channel("room-1")
+                    .onPostgresChange<Message>(
+                        schema = "public",
+                        table = "messages",
+                        filter = realtimeFilter { eq("room_id", 5) },
+                        event = PostgresChangeEvent.INSERT,
+                    ) { }
+                    .subscribe()
+
+            val binding = (subscription as ChannelSubscriptionImpl).postgresCallbacks.single()
+            assertEquals("public", binding.schema)
+            assertEquals("messages", binding.table)
+            assertEquals("room_id=eq.5", binding.filter)
+            assertEquals(PostgresChangeEvent.INSERT, binding.event)
+        }
+
+    @Test
+    fun test_change_withoutTableOrFilter_leavesThemNull() =
+        runTest {
+            val subscription =
+                realtime()
+                    .channel("schema-wide")
+                    .onPostgresChange(schema = "public") { }
+                    .subscribe()
+
+            val binding = (subscription as ChannelSubscriptionImpl).postgresCallbacks.single()
+            assertEquals("public", binding.schema)
+            assertEquals(null, binding.table)
+            assertEquals(null, binding.filter)
+            assertEquals(PostgresChangeEvent.ALL, binding.event)
+        }
+
+    @Test
+    fun test_realtimeFilter_inOperator_usesParenList() {
+        assertEquals("status=in.(open,pending)", realtimeFilter { isIn("status", listOf("open", "pending")) })
+    }
+}
+
+private class FakeClient : SupabaseClient {
+    override val projectUrl: String = "https://example.supabase.co"
+    override val apiKey: String = "anon"
+    override val accessTokenOrNull: String? = null
+
+    override suspend fun get(
+        endpoint: String,
+        queryParams: List<Pair<String, String>>,
+        headers: Map<String, String>,
+    ): SupabaseResult<String> = SupabaseResult.Success("{}")
+
+    override suspend fun post(
+        endpoint: String,
+        body: String?,
+        headers: Map<String, String>,
+    ): SupabaseResult<String> = SupabaseResult.Success("{}")
+
+    override suspend fun put(
+        endpoint: String,
+        body: String?,
+        headers: Map<String, String>,
+    ): SupabaseResult<String> = SupabaseResult.Success("{}")
+
+    override suspend fun patch(
+        endpoint: String,
+        body: String?,
+        headers: Map<String, String>,
+    ): SupabaseResult<String> = SupabaseResult.Success("{}")
+
+    override suspend fun delete(
+        endpoint: String,
+        body: String?,
+        headers: Map<String, String>,
+    ): SupabaseResult<String> = SupabaseResult.Success("{}")
+
+    override suspend fun postRaw(
+        url: String,
+        body: ByteArray,
+        contentType: String,
+        headers: Map<String, String>,
+    ): SupabaseResult<String> = SupabaseResult.Success("{}")
+
+    override suspend fun putRaw(
+        url: String,
+        body: ByteArray,
+        contentType: String,
+        headers: Map<String, String>,
+    ): SupabaseResult<String> = SupabaseResult.Success("{}")
+
+    override suspend fun rawRequest(
+        method: SupabaseHttpMethod,
+        url: String,
+        body: ByteArray?,
+        contentType: String?,
+        headers: Map<String, String>,
+    ): SupabaseResult<SupabaseHttpResponse> = SupabaseResult.Failure(SupabaseError("not used"))
+
+    override fun setAccessToken(token: String) = Unit
+
+    override fun clearAccessToken() = Unit
+
+    override fun close() = Unit
+}


### PR DESCRIPTION
## Docs-grounded conformance & reliability tests

Locks the SDK's wire behavior against the **documented** PostgREST / GoTrue /
Realtime contracts (sourced from the upstream PostgREST `.rst`, the GoTrue repo,
and the Supabase Realtime protocol docs) so a regression in request building or
error handling fails CI instead of surfacing only against a live server.

### PostgREST request conformance
`PostgrestConformanceTest` pins the exact wire format the SDK emits:
- `Prefer` header content **and ordering** — `return`, `count`, `resolution`,
  `missing=default`, `tx=rollback`, `handling=strict` + `max-affected`.
- `Accept` media types — `application/vnd.pgrst.object+json` (+`;nulls=stripped`),
  `text/csv`, `application/geo+json`, stripped-nulls array, explain plan.
- Schema selection headers — `Accept-Profile` (read) vs `Content-Profile` (write).
- The emitted `select` / filter / `order` / `limit` query string.

### Filter quoting / injection safety
`FiltersTest` now covers values containing `,` `( )` `"` `\` and empty strings —
PostgREST structural characters — verifying they're double-quoted and escaped so
a filter value can't inject query structure, plus nested `and`/`or` grouping.

### Error-body parsing conformance
`ErrorParsingConformanceTest` drives the transport against every error shape the
services actually return:
- GoTrue **legacy** `{code:<int>, error_code, msg}`, **new** `{code:<string>,
  message}`, and **OAuth** `{error, error_description}`.
- PostgREST `{code, message, details, hint}` and Storage `{code, message}`.
- `Retry-After` capture, and HTTP-status → category mapping for empty / non-JSON
  bodies.

### Realtime conformance
`PostgresChangesConformanceTest` verifies the `postgres_changes` binding config
(`event`/`schema`/`table`/`filter`) propagates into the join payload, and that
the filter builder's operator set matches Realtime's supported set
(`eq, neq, gt, gte, lt, lte, in`).

## Reliability fix surfaced by the docs
Prefer the textual `error_code` over the numeric legacy GoTrue `code`, so
`error.code` surfaces e.g. `weak_password` instead of `422`. PostgREST, new
GoTrue, and Storage are unaffected (they don't send `error_code`). Private
parser change — no ABI impact.

## Compatibility
Tests + one private parser change. No public API changes (ABI unchanged). 0.x.
