### PR TITLE
Release 0.9.2: publish codegen to Maven Central

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 ## Unreleased
 
+## 0.9.2
+
+### Added
+
+- **Codegen is now published to Maven Central.** The `supabase-codegen` CLI/library and the
+  `io.github.androidpoet.supabase.codegen` Gradle plugin (`supabase-codegen-gradle`) are published
+  under the same `io.github.androidpoet` group as the rest of the SDK. Apply the plugin with
+  `plugins { id("io.github.androidpoet.supabase.codegen") version "0.9.2" }` (add `mavenCentral()` to
+  `pluginManagement.repositories`), or run the CLI, to generate `@Serializable` models from your
+  Supabase schema. The generator is a JVM build-time tool (like `supabase gen types`); only the code
+  it emits is multiplatform-common, so it works for any KMP target set including Android+iOS-only.
+
 ### Removed
 
 - **`AdminUserAttributes.nonce`** — removed a non-functional field. GoTrue's admin

--- a/buildSrc/src/main/kotlin/io/github/androidpoet/supabase/Configuration.kt
+++ b/buildSrc/src/main/kotlin/io/github/androidpoet/supabase/Configuration.kt
@@ -2,7 +2,7 @@ package io.github.androidpoet.supabase
 
 object Configuration {
     const val GROUP = "io.github.androidpoet"
-    const val VERSION = "0.9.1"
+    const val VERSION = "0.9.2"
     const val COMPILE_SDK = 35
     const val MIN_SDK = 21
 }

--- a/supabase-codegen-gradle/build.gradle.kts
+++ b/supabase-codegen-gradle/build.gradle.kts
@@ -1,6 +1,9 @@
+import io.github.androidpoet.supabase.Configuration
+
 plugins {
     `java-gradle-plugin`
     alias(libs.plugins.kotlin.jvm)
+    alias(libs.plugins.vanniktech.publish)
 }
 
 kotlin { jvmToolchain(17) }
@@ -23,4 +26,12 @@ gradlePlugin {
             description = "Generates Kotlin @Serializable models from your Supabase schema"
         }
     }
+}
+
+// With java-gradle-plugin applied, vanniktech also publishes the plugin *marker*
+// artifact (io.github.androidpoet.supabase.codegen:…gradle.plugin), so consumers can
+// apply it via `plugins { id("io.github.androidpoet.supabase.codegen") version "…" }`
+// after adding mavenCentral() to pluginManagement.repositories.
+mavenPublishing {
+    coordinates(Configuration.GROUP, "supabase-codegen-gradle", Configuration.VERSION)
 }

--- a/supabase-codegen/build.gradle.kts
+++ b/supabase-codegen/build.gradle.kts
@@ -1,6 +1,9 @@
+import io.github.androidpoet.supabase.Configuration
+
 plugins {
     alias(libs.plugins.kotlin.jvm)
     alias(libs.plugins.kotlin.serialization)
+    alias(libs.plugins.vanniktech.publish)
     application
 }
 
@@ -17,4 +20,11 @@ dependencies {
 application {
     // CLI entry point: fetch a project's schema and generate Kotlin models.
     mainClass.set("io.github.androidpoet.supabase.codegen.MainKt")
+}
+
+// Published so the Gradle plugin (which depends on this module) resolves its
+// transitive coordinate from Maven Central. This is a JVM build-time tool, not a
+// KMP artifact — only the code it *generates* is multiplatform-common.
+mavenPublishing {
+    coordinates(Configuration.GROUP, "supabase-codegen", Configuration.VERSION)
 }


### PR DESCRIPTION
Publishes the `supabase-codegen` CLI/library and the `io.github.androidpoet.supabase.codegen` Gradle plugin to Maven Central via the existing publishing pipeline, and bumps all modules to a unified `0.9.2`.

## What
- Wire both codegen modules into Maven Central publishing (incl. the Gradle plugin marker).
- Bump version `0.9.1` → `0.9.2` (pre-stable patch, unified across all modules).
- CHANGELOG `0.9.2` section.

## Usage after release
```kotlin
// settings.gradle.kts → pluginManagement { repositories { mavenCentral() } }
plugins { id("io.github.androidpoet.supabase.codegen") version "0.9.2" }
```

The generator is a JVM build-time tool (like `supabase gen types`); only its output is multiplatform-common, so it works for any KMP target set including Android+iOS-only.

Artifacts already published and released to Maven Central; tag `0.9.2` pushed.