### PR TITLE
fix(auth): reject structurally unusable persisted sessions on load

### DIFF
--- a/supabase-auth/src/commonMain/kotlin/io/github/androidpoet/supabase/auth/session/KeyValueSessionStorage.kt
+++ b/supabase-auth/src/commonMain/kotlin/io/github/androidpoet/supabase/auth/session/KeyValueSessionStorage.kt
@@ -43,8 +43,21 @@ public class KeyValueSessionStorage(
         val raw = store.get(key) ?: return null
         // A corrupt or schema-changed payload should read as "no session" rather
         // than crash the caller; the next sign-in overwrites it.
-        return runCatching { json.decodeFromString(Session.serializer(), raw) }.getOrNull()
+        val session = runCatching { json.decodeFromString(Session.serializer(), raw) }.getOrNull()
+        // Valid JSON can still decode into a structurally unusable session —
+        // empty tokens or a negative expiry from partial corruption or a tampered
+        // store. Treat those as "no session" too, so the caller doesn't restore a
+        // token that can only fail with a surprising 401 on the first request.
+        return session?.takeIf(::isUsable)
     }
+
+    // A session is only usable if it carries both tokens and a non-negative
+    // lifetime; the refresh token in particular must survive so the session can
+    // be renewed after the access token expires.
+    private fun isUsable(session: Session): Boolean =
+        session.accessToken.isNotBlank() &&
+            session.refreshToken.isNotBlank() &&
+            session.expiresIn >= 0
 
     override suspend fun clear() {
         store.remove(key)

--- a/supabase-auth/src/commonTest/kotlin/io/github/androidpoet/supabase/auth/session/KeyValueSessionStorageTest.kt
+++ b/supabase-auth/src/commonTest/kotlin/io/github/androidpoet/supabase/auth/session/KeyValueSessionStorageTest.kt
@@ -1,0 +1,79 @@
+package io.github.androidpoet.supabase.auth.session
+
+import io.github.androidpoet.supabase.auth.models.Session
+import io.github.androidpoet.supabase.auth.models.User
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class KeyValueSessionStorageTest {
+    @Test
+    fun test_load_roundTripsUsableSession() =
+        runTest {
+            val store = FakeKeyValueStore()
+            val storage = KeyValueSessionStorage(store)
+
+            storage.save(validSession)
+
+            assertEquals(validSession, storage.load())
+        }
+
+    @Test
+    fun test_load_returnsNullForCorruptPayload() =
+        runTest {
+            val store = FakeKeyValueStore()
+            store.set(KeyValueSessionStorage.DEFAULT_KEY, "not-json{")
+
+            assertNull(KeyValueSessionStorage(store).load())
+        }
+
+    @Test
+    fun test_load_rejectsStructurallyUnusableSession() =
+        runTest {
+            // Valid JSON, but the refresh token is empty — the session can never be
+            // renewed, so restoring it would only yield a 401 later.
+            val store = FakeKeyValueStore()
+            store.set(
+                KeyValueSessionStorage.DEFAULT_KEY,
+                """{"access_token":"acc","refresh_token":"","expires_in":3600,"token_type":"bearer","user":{"id":"u1"}}""",
+            )
+
+            assertNull(KeyValueSessionStorage(store).load())
+        }
+
+    @Test
+    fun test_load_rejectsNegativeExpiry() =
+        runTest {
+            val store = FakeKeyValueStore()
+            store.set(
+                KeyValueSessionStorage.DEFAULT_KEY,
+                """{"access_token":"acc","refresh_token":"ref","expires_in":-1,"token_type":"bearer","user":{"id":"u1"}}""",
+            )
+
+            assertNull(KeyValueSessionStorage(store).load())
+        }
+}
+
+private val validSession =
+    Session(
+        accessToken = "acc",
+        refreshToken = "ref",
+        expiresIn = 3600,
+        tokenType = "bearer",
+        user = User(id = "u1"),
+    )
+
+private class FakeKeyValueStore : KeyValueStore {
+    private val map = mutableMapOf<String, String>()
+
+    override suspend fun get(key: String): String? = map[key]
+
+    override suspend fun set(key: String, value: String) {
+        map[key] = value
+    }
+
+    override suspend fun remove(key: String) {
+        map.remove(key)
+    }
+}


### PR DESCRIPTION
## Problem

`KeyValueSessionStorage.load()` returned any payload that merely **parsed** as valid JSON:

```kotlin
return runCatching { json.decodeFromString(Session.serializer(), raw) }.getOrNull()
```

Partial corruption or a tampered store can decode into a structurally broken `Session` — empty `access_token`/`refresh_token` or a negative `expires_in`. The caller restores it, then the first request fails with a surprising `401`, and with an empty refresh token the session can't even be renewed.

## Fix

Validate the decoded session and treat an unusable one as **"no session"** (so the next sign-in cleanly overwrites it):

```kotlin
private fun isUsable(session: Session): Boolean =
    session.accessToken.isNotBlank() &&
        session.refreshToken.isNotBlank() &&
        session.expiresIn >= 0
```

The existing corrupt-JSON behaviour (read as null, never crash) is unchanged.

## Tests

New `KeyValueSessionStorageTest`:
- usable session round-trips
- corrupt non-JSON → null (unchanged)
- empty refresh token → null
- negative expiry → null

## Scope

No public API change.