### PR TITLE
fix(auth): schedule token refresh off absolute JWT exp, not relative expires_in

### DIFF
--- a/supabase-auth/src/commonMain/kotlin/io/github/androidpoet/supabase/auth/AuthClientExt.kt
+++ b/supabase-auth/src/commonMain/kotlin/io/github/androidpoet/supabase/auth/AuthClientExt.kt
@@ -769,6 +769,16 @@ private fun decodeJwtHeader(segment: String): JwtHeader? {
     }
 }
 
+/**
+ * Extracts the absolute `exp` claim (seconds since the Unix epoch) from an
+ * access token, or null when the token is not a decodable JWT. The session
+ * layer uses this to schedule auto-refresh against wall-clock time instead of a
+ * relative `expires_in`, which goes stale the moment a session is persisted and
+ * restored later.
+ */
+internal fun accessTokenExpiryEpochSeconds(accessToken: String): Long? =
+    (decodeJwt(accessToken) as? SupabaseResult.Success)?.value?.claims?.expiresAt
+
 private fun decodeJwt(jwt: String): SupabaseResult<JwtClaimsResult> {
     val parts = jwt.split('.')
     if (parts.size < 2) {

--- a/supabase-auth/src/commonMain/kotlin/io/github/androidpoet/supabase/auth/session/SessionManagerImpl.kt
+++ b/supabase-auth/src/commonMain/kotlin/io/github/androidpoet/supabase/auth/session/SessionManagerImpl.kt
@@ -1,5 +1,6 @@
 package io.github.androidpoet.supabase.auth.session
 import io.github.androidpoet.supabase.auth.AuthClient
+import io.github.androidpoet.supabase.auth.accessTokenExpiryEpochSeconds
 import io.github.androidpoet.supabase.auth.models.Session
 import io.github.androidpoet.supabase.client.SupabaseClient
 import io.github.androidpoet.supabase.core.result.SupabaseError
@@ -18,6 +19,7 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
+import kotlinx.datetime.Clock
 import kotlin.concurrent.Volatile
 
 internal class SessionManagerImpl(
@@ -132,7 +134,7 @@ internal class SessionManagerImpl(
     private fun scheduleRefresh(session: Session) {
         if (!autoRefreshEnabled) return
         cancelRefresh()
-        val delayMs = maxOf((session.expiresIn - refreshBufferSeconds) * 1000L, 0L)
+        val delayMs = computeRefreshDelayMs(session)
         refreshJob =
             scope.launch {
                 delay(delayMs)
@@ -140,8 +142,43 @@ internal class SessionManagerImpl(
             }
     }
 
+    private fun computeRefreshDelayMs(session: Session): Long {
+        val remainingSeconds = remainingSecondsUntilExpiry(session)
+        // A session restored from storage may already be past its scheduled
+        // refresh (or expired); refresh promptly, but never with a zero delay
+        // that would spin the loop if the next token is also short-lived.
+        if (remainingSeconds <= 0) return MIN_REFRESH_DELAY_MS
+        // Cap the buffer at half the remaining lifetime so a token whose life is
+        // shorter than refreshBufferSeconds still schedules a positive delay
+        // instead of refreshing immediately in a tight loop. For normal,
+        // long-lived tokens this is exactly refreshBufferSeconds.
+        val effectiveBuffer = minOf(refreshBufferSeconds, remainingSeconds / 2)
+        val secondsUntilRefresh = remainingSeconds - effectiveBuffer
+        return maxOf(secondsUntilRefresh * 1000L, MIN_REFRESH_DELAY_MS)
+    }
+
+    // Prefer the access token's absolute `exp` claim: a persisted session
+    // carries a relative `expires_in` captured at issue time, so scheduling off
+    // it after the clock has advanced refreshes too late (or never). Fall back
+    // to `expires_in` when the token is not a decodable JWT.
+    private fun remainingSecondsUntilExpiry(session: Session): Long {
+        val expiryEpochSeconds = accessTokenExpiryEpochSeconds(session.accessToken)
+        return if (expiryEpochSeconds != null) {
+            expiryEpochSeconds - Clock.System.now().epochSeconds
+        } else {
+            session.expiresIn
+        }
+    }
+
     private fun cancelRefresh() {
         refreshJob?.cancel()
         refreshJob = null
+    }
+
+    private companion object {
+        // Lower bound on the scheduled delay. Prevents a 0 ms delay from busy-
+        // looping the refresh coroutine when a token is already past its refresh
+        // window, while still refreshing quickly.
+        private const val MIN_REFRESH_DELAY_MS = 1_000L
     }
 }

--- a/supabase-auth/src/commonTest/kotlin/io/github/androidpoet/supabase/auth/session/SessionManagerImplTest.kt
+++ b/supabase-auth/src/commonTest/kotlin/io/github/androidpoet/supabase/auth/session/SessionManagerImplTest.kt
@@ -1,6 +1,7 @@
 package io.github.androidpoet.supabase.auth.session
 
 import io.github.androidpoet.supabase.auth.AuthClientImpl
+import io.github.androidpoet.supabase.auth.accessTokenExpiryEpochSeconds
 import io.github.androidpoet.supabase.auth.models.Session
 import io.github.androidpoet.supabase.auth.models.User
 import io.github.androidpoet.supabase.client.SupabaseClient
@@ -10,9 +11,27 @@ import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
 class SessionManagerImplTest {
+    @Test
+    fun test_accessTokenExpiry_readsAbsoluteExpClaimFromJwt() {
+        // header {"alg":"none","typ":"JWT"} . payload {"exp":1700000000,"sub":"u1"} .
+        val jwt =
+            "eyJhbGciOiJub25lIiwidHlwIjoiSldUIn0" +
+                ".eyJleHAiOjE3MDAwMDAwMDAsInN1YiI6InUxIn0."
+
+        // Refresh scheduling derives the delay from this absolute claim rather
+        // than the relative expires_in, so a restored session refreshes on time.
+        assertEquals(1700000000L, accessTokenExpiryEpochSeconds(jwt))
+    }
+
+    @Test
+    fun test_accessTokenExpiry_returnsNullForNonJwt() {
+        assertNull(accessTokenExpiryEpochSeconds("opaque-access-token"))
+    }
+
     @Test
     fun test_initialize_restoresAndRefreshesStoredSession() =
         runTest {


### PR DESCRIPTION
## Problem

`SessionManagerImpl.scheduleRefresh()` computed its delay from the **relative** `expires_in`:

```kotlin
val delayMs = maxOf((session.expiresIn - refreshBufferSeconds) * 1000L, 0L)
```

`expires_in` is captured at token-issue time. Two failure modes:

1. **Stale after restore** — a session loaded from `SessionStorage` minutes/hours later still uses the original `expires_in`, so the refresh is scheduled too late (or, once the value is effectively in the past, fires immediately).
2. **0 ms storm** — a token whose lifetime is shorter than `refreshBufferSeconds` (default 60s) yields `delayMs == 0`, and if the refreshed token is also short-lived the loop spins.

## Fix

Schedule against the token's **absolute `exp` claim**:

- New internal `accessTokenExpiryEpochSeconds()` reuses the existing JWT decoder to read `exp`; falls back to `expires_in` for opaque (non-JWT) tokens.
- `remainingSecondsUntilExpiry = exp - now` (wall clock), so a restored session schedules correctly.
- **Cap the buffer at half the remaining lifetime** → short-lived tokens still get a positive delay instead of refreshing instantly.
- **Floor the delay at 1s** → an already-expired restored session refreshes promptly without busy-looping.

For a normal long-lived token the effective behaviour is unchanged (`remaining - refreshBufferSeconds`).

## Tests

- `test_accessTokenExpiry_readsAbsoluteExpClaimFromJwt` — deterministic, asserts the absolute claim is extracted.
- `test_accessTokenExpiry_returnsNullForNonJwt` — opaque tokens fall back.
- Existing `SessionManagerImplTest` suite still green on JVM.

## Scope

No public API change (`accessTokenExpiryEpochSeconds` is `internal`).