### PR TITLE
Add codegen-generated Supabase models to chat-compose sample

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,5 +16,11 @@ docs/
 # Local-only Supabase config for the web sample
 samples/passkey-web/src/wasmJsMain/resources/config.js
 
+# Codegen credentials (kept local, never committed). The credentials are passed via
+# SUPABASE_URL / SUPABASE_KEY env vars; this guards any stray files. The *generated*
+# models contain no secrets (just table structure) and ARE committed — see
+# samples/chat-compose/.../generated/SupabaseModels.kt.
+codegen.local.properties
+
 # Local-only JVM desktop demo app — kept on this machine, never pushed to GitHub
 samples/desktop-demo/

--- a/samples/chat-compose/src/main/java/io/github/androidpoet/supabase/sample/chat/generated/SupabaseModels.kt
+++ b/samples/chat-compose/src/main/java/io/github/androidpoet/supabase/sample/chat/generated/SupabaseModels.kt
@@ -1,0 +1,36 @@
+// Generated from the Supabase schema. Do not edit by hand.
+package io.github.androidpoet.supabase.sample.chat.generated
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlin.String
+
+@Serializable
+public data class E2eMessages(
+    public val id: String,
+    public val body: String,
+    @SerialName("created_at")
+    public val createdAt: String,
+)
+
+@Serializable
+public data class ChatRooms(
+    public val id: String,
+    public val name: String,
+    @SerialName("created_at")
+    public val createdAt: String,
+)
+
+@Serializable
+public data class ChatMessages(
+    public val id: String,
+    @SerialName("room_id")
+    public val roomId: String,
+    @SerialName("sender_id")
+    public val senderId: String? = null,
+    @SerialName("sender_name")
+    public val senderName: String,
+    public val body: String,
+    @SerialName("created_at")
+    public val createdAt: String,
+)


### PR DESCRIPTION
Adds the `supabase-codegen` output to the chat-compose sample so the generated models are visible in the repo.

## What
- `samples/chat-compose/.../generated/SupabaseModels.kt` — generated by `supabase-codegen` from the local Supabase stack (`supabase/migrations`): `ChatRooms`, `ChatMessages`, `E2eMessages`.
- `.gitignore` — keeps the credential guard (`codegen.local.properties`); generated models contain no secrets (just table structure) so they're committed.

## Verified
Compiled the generated models with `kotlinc` + the serialization plugin and **deserialized live rows** from the running local instance:
```
ChatRooms decoded: 2  -> [general, random]
ChatMessages decoded: 1 (nullable senderId handled)
E2eMessages decoded: 0
VERIFY OK
```
Confirms correct nullable/non-null inference and snake_case to camelCase mapping against real data.