### PR TITLE
feat(realtime): signal dropped messages when the offline send buffer is full

### DIFF
--- a/supabase-realtime/api/android/supabase-realtime.api
+++ b/supabase-realtime/api/android/supabase-realtime.api
@@ -189,6 +189,19 @@ public final class io/github/androidpoet/supabase/realtime/RealtimeDebugEvent$Ou
 	public fun toString ()Ljava/lang/String;
 }
 
+public final class io/github/androidpoet/supabase/realtime/RealtimeDebugEvent$OutboundMessageDropped : io/github/androidpoet/supabase/realtime/RealtimeDebugEvent {
+	public fun <init> (Lio/github/androidpoet/supabase/realtime/models/RealtimeMessage;I)V
+	public final fun component1 ()Lio/github/androidpoet/supabase/realtime/models/RealtimeMessage;
+	public final fun component2 ()I
+	public final fun copy (Lio/github/androidpoet/supabase/realtime/models/RealtimeMessage;I)Lio/github/androidpoet/supabase/realtime/RealtimeDebugEvent$OutboundMessageDropped;
+	public static synthetic fun copy$default (Lio/github/androidpoet/supabase/realtime/RealtimeDebugEvent$OutboundMessageDropped;Lio/github/androidpoet/supabase/realtime/models/RealtimeMessage;IILjava/lang/Object;)Lio/github/androidpoet/supabase/realtime/RealtimeDebugEvent$OutboundMessageDropped;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCapacity ()I
+	public final fun getMessage ()Lio/github/androidpoet/supabase/realtime/models/RealtimeMessage;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
 public final class io/github/androidpoet/supabase/realtime/RealtimeDebugState {
 	public fun <init> ()V
 	public fun <init> (JJJJLjava/lang/String;Ljava/lang/String;)V

--- a/supabase-realtime/api/jvm/supabase-realtime.api
+++ b/supabase-realtime/api/jvm/supabase-realtime.api
@@ -189,6 +189,19 @@ public final class io/github/androidpoet/supabase/realtime/RealtimeDebugEvent$Ou
 	public fun toString ()Ljava/lang/String;
 }
 
+public final class io/github/androidpoet/supabase/realtime/RealtimeDebugEvent$OutboundMessageDropped : io/github/androidpoet/supabase/realtime/RealtimeDebugEvent {
+	public fun <init> (Lio/github/androidpoet/supabase/realtime/models/RealtimeMessage;I)V
+	public final fun component1 ()Lio/github/androidpoet/supabase/realtime/models/RealtimeMessage;
+	public final fun component2 ()I
+	public final fun copy (Lio/github/androidpoet/supabase/realtime/models/RealtimeMessage;I)Lio/github/androidpoet/supabase/realtime/RealtimeDebugEvent$OutboundMessageDropped;
+	public static synthetic fun copy$default (Lio/github/androidpoet/supabase/realtime/RealtimeDebugEvent$OutboundMessageDropped;Lio/github/androidpoet/supabase/realtime/models/RealtimeMessage;IILjava/lang/Object;)Lio/github/androidpoet/supabase/realtime/RealtimeDebugEvent$OutboundMessageDropped;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCapacity ()I
+	public final fun getMessage ()Lio/github/androidpoet/supabase/realtime/models/RealtimeMessage;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
 public final class io/github/androidpoet/supabase/realtime/RealtimeDebugState {
 	public fun <init> ()V
 	public fun <init> (JJJJLjava/lang/String;Ljava/lang/String;)V

--- a/supabase-realtime/api/supabase-realtime.klib.api
+++ b/supabase-realtime/api/supabase-realtime.klib.api
@@ -215,6 +215,22 @@ sealed interface io.github.androidpoet.supabase.realtime/RealtimeDebugEvent { //
         final fun hashCode(): kotlin/Int // io.github.androidpoet.supabase.realtime/RealtimeDebugEvent.OutboundMessage.hashCode|hashCode(){}[0]
         final fun toString(): kotlin/String // io.github.androidpoet.supabase.realtime/RealtimeDebugEvent.OutboundMessage.toString|toString(){}[0]
     }
+
+    final class OutboundMessageDropped : io.github.androidpoet.supabase.realtime/RealtimeDebugEvent { // io.github.androidpoet.supabase.realtime/RealtimeDebugEvent.OutboundMessageDropped|null[0]
+        constructor <init>(io.github.androidpoet.supabase.realtime.models/RealtimeMessage, kotlin/Int) // io.github.androidpoet.supabase.realtime/RealtimeDebugEvent.OutboundMessageDropped.<init>|<init>(io.github.androidpoet.supabase.realtime.models.RealtimeMessage;kotlin.Int){}[0]
+
+        final val capacity // io.github.androidpoet.supabase.realtime/RealtimeDebugEvent.OutboundMessageDropped.capacity|{}capacity[0]
+            final fun <get-capacity>(): kotlin/Int // io.github.androidpoet.supabase.realtime/RealtimeDebugEvent.OutboundMessageDropped.capacity.<get-capacity>|<get-capacity>(){}[0]
+        final val message // io.github.androidpoet.supabase.realtime/RealtimeDebugEvent.OutboundMessageDropped.message|{}message[0]
+            final fun <get-message>(): io.github.androidpoet.supabase.realtime.models/RealtimeMessage // io.github.androidpoet.supabase.realtime/RealtimeDebugEvent.OutboundMessageDropped.message.<get-message>|<get-message>(){}[0]
+
+        final fun component1(): io.github.androidpoet.supabase.realtime.models/RealtimeMessage // io.github.androidpoet.supabase.realtime/RealtimeDebugEvent.OutboundMessageDropped.component1|component1(){}[0]
+        final fun component2(): kotlin/Int // io.github.androidpoet.supabase.realtime/RealtimeDebugEvent.OutboundMessageDropped.component2|component2(){}[0]
+        final fun copy(io.github.androidpoet.supabase.realtime.models/RealtimeMessage = ..., kotlin/Int = ...): io.github.androidpoet.supabase.realtime/RealtimeDebugEvent.OutboundMessageDropped // io.github.androidpoet.supabase.realtime/RealtimeDebugEvent.OutboundMessageDropped.copy|copy(io.github.androidpoet.supabase.realtime.models.RealtimeMessage;kotlin.Int){}[0]
+        final fun equals(kotlin/Any?): kotlin/Boolean // io.github.androidpoet.supabase.realtime/RealtimeDebugEvent.OutboundMessageDropped.equals|equals(kotlin.Any?){}[0]
+        final fun hashCode(): kotlin/Int // io.github.androidpoet.supabase.realtime/RealtimeDebugEvent.OutboundMessageDropped.hashCode|hashCode(){}[0]
+        final fun toString(): kotlin/String // io.github.androidpoet.supabase.realtime/RealtimeDebugEvent.OutboundMessageDropped.toString|toString(){}[0]
+    }
 }
 
 sealed interface io.github.androidpoet.supabase.realtime/RealtimeEvent { // io.github.androidpoet.supabase.realtime/RealtimeEvent|null[0]

--- a/supabase-realtime/src/commonMain/kotlin/io/github/androidpoet/supabase/realtime/RealtimeClient.kt
+++ b/supabase-realtime/src/commonMain/kotlin/io/github/androidpoet/supabase/realtime/RealtimeClient.kt
@@ -70,6 +70,17 @@ public sealed interface RealtimeDebugEvent {
         public val message: RealtimeMessage,
     ) : RealtimeDebugEvent
 
+    /**
+     * Emitted when an outbound application message is dropped from the offline
+     * send buffer because it was already full ([capacity] messages). The oldest
+     * buffered message is discarded to make room for the newest. Fire-and-forget
+     * senders can observe this to detect data lost during a prolonged disconnect.
+     */
+    public data class OutboundMessageDropped(
+        public val message: RealtimeMessage,
+        public val capacity: Int,
+    ) : RealtimeDebugEvent
+
     public data class InboundMessage(
         public val message: RealtimeMessage,
     ) : RealtimeDebugEvent

--- a/supabase-realtime/src/commonMain/kotlin/io/github/androidpoet/supabase/realtime/RealtimeClientImpl.kt
+++ b/supabase-realtime/src/commonMain/kotlin/io/github/androidpoet/supabase/realtime/RealtimeClientImpl.kt
@@ -289,7 +289,12 @@ internal class RealtimeClientImpl(
         // regenerated on reconnect, so only buffer application messages.
         if (message.event in NON_BUFFERED_EVENTS) return
         outboundBufferLock.withLock {
-            if (outboundBuffer.size >= MAX_OUTBOUND_BUFFER) outboundBuffer.removeAt(0)
+            if (outboundBuffer.size >= MAX_OUTBOUND_BUFFER) {
+                // The buffer is full: drop the oldest message to make room. Signal
+                // the loss so fire-and-forget senders aren't silently truncated.
+                val dropped = outboundBuffer.removeAt(0)
+                _debugEvents.tryEmit(RealtimeDebugEvent.OutboundMessageDropped(dropped, MAX_OUTBOUND_BUFFER))
+            }
             outboundBuffer.add(message)
         }
     }

--- a/supabase-realtime/src/commonTest/kotlin/io/github/androidpoet/supabase/realtime/RealtimeClientExtTest.kt
+++ b/supabase-realtime/src/commonTest/kotlin/io/github/androidpoet/supabase/realtime/RealtimeClientExtTest.kt
@@ -6,6 +6,7 @@ import io.github.androidpoet.supabase.core.result.SupabaseResult
 import io.github.androidpoet.supabase.realtime.models.PostgresChangeEvent
 import io.github.androidpoet.supabase.realtime.models.PresenceState
 import io.github.androidpoet.supabase.realtime.models.RealtimeChannel
+import io.github.androidpoet.supabase.realtime.models.RealtimeMessage
 import kotlinx.coroutines.async
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
@@ -224,6 +225,42 @@ class RealtimeClientExtTest {
             assertEquals(1, realtime.debugState.value.outboundMessageCount)
             assertEquals(1, realtime.debugState.value.heartbeatSentCount)
             assertEquals("1", realtime.debugState.value.lastOutboundRef)
+        }
+
+    @Test
+    fun test_sendMessage_dropsOldestAndSignalsWhenOfflineBufferFull() =
+        runTest {
+            val realtime = RealtimeClientImpl(ExtFakeSupabaseClient(), RealtimeConfig(autoReconnect = false))
+
+            // Never connected -> the socket is null, so application messages buffer
+            // offline instead of being sent.
+            val dropped =
+                async {
+                    realtime.debugEvents
+                        .filterIsInstance<RealtimeDebugEvent.OutboundMessageDropped>()
+                        .first()
+                }
+            yield()
+
+            // Fill the 100-message buffer, then send one more to force an eviction.
+            // Yield each iteration so the debug collector drains events as they are
+            // emitted instead of overflowing the SharedFlow's replay buffer.
+            repeat(101) { i ->
+                realtime.sendMessage(
+                    RealtimeMessage(
+                        topic = "realtime:test",
+                        event = "broadcast",
+                        payload = buildJsonObject { put("i", i) },
+                        ref = i.toString(),
+                    ),
+                )
+                yield()
+            }
+
+            val event = dropped.await()
+            // The oldest message (ref "0") is the one discarded.
+            assertEquals("0", event.message.ref)
+            assertEquals(100, event.capacity)
         }
 }
 


### PR DESCRIPTION
## Problem

While the realtime socket is down, outbound **application** messages are buffered (up to `MAX_OUTBOUND_BUFFER` = 100) and replayed on reconnect. On overflow the oldest message was discarded **silently**:

```kotlin
if (outboundBuffer.size >= MAX_OUTBOUND_BUFFER) outboundBuffer.removeAt(0)
```

A fire-and-forget sender (e.g. broadcasting during spotty connectivity) could lose data during a prolonged disconnect with no way to detect it.

## Fix

Emit a new debug event on eviction so the loss is observable:

```kotlin
public data class OutboundMessageDropped(
    public val message: RealtimeMessage,
    public val capacity: Int,
) : RealtimeDebugEvent
```

Consumers already subscribed to `realtime.debugEvents` can now `filterIsInstance<OutboundMessageDropped>()` to react. Buffer behaviour (drop-oldest) is unchanged — this only adds the signal.

## API

Additive: one new subtype of the public sealed `RealtimeDebugEvent`. JVM/Android/klib API dumps regenerated.

## Test

`test_sendMessage_dropsOldestAndSignalsWhenOfflineBufferFull` — fills the offline buffer past capacity and asserts the oldest message (`ref "0"`) is reported via `OutboundMessageDropped` with `capacity = 100`.