### PR TITLE
Release codegen 0.9.4 (stale-model cleanup + fetch timeouts)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+## 0.9.4
+
+> Codegen-only release: `supabase-codegen` + `supabase-codegen-gradle` published at `0.9.4`.
+> The other SDK modules are unchanged from `0.9.2`/`0.9.3`.
+
 ### Fixed
 
 - **Codegen clears stale models on regeneration.** Before writing, the CLI and Gradle task now

--- a/buildSrc/src/main/kotlin/io/github/androidpoet/supabase/Configuration.kt
+++ b/buildSrc/src/main/kotlin/io/github/androidpoet/supabase/Configuration.kt
@@ -2,7 +2,7 @@ package io.github.androidpoet.supabase
 
 object Configuration {
     const val GROUP = "io.github.androidpoet"
-    const val VERSION = "0.9.3"
+    const val VERSION = "0.9.4"
     const val COMPILE_SDK = 35
     const val MIN_SDK = 21
 }


### PR DESCRIPTION
Codegen-only patch release. Publishes `supabase-codegen` + `supabase-codegen-gradle` at **0.9.4** (the other SDK modules are standalone-unrelated and stay at 0.9.3 on Central).

## Ships (from the audit)
- **Stale-model cleanup** — regen deletes the generator-owned `tables/`/`enums/` first, so a dropped table/enum no longer orphans a file (key for `autoSync`). Scoped cleanup; invariant test guards it.
- **Fetch timeouts** — 30s connect / 60s request so a stalled fetch fails fast instead of hanging the compile.

Already published + released to Maven Central; tag `codegen-0.9.4` pushed.

```kotlin
plugins { id("io.github.androidpoet.supabase.codegen") version "0.9.4" }
```