### PR TITLE
feat(realtime): add subscribeWithResult() reporting the join outcome

### DIFF
--- a/supabase-realtime/api/android/supabase-realtime.api
+++ b/supabase-realtime/api/android/supabase-realtime.api
@@ -71,6 +71,7 @@ public final class io/github/androidpoet/supabase/realtime/RealtimeChannelBuilde
 	public final fun setPrivate (Z)Lio/github/androidpoet/supabase/realtime/RealtimeChannelBuilder;
 	public static synthetic fun setPrivate$default (Lio/github/androidpoet/supabase/realtime/RealtimeChannelBuilder;ZILjava/lang/Object;)Lio/github/androidpoet/supabase/realtime/RealtimeChannelBuilder;
 	public final fun subscribe (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun subscribeWithResult (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
 public abstract interface class io/github/androidpoet/supabase/realtime/RealtimeClient {

--- a/supabase-realtime/api/jvm/supabase-realtime.api
+++ b/supabase-realtime/api/jvm/supabase-realtime.api
@@ -71,6 +71,7 @@ public final class io/github/androidpoet/supabase/realtime/RealtimeChannelBuilde
 	public final fun setPrivate (Z)Lio/github/androidpoet/supabase/realtime/RealtimeChannelBuilder;
 	public static synthetic fun setPrivate$default (Lio/github/androidpoet/supabase/realtime/RealtimeChannelBuilder;ZILjava/lang/Object;)Lio/github/androidpoet/supabase/realtime/RealtimeChannelBuilder;
 	public final fun subscribe (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun subscribeWithResult (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
 public abstract interface class io/github/androidpoet/supabase/realtime/RealtimeClient {

--- a/supabase-realtime/api/supabase-realtime.klib.api
+++ b/supabase-realtime/api/supabase-realtime.klib.api
@@ -487,6 +487,7 @@ final class io.github.androidpoet.supabase.realtime/RealtimeChannelBuilder { // 
     final fun onPresence(kotlin.coroutines/SuspendFunction1<kotlin.collections/Map<kotlin/String, kotlinx.serialization.json/JsonObject>, kotlin/Unit>): io.github.androidpoet.supabase.realtime/RealtimeChannelBuilder // io.github.androidpoet.supabase.realtime/RealtimeChannelBuilder.onPresence|onPresence(kotlin.coroutines.SuspendFunction1<kotlin.collections.Map<kotlin.String,kotlinx.serialization.json.JsonObject>,kotlin.Unit>){}[0]
     final fun setPrivate(kotlin/Boolean = ...): io.github.androidpoet.supabase.realtime/RealtimeChannelBuilder // io.github.androidpoet.supabase.realtime/RealtimeChannelBuilder.setPrivate|setPrivate(kotlin.Boolean){}[0]
     final suspend fun subscribe(): io.github.androidpoet.supabase.realtime/RealtimeSubscription // io.github.androidpoet.supabase.realtime/RealtimeChannelBuilder.subscribe|subscribe(){}[0]
+    final suspend fun subscribeWithResult(): io.github.androidpoet.supabase.core.result/SupabaseResult<io.github.androidpoet.supabase.realtime/RealtimeSubscription> // io.github.androidpoet.supabase.realtime/RealtimeChannelBuilder.subscribeWithResult|subscribeWithResult(){}[0]
 }
 
 final class io.github.androidpoet.supabase.realtime/RealtimeConfig { // io.github.androidpoet.supabase.realtime/RealtimeConfig|null[0]

--- a/supabase-realtime/src/commonMain/kotlin/io/github/androidpoet/supabase/realtime/RealtimeChannelBuilder.kt
+++ b/supabase-realtime/src/commonMain/kotlin/io/github/androidpoet/supabase/realtime/RealtimeChannelBuilder.kt
@@ -1,4 +1,5 @@
 package io.github.androidpoet.supabase.realtime
+import io.github.androidpoet.supabase.core.result.SupabaseResult
 import io.github.androidpoet.supabase.realtime.models.PostgresChangeEvent
 import io.github.androidpoet.supabase.realtime.models.PresenceState
 import kotlinx.serialization.json.JsonObject
@@ -102,6 +103,17 @@ public class RealtimeChannelBuilder internal constructor(
 
     public suspend fun subscribe(): RealtimeSubscription =
         client.subscribe(this)
+
+    /**
+     * Like [subscribe], but suspends until the channel join resolves and reports
+     * the outcome as a [SupabaseResult] instead of handing back a subscription
+     * that may still be joining. Returns [SupabaseResult.Failure] if the join is
+     * rejected by the server or times out (after `connectionTimeoutMs`), so a
+     * failed subscription no longer has to be detected by polling
+     * [RealtimeSubscription.status].
+     */
+    public suspend fun subscribeWithResult(): SupabaseResult<RealtimeSubscription> =
+        client.subscribeWithResult(this)
 }
 
 internal sealed class PostgresCallbackConfig {

--- a/supabase-realtime/src/commonMain/kotlin/io/github/androidpoet/supabase/realtime/RealtimeClientImpl.kt
+++ b/supabase-realtime/src/commonMain/kotlin/io/github/androidpoet/supabase/realtime/RealtimeClientImpl.kt
@@ -1,5 +1,7 @@
 package io.github.androidpoet.supabase.realtime
 import io.github.androidpoet.supabase.client.SupabaseClient
+import io.github.androidpoet.supabase.core.result.SupabaseError
+import io.github.androidpoet.supabase.core.result.SupabaseResult
 import io.github.androidpoet.supabase.realtime.models.PostgresChangeEvent
 import io.github.androidpoet.supabase.realtime.models.PresenceState
 import io.github.androidpoet.supabase.realtime.models.RealtimeChannel
@@ -265,6 +267,31 @@ internal class RealtimeClientImpl(
         synchronized(subscriptionsLock) { activeSubscriptions[topic] = subscription }
         sendJoinMessage(subscription)
         return subscription
+    }
+
+    internal suspend fun subscribeWithResult(
+        builder: RealtimeChannelBuilder,
+    ): SupabaseResult<RealtimeSubscription> {
+        val subscription = subscribe(builder)
+        // Wait for the join to resolve instead of handing back a still-SUBSCRIBING
+        // subscription. Bound it ourselves: if the socket is down the internal
+        // join watchdog never launches, so the status would otherwise hang here.
+        val terminal =
+            withTimeoutOrNull(config.connectionTimeoutMs) {
+                subscription.status.first { it != RealtimeSubscription.Status.SUBSCRIBING }
+            }
+        return if (terminal == RealtimeSubscription.Status.SUBSCRIBED) {
+            SupabaseResult.Success(subscription)
+        } else {
+            // Timed out (null) or reached a non-subscribed terminal state (ERROR).
+            // Ensure a timed-out join is marked failed for any status observers.
+            (subscription as? ChannelSubscriptionImpl)?.markJoinTimedOut()
+            SupabaseResult.Failure(
+                SupabaseError(
+                    message = "Channel '${builder.channelName}' failed to subscribe: ${terminal ?: "join timed out"}",
+                ),
+            )
+        }
     }
 
     internal suspend fun leaveChannel(topic: String) {

--- a/supabase-realtime/src/commonTest/kotlin/io/github/androidpoet/supabase/realtime/RealtimeClientExtTest.kt
+++ b/supabase-realtime/src/commonTest/kotlin/io/github/androidpoet/supabase/realtime/RealtimeClientExtTest.kt
@@ -262,6 +262,23 @@ class RealtimeClientExtTest {
             assertEquals("0", event.message.ref)
             assertEquals(100, event.capacity)
         }
+
+    @Test
+    fun test_subscribeWithResult_failsWhenJoinNeverCompletes() =
+        runTest {
+            val realtime =
+                RealtimeClientImpl(
+                    ExtFakeSupabaseClient(),
+                    RealtimeConfig(autoReconnect = false, connectionTimeoutMs = 100),
+                )
+
+            // Not connected, so the phx_join is never acknowledged. Instead of
+            // returning a subscription stuck in SUBSCRIBING, the result reports the
+            // failure directly.
+            val result = realtime.channel("room").subscribeWithResult()
+
+            assertTrue(result is SupabaseResult.Failure)
+        }
 }
 
 private class ExtFakeSupabaseClient : SupabaseClient {


### PR DESCRIPTION
## Problem

`RealtimeChannelBuilder.subscribe()` returns a `RealtimeSubscription` **immediately**, while the channel join resolves asynchronously (`phx_reply`, or a timeout that flips the status to `ERROR`). A caller could only discover a failed join by **polling** `RealtimeSubscription.status` — and a missed status update meant the failure went unnoticed.

## Fix (non-breaking)

Add an opt-in overload that awaits the join and reports it Result-first:

```kotlin
public suspend fun subscribeWithResult(): SupabaseResult<RealtimeSubscription>
```

- Suspends until the join leaves `SUBSCRIBING`.
- `SUBSCRIBED` → `Success(subscription)`; `ERROR` or timeout → `Failure`.
- Bounded by `connectionTimeoutMs` **with its own `withTimeoutOrNull`**, so a disconnected client (whose internal join watchdog never launches) can't hang.

`subscribe()` is untouched — existing callers are unaffected.

## API

Additive: one new `public suspend fun` on `RealtimeChannelBuilder`. JVM/Android/klib dumps regenerated (only this method added).

## Test

`test_subscribeWithResult_failsWhenJoinNeverCompletes` — on a never-connected client the join can't be acknowledged, and the call returns `SupabaseResult.Failure` instead of a stuck-SUBSCRIBING subscription.