### PR TITLE
chore: bump version to 0.4.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Add the dependencies you need to your `build.gradle.kts`:
 
 ```kotlin
 [versions]
-supabase-kmp = "0.4.0"
+supabase-kmp = "0.4.1"
 
 [libraries]
 supabase-core = { module = "io.github.androidpoet:supabase-core", version.ref = "supabase-kmp" }

--- a/buildSrc/src/main/kotlin/io/github/androidpoet/supabase/Configuration.kt
+++ b/buildSrc/src/main/kotlin/io/github/androidpoet/supabase/Configuration.kt
@@ -2,7 +2,7 @@ package io.github.androidpoet.supabase
 
 object Configuration {
     const val GROUP = "io.github.androidpoet"
-    const val VERSION = "0.4.0"
+    const val VERSION = "0.4.1"
     const val COMPILE_SDK = 35
     const val MIN_SDK = 21
 }

--- a/website/pages/getting-started.mdx
+++ b/website/pages/getting-started.mdx
@@ -13,7 +13,7 @@ version and the modules you need to your version catalog.
 
 ```toml filename="gradle/libs.versions.toml"
 [versions]
-supabase-kmp = "0.4.0"
+supabase-kmp = "0.4.1"
 
 [libraries]
 supabase-client = { module = "io.github.androidpoet:supabase-client", version.ref = "supabase-kmp" }


### PR DESCRIPTION
Version bump to 0.4.1 for release. Covers the ergonomics additions (#37) and the docs-grounded conformance tests + tolerant error-code parsing (#38). Bumps `Configuration.VERSION`, README, and the docs install snippet.

Publishing to Maven Central runs from `publish.yml` when the GitHub release `v0.4.1` is published.