### PR TITLE
fix(client): classify network errors by Ktor exception type

### DIFF
--- a/supabase-client/src/commonMain/kotlin/io/github/androidpoet/supabase/client/transport/HttpTransport.kt
+++ b/supabase-client/src/commonMain/kotlin/io/github/androidpoet/supabase/client/transport/HttpTransport.kt
@@ -7,6 +7,9 @@ import io.github.androidpoet.supabase.core.result.SupabaseErrorCodes
 import io.github.androidpoet.supabase.core.result.SupabaseResult
 import io.ktor.client.HttpClient
 import io.ktor.client.engine.HttpClientEngineFactory
+import io.ktor.client.network.sockets.ConnectTimeoutException
+import io.ktor.client.network.sockets.SocketTimeoutException
+import io.ktor.client.plugins.HttpRequestTimeoutException
 import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
 import io.ktor.client.plugins.defaultRequest
 import io.ktor.client.plugins.logging.Logging
@@ -28,6 +31,7 @@ import io.ktor.http.isSuccess
 import io.ktor.serialization.kotlinx.json.json
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.delay
+import kotlinx.io.IOException
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
@@ -347,12 +351,25 @@ internal class HttpTransport(
         throwable: Throwable? = null,
         message: String? = null,
     ): SupabaseError {
-        val name = throwable?.let { it::class.simpleName.orEmpty() } ?: ""
         val code =
-            when {
-                name.contains("Timeout", ignoreCase = true) -> SupabaseErrorCodes.Client.TIMEOUT
-                name.contains("Connect", ignoreCase = true) -> SupabaseErrorCodes.Client.CONNECTION_FAILED
-                else -> SupabaseErrorCodes.Client.NETWORK_ERROR
+            when (throwable) {
+                // Match Ktor's typed exceptions first so a future class rename can't
+                // silently misroute the error. Fall back to name matching only for
+                // engine-specific exceptions we don't model directly.
+                is HttpRequestTimeoutException,
+                is ConnectTimeoutException,
+                is SocketTimeoutException,
+                -> SupabaseErrorCodes.Client.TIMEOUT
+                is IOException -> SupabaseErrorCodes.Client.CONNECTION_FAILED
+                null -> SupabaseErrorCodes.Client.NETWORK_ERROR
+                else -> {
+                    val name = throwable::class.simpleName.orEmpty()
+                    when {
+                        name.contains("Timeout", ignoreCase = true) -> SupabaseErrorCodes.Client.TIMEOUT
+                        name.contains("Connect", ignoreCase = true) -> SupabaseErrorCodes.Client.CONNECTION_FAILED
+                        else -> SupabaseErrorCodes.Client.NETWORK_ERROR
+                    }
+                }
             }
         return SupabaseError(
             message = message ?: throwable?.message ?: "Network request failed",

--- a/supabase-client/src/commonTest/kotlin/io/github/androidpoet/supabase/client/transport/HttpTransportTest.kt
+++ b/supabase-client/src/commonTest/kotlin/io/github/androidpoet/supabase/client/transport/HttpTransportTest.kt
@@ -72,6 +72,36 @@ class HttpTransportTest {
         }
 
     @Test
+    fun test_get_typedIOExceptionMapsToConnectionFailed() =
+        runTest {
+            val transport =
+                HttpTransport(
+                    config =
+                        SupabaseConfig(
+                            logging = false,
+                            logLevel = io.ktor.client.plugins.logging.LogLevel.NONE,
+                            headers = emptyMap(),
+                        ),
+                    engineFactory =
+                        TestMockEngineFactory {
+                            throw kotlinx.io.IOException("connection refused")
+                        },
+                    projectUrl = "https://example.supabase.co",
+                    apiKey = "anon",
+                )
+
+            val result = transport.get(url = "https://example.supabase.co/rest/v1/messages")
+
+            // An IOException carries neither "Timeout" nor "Connect" in its class name,
+            // so the old string-matching path mislabeled it NETWORK_ERROR. Typed
+            // classification recognizes it as a connection failure.
+            assertEquals(
+                io.github.androidpoet.supabase.core.result.SupabaseErrorCodes.Client.CONNECTION_FAILED,
+                result.errorOrNull()?.code,
+            )
+        }
+
+    @Test
     fun test_get_propagatesCoroutineCancellation() =
         runTest {
             val transport =


### PR DESCRIPTION
## Problem

`HttpTransport.networkError()` classified thrown request exceptions by **substring-matching the class name** (`name.contains("Timeout")`/`name.contains("Connect")`). Two issues:

1. **Fragile** — an upstream class rename silently misroutes the error code.
2. **Incorrect fallthrough** — exceptions whose names contain neither token (e.g. `IOException` for a refused/dropped connection) were labelled `NETWORK_ERROR` instead of `CONNECTION_FAILED`.

## Fix

Match Ktor's **typed** exceptions first, name matching only as fallback:

| Exception | Code |
|---|---|
| `HttpRequestTimeoutException`, `ConnectTimeoutException`, `SocketTimeoutException` | `TIMEOUT` |
| `IOException` | `CONNECTION_FAILED` |
| (unmodeled) | name-match fallback, then `NETWORK_ERROR` |

All map to `SupabaseErrorCategory.Network`, so retry/offline behaviour is unchanged; codes are now accurate.

## Test

Adds `test_get_typedIOExceptionMapsToConnectionFailed`. Full `HttpTransportTest` suite green on JVM. Single private function + imports + one test. No public API change.