### PR TITLE
docs: complete per-module API Reference section

### DIFF
--- a/website/pages/_meta.jsx
+++ b/website/pages/_meta.jsx
@@ -17,6 +17,7 @@ export default {
   encryption: 'End-to-End Encryption',
   'vector-search': 'Vector Search',
   platforms: 'Platforms',
+  reference: 'API Reference',
   github_link: {
     title: 'GitHub',
     type: 'page',

--- a/website/pages/database.mdx
+++ b/website/pages/database.mdx
@@ -78,7 +78,7 @@ Pick the read method that matches how many rows you expect back:
 `columns` accepts PostgREST projection syntax — `"*"`, `"id,title"`, or embedded
 relations like `"*,author(*)"`. The typed read helpers all accept an optional
 `schema`. For PostGIS rows as a GeoJSON `FeatureCollection`, use `selectGeoJson(…)`
-(or the raw `select(…, geojson = true)`).
+(or pass `format = ResponseFormat.GEOJSON` to the raw `select(…)`).
 
 ## Insert, Update, Upsert, Delete
 

--- a/website/pages/reference/_meta.jsx
+++ b/website/pages/reference/_meta.jsx
@@ -1,0 +1,15 @@
+export default {
+  index: 'Overview',
+  core: 'Core',
+  client: 'Client',
+  auth: 'Authentication',
+  'auth-admin': 'Auth Admin',
+  'auth-native': 'Native Sign-In',
+  database: 'Database',
+  storage: 'Storage',
+  realtime: 'Realtime',
+  functions: 'Edge Functions',
+  e2ee: 'End-to-End Encryption',
+  sync: 'Offline Sync',
+  codegen: 'Codegen',
+}

--- a/website/pages/reference/auth-admin.mdx
+++ b/website/pages/reference/auth-admin.mdx
@@ -1,0 +1,1185 @@
+---
+title: Auth Admin — API Reference
+description: Server-side admin client for Supabase Auth (GoTrue). Manage users, MFA factors, OAuth clients, custom OIDC/OAuth2 providers, SAML SSO providers, passkeys, audit logs and sign-out — all authenticated with the service-role key. Complete 1.0.0 reference for io.github.androidpoet:supabase-auth-admin.
+---
+
+import { Callout } from 'nextra/components'
+
+# Auth Admin — API Reference
+
+The **supabase-auth-admin** module is a thin, typed wrapper over the GoTrue
+**admin** REST API. It lets a trusted backend manage your project's auth state:
+list and mutate users, run their MFA factors, register OAuth clients, configure
+custom OIDC/OAuth2 and SAML SSO providers, inspect passkeys and audit logs, and
+force-sign-out a session. Every call returns a `SupabaseResult<T>`, so failures
+are values you handle rather than exceptions you catch.
+
+- **Maven artifact:** `io.github.androidpoet:supabase-auth-admin`
+- **Entry point:** `createAuthAdminClient(client, serviceRoleKey)`
+- **Package:** `io.github.androidpoet.supabase.auth.admin` (models in `…admin.models`)
+
+<Callout type="error">
+**This module uses the service-role key. Never ship it in a client app.**
+
+The service-role key **bypasses Row Level Security** and can read, modify, or
+delete *any* user and *any* row in your project. It must only ever run in a
+trusted, server-side environment (a backend service or edge function) — never in
+a mobile, desktop, or browser app where it can be extracted. The key is a
+**required** argument with **no default** by design, so an admin client can never
+be created by accident with the public anon key. Source it from a secret store,
+not from committed code.
+</Callout>
+
+## Setup
+
+`createAuthAdminClient` builds an [`AuthAdminClient`](#authadminclient) from an
+existing `SupabaseClient` and your service-role key.
+
+```kotlin
+fun createAuthAdminClient(
+    supabaseClient: SupabaseClient,
+    serviceRoleKey: String,
+): AuthAdminClient
+```
+
+- `supabaseClient` — the configured `SupabaseClient` whose project URL the admin calls target.
+- `serviceRoleKey` — the project's service-role key. Required, no default. Bypasses RLS.
+
+**Returns** an `AuthAdminClient` instance. This call does no I/O and does not fail.
+
+```kotlin
+val admin = createAuthAdminClient(
+    supabaseClient = client,
+    serviceRoleKey = System.getenv("SUPABASE_SERVICE_ROLE_KEY"),
+)
+```
+
+---
+
+## AuthAdminClient
+
+The interface exposing every admin operation. All methods are `suspend` and
+return `SupabaseResult<T>`: a `Success` carrying the value, or a `Failure`
+carrying the error. The sections below group the methods by area.
+
+### User management
+
+#### createUser
+
+Creates a user directly, skipping the normal sign-up flow. Set `emailConfirm` /
+`phoneConfirm` to mark contacts pre-verified.
+
+```kotlin
+suspend fun createUser(attributes: AdminUserAttributes): SupabaseResult<User>
+```
+
+- `attributes` — the fields to set on the new user (see [`AdminUserAttributes`](#adminuserattributes)).
+
+**Returns** `SupabaseResult<User>` — `Success` with the created user, `Failure` on error.
+
+```kotlin
+val result = admin.createUser(
+    AdminUserAttributes(
+        email = "jane@example.com",
+        password = "s3cret-pass",
+        emailConfirm = true,
+    ),
+)
+```
+
+#### listUsers
+
+Lists users one page at a time. GoTrue's admin list is page-based and 1-indexed.
+
+```kotlin
+suspend fun listUsers(
+    page: Int? = null,
+    perPage: Int? = null,
+): SupabaseResult<ListUsersResponse>
+```
+
+- `page` — 1-indexed page number. Default `null` (server default, the first page).
+- `perPage` — users per page. Default `null` (server default).
+
+**Returns** `SupabaseResult<ListUsersResponse>` — `Success` with the page of users, `Failure` on error.
+
+```kotlin
+val page = admin.listUsers(page = 1, perPage = 50)
+```
+
+<Callout type="info">
+For ergonomic paging see [`listUsersOrThrow`](#listusersorthrow) and
+[`usersPaginator`](#userspaginator) below.
+</Callout>
+
+#### getUserById
+
+Fetches a single user by id.
+
+```kotlin
+suspend fun getUserById(userId: String): SupabaseResult<User>
+```
+
+- `userId` — the user's UUID.
+
+**Returns** `SupabaseResult<User>` — `Success` with the user, `Failure` if not found or on error.
+
+```kotlin
+val user = admin.getUserById("8f3a…")
+```
+
+#### updateUserById
+
+Updates an existing user. Only the non-null fields on `attributes` are changed.
+
+```kotlin
+suspend fun updateUserById(
+    userId: String,
+    attributes: AdminUserAttributes,
+): SupabaseResult<User>
+```
+
+- `userId` — the user's UUID.
+- `attributes` — fields to change (see [`AdminUserAttributes`](#adminuserattributes)). Use `banDuration` to ban (e.g. `"24h"`) or `"none"` to unban.
+
+**Returns** `SupabaseResult<User>` — `Success` with the updated user, `Failure` on error.
+
+```kotlin
+val updated = admin.updateUserById(
+    userId = "8f3a…",
+    attributes = AdminUserAttributes(banDuration = "24h"),
+)
+```
+
+#### deleteUser
+
+Deletes a user.
+
+```kotlin
+suspend fun deleteUser(
+    userId: String,
+    shouldSoftDelete: Boolean = false,
+): SupabaseResult<Unit>
+```
+
+- `userId` — the user's UUID.
+- `shouldSoftDelete` — if `true`, soft-deletes (retains the row, marks it deleted); if `false`, hard-deletes. Default `false`.
+
+**Returns** `SupabaseResult<Unit>` — `Success` on deletion, `Failure` on error.
+
+```kotlin
+admin.deleteUser("8f3a…", shouldSoftDelete = true)
+```
+
+#### inviteUserByEmail
+
+Sends an invite email and creates a pending user.
+
+```kotlin
+suspend fun inviteUserByEmail(
+    email: String,
+    data: JsonObject? = null,
+    redirectTo: String? = null,
+): SupabaseResult<User>
+```
+
+- `email` — the invitee's email address.
+- `data` — optional metadata stored on the user (becomes `user_metadata`). Default `null`.
+- `redirectTo` — optional URL to redirect to after the invite is accepted. Default `null`.
+
+**Returns** `SupabaseResult<User>` — `Success` with the invited user, `Failure` on error.
+
+```kotlin
+admin.inviteUserByEmail("new@example.com")
+```
+
+#### generateLink
+
+Generates an action link (signup, magic link, recovery, invite, or email change)
+without sending the email yourself.
+
+```kotlin
+suspend fun generateLink(request: GenerateLinkRequest): SupabaseResult<GenerateLinkResponse>
+```
+
+- `request` — the link parameters (see [`GenerateLinkRequest`](#generatelinkrequest)).
+
+**Returns** `SupabaseResult<GenerateLinkResponse>` — `Success` with the generated link properties and (where applicable) the user, `Failure` on error.
+
+```kotlin
+val link = admin.generateLink(
+    GenerateLinkRequest(
+        type = GenerateLinkType.MAGIC_LINK,
+        email = "jane@example.com",
+    ),
+)
+```
+
+#### signOut
+
+Revokes a user's session(s) given their access token.
+
+```kotlin
+suspend fun signOut(
+    accessToken: String,
+    scope: SignOutScope = SignOutScope.LOCAL,
+): SupabaseResult<Unit>
+```
+
+- `accessToken` — the user's JWT access token to sign out.
+- `scope` — which sessions to revoke (`SignOutScope.LOCAL`, `GLOBAL`, or `OTHERS`). Default `SignOutScope.LOCAL`.
+
+**Returns** `SupabaseResult<Unit>` — `Success` on sign-out, `Failure` on error.
+
+```kotlin
+admin.signOut(accessToken = userJwt, scope = SignOutScope.GLOBAL)
+```
+
+### Multi-factor authentication
+
+#### listFactors
+
+Lists a user's enrolled MFA factors.
+
+```kotlin
+suspend fun listFactors(userId: String): SupabaseResult<MfaAdminListFactorsResponse>
+```
+
+- `userId` — the user's UUID.
+
+**Returns** `SupabaseResult<MfaAdminListFactorsResponse>` — `Success` with the factor list, `Failure` on error.
+
+```kotlin
+val factors = admin.listFactors("8f3a…")
+```
+
+#### updateFactor
+
+Updates a user's MFA factor — currently its friendly name. PUTs to
+`/admin/users/{userId}/factors/{factorId}` and returns the full updated factor.
+
+```kotlin
+suspend fun updateFactor(
+    userId: String,
+    factorId: String,
+    friendlyName: String? = null,
+): SupabaseResult<MfaFactor>
+```
+
+- `userId` — the user's UUID.
+- `factorId` — the factor's id.
+- `friendlyName` — the new display name for the factor. Default `null`.
+
+**Returns** `SupabaseResult<MfaFactor>` — `Success` with the updated factor, `Failure` on error.
+
+```kotlin
+admin.updateFactor("8f3a…", "factor-id", friendlyName = "My phone")
+```
+
+#### deleteFactor
+
+Removes a user's MFA factor.
+
+```kotlin
+suspend fun deleteFactor(
+    userId: String,
+    factorId: String,
+): SupabaseResult<MfaAdminDeleteFactorResponse>
+```
+
+- `userId` — the user's UUID.
+- `factorId` — the factor's id.
+
+**Returns** `SupabaseResult<MfaAdminDeleteFactorResponse>` — `Success` with the deleted factor's id, `Failure` on error.
+
+```kotlin
+admin.deleteFactor("8f3a…", "factor-id")
+```
+
+### OAuth clients
+
+#### listOAuthClients
+
+Lists registered OAuth clients, page by page.
+
+```kotlin
+suspend fun listOAuthClients(
+    page: Int? = null,
+    perPage: Int? = null,
+): SupabaseResult<OAuthClientListResponse>
+```
+
+- `page` — 1-indexed page number. Default `null`.
+- `perPage` — clients per page. Default `null`.
+
+**Returns** `SupabaseResult<OAuthClientListResponse>` — `Success` with the page of clients, `Failure` on error.
+
+```kotlin
+val clients = admin.listOAuthClients(page = 1, perPage = 20)
+```
+
+#### createOAuthClient
+
+Registers a new OAuth client.
+
+```kotlin
+suspend fun createOAuthClient(request: OAuthClientCreateRequest): SupabaseResult<OAuthClient>
+```
+
+- `request` — the new client's configuration (see [`OAuthClientCreateRequest`](#oauthclientcreaterequest)).
+
+**Returns** `SupabaseResult<OAuthClient>` — `Success` with the created client (including its secret), `Failure` on error.
+
+```kotlin
+val client = admin.createOAuthClient(
+    OAuthClientCreateRequest(
+        clientName = "My App",
+        redirectUris = listOf("https://app.example.com/callback"),
+    ),
+)
+```
+
+#### getOAuthClient
+
+Fetches a single OAuth client by id.
+
+```kotlin
+suspend fun getOAuthClient(clientId: String): SupabaseResult<OAuthClient>
+```
+
+- `clientId` — the client's id.
+
+**Returns** `SupabaseResult<OAuthClient>` — `Success` with the client, `Failure` on error.
+
+```kotlin
+val client = admin.getOAuthClient("client-id")
+```
+
+#### updateOAuthClient
+
+Updates an existing OAuth client. Only non-null fields on `request` are changed.
+
+```kotlin
+suspend fun updateOAuthClient(
+    clientId: String,
+    request: OAuthClientUpdateRequest,
+): SupabaseResult<OAuthClient>
+```
+
+- `clientId` — the client's id.
+- `request` — fields to change (see [`OAuthClientUpdateRequest`](#oauthclientupdaterequest)).
+
+**Returns** `SupabaseResult<OAuthClient>` — `Success` with the updated client, `Failure` on error.
+
+```kotlin
+admin.updateOAuthClient(
+    clientId = "client-id",
+    request = OAuthClientUpdateRequest(clientName = "Renamed App"),
+)
+```
+
+#### deleteOAuthClient
+
+Deletes an OAuth client.
+
+```kotlin
+suspend fun deleteOAuthClient(clientId: String): SupabaseResult<Unit>
+```
+
+- `clientId` — the client's id.
+
+**Returns** `SupabaseResult<Unit>` — `Success` on deletion, `Failure` on error.
+
+```kotlin
+admin.deleteOAuthClient("client-id")
+```
+
+#### regenerateOAuthClientSecret
+
+Issues a fresh secret for an OAuth client, invalidating the old one.
+
+```kotlin
+suspend fun regenerateOAuthClientSecret(clientId: String): SupabaseResult<OAuthClient>
+```
+
+- `clientId` — the client's id.
+
+**Returns** `SupabaseResult<OAuthClient>` — `Success` with the client carrying the new secret, `Failure` on error.
+
+```kotlin
+val rotated = admin.regenerateOAuthClientSecret("client-id")
+```
+
+### Custom OIDC / OAuth2 providers
+
+#### listCustomProviders
+
+Lists custom identity providers, optionally filtered by type.
+
+```kotlin
+suspend fun listCustomProviders(type: CustomProviderType? = null): SupabaseResult<CustomProviderListResponse>
+```
+
+- `type` — restrict to a provider type (`OAUTH2` or `OIDC`). Default `null` (all types).
+
+**Returns** `SupabaseResult<CustomProviderListResponse>` — `Success` with the provider list, `Failure` on error.
+
+```kotlin
+val providers = admin.listCustomProviders(type = CustomProviderType.OIDC)
+```
+
+#### createCustomProvider
+
+Registers a new custom OIDC/OAuth2 provider.
+
+```kotlin
+suspend fun createCustomProvider(request: CustomProviderCreateRequest): SupabaseResult<CustomProvider>
+```
+
+- `request` — the provider configuration (see [`CustomProviderCreateRequest`](#customprovidercreaterequest)).
+
+**Returns** `SupabaseResult<CustomProvider>` — `Success` with the created provider, `Failure` on error.
+
+```kotlin
+val provider = admin.createCustomProvider(
+    CustomProviderCreateRequest(
+        providerType = CustomProviderType.OIDC,
+        identifier = "acme",
+        name = "Acme SSO",
+        clientId = "client-id",
+        clientSecret = "client-secret",
+        discoveryUrl = "https://acme.example.com/.well-known/openid-configuration",
+    ),
+)
+```
+
+#### getCustomProvider
+
+Fetches a single custom provider by its identifier.
+
+```kotlin
+suspend fun getCustomProvider(identifier: String): SupabaseResult<CustomProvider>
+```
+
+- `identifier` — the provider's identifier.
+
+**Returns** `SupabaseResult<CustomProvider>` — `Success` with the provider, `Failure` on error.
+
+```kotlin
+val provider = admin.getCustomProvider("acme")
+```
+
+#### updateCustomProvider
+
+Updates an existing custom provider. Only non-null fields on `request` are changed.
+
+```kotlin
+suspend fun updateCustomProvider(
+    identifier: String,
+    request: CustomProviderUpdateRequest,
+): SupabaseResult<CustomProvider>
+```
+
+- `identifier` — the provider's identifier.
+- `request` — fields to change (see [`CustomProviderUpdateRequest`](#customproviderupdaterequest)).
+
+**Returns** `SupabaseResult<CustomProvider>` — `Success` with the updated provider, `Failure` on error.
+
+```kotlin
+admin.updateCustomProvider(
+    identifier = "acme",
+    request = CustomProviderUpdateRequest(enabled = false),
+)
+```
+
+#### deleteCustomProvider
+
+Deletes a custom provider.
+
+```kotlin
+suspend fun deleteCustomProvider(identifier: String): SupabaseResult<Unit>
+```
+
+- `identifier` — the provider's identifier.
+
+**Returns** `SupabaseResult<Unit>` — `Success` on deletion, `Failure` on error.
+
+```kotlin
+admin.deleteCustomProvider("acme")
+```
+
+### SAML SSO providers
+
+#### createSsoProvider
+
+Registers a new SAML SSO identity provider. Provide either `metadataUrl` or
+`metadataXml` on the request.
+
+```kotlin
+suspend fun createSsoProvider(request: SsoProviderCreateRequest): SupabaseResult<SsoProvider>
+```
+
+- `request` — the provider configuration (see [`SsoProviderCreateRequest`](#ssoprovidercreaterequest)).
+
+**Returns** `SupabaseResult<SsoProvider>` — `Success` with the created provider, `Failure` on error.
+
+```kotlin
+val provider = admin.createSsoProvider(
+    SsoProviderCreateRequest(
+        metadataUrl = "https://idp.example.com/metadata.xml",
+        domains = listOf("example.com"),
+    ),
+)
+```
+
+#### listSsoProviders
+
+Lists all registered SAML SSO providers. The API's `{ "items": [...] }` wrapper is
+unwrapped to a plain list.
+
+```kotlin
+suspend fun listSsoProviders(): SupabaseResult<List<SsoProvider>>
+```
+
+**Returns** `SupabaseResult<List<SsoProvider>>` — `Success` with the providers, `Failure` on error.
+
+```kotlin
+val providers = admin.listSsoProviders()
+```
+
+#### getSsoProvider
+
+Fetches a single SAML SSO provider by id.
+
+```kotlin
+suspend fun getSsoProvider(id: String): SupabaseResult<SsoProvider>
+```
+
+- `id` — the provider's id.
+
+**Returns** `SupabaseResult<SsoProvider>` — `Success` with the provider, `Failure` on error.
+
+```kotlin
+val provider = admin.getSsoProvider("provider-id")
+```
+
+#### updateSsoProvider
+
+Updates an existing SAML SSO provider. Omitted `domains` / `attribute_mapping`
+keep their existing values.
+
+```kotlin
+suspend fun updateSsoProvider(
+    id: String,
+    request: SsoProviderUpdateRequest,
+): SupabaseResult<SsoProvider>
+```
+
+- `id` — the provider's id.
+- `request` — fields to change (see [`SsoProviderUpdateRequest`](#ssoproviderupdaterequest)).
+
+**Returns** `SupabaseResult<SsoProvider>` — `Success` with the updated provider, `Failure` on error.
+
+```kotlin
+admin.updateSsoProvider(
+    id = "provider-id",
+    request = SsoProviderUpdateRequest(disabled = true),
+)
+```
+
+#### deleteSsoProvider
+
+Removes a SAML SSO provider and returns the provider that was deleted.
+
+```kotlin
+suspend fun deleteSsoProvider(id: String): SupabaseResult<SsoProvider>
+```
+
+- `id` — the provider's id.
+
+**Returns** `SupabaseResult<SsoProvider>` — `Success` with the deleted provider, `Failure` on error.
+
+```kotlin
+val removed = admin.deleteSsoProvider("provider-id")
+```
+
+### Passkeys
+
+#### listPasskeys
+
+Lists a user's registered passkeys.
+
+```kotlin
+suspend fun listPasskeys(userId: String): SupabaseResult<List<Passkey>>
+```
+
+- `userId` — the user's UUID.
+
+**Returns** `SupabaseResult<List<Passkey>>` — `Success` with the passkeys, `Failure` on error.
+
+```kotlin
+val passkeys = admin.listPasskeys("8f3a…")
+```
+
+#### deletePasskey
+
+Removes a passkey from a user.
+
+```kotlin
+suspend fun deletePasskey(
+    userId: String,
+    passkeyId: String,
+): SupabaseResult<Unit>
+```
+
+- `userId` — the user's UUID.
+- `passkeyId` — the passkey's id.
+
+**Returns** `SupabaseResult<Unit>` — `Success` on deletion, `Failure` on error.
+
+```kotlin
+admin.deletePasskey("8f3a…", "passkey-id")
+```
+
+### Audit logs
+
+#### listAuditLogEvents
+
+Fetches audit-log events. The endpoint returns a bare JSON array of entries.
+`page` and `perPage` are sent as `page` / `per_page` query params only when
+non-null.
+
+```kotlin
+suspend fun listAuditLogEvents(
+    page: Int? = null,
+    perPage: Int? = null,
+): SupabaseResult<List<AuditLogEntry>>
+```
+
+- `page` — 1-indexed page number. Default `null` (omitted).
+- `perPage` — entries per page. Default `null` (omitted).
+
+**Returns** `SupabaseResult<List<AuditLogEntry>>` — `Success` with the entries, `Failure` on error.
+
+```kotlin
+val events = admin.listAuditLogEvents(page = 1, perPage = 100)
+```
+
+---
+
+## Extension functions
+
+### listUsersOrThrow
+
+The plain (no-`SupabaseResult`) form of `listUsers`: returns the `List<User>`
+directly and **throws** on failure. Service-role only.
+
+```kotlin
+suspend fun AuthAdminClient.listUsersOrThrow(
+    page: Int? = null,
+    perPage: Int? = null,
+): List<User>
+```
+
+- `page` — 1-indexed page number. Default `null`.
+- `perPage` — users per page. Default `null`.
+
+**Returns** `List<User>` on success; **throws** the underlying error on failure.
+
+```kotlin
+val users = admin.listUsersOrThrow(page = 1, perPage = 50)
+```
+
+### usersPaginator
+
+Builds a demand-driven `Paginator` over all users, fetching one page per
+`loadNext`. GoTrue's admin list is page-based and 1-indexed; this adapter
+converts the offset the paginator tracks into the right `page` number, so callers
+just observe `Paginator.items` and call `loadNext` near the list end. A failure
+surfaces via `Paginator.error`. Service-role only.
+
+```kotlin
+fun AuthAdminClient.usersPaginator(perPage: Int = 50): Paginator<User>
+```
+
+- `perPage` — users per page; must be greater than 0. Default `50`.
+
+**Returns** a `Paginator<User>` you drive with `loadNext()`.
+
+```kotlin
+val paginator = admin.usersPaginator(perPage = 50)
+paginator.loadNext() // fetches page 1; observe paginator.items / paginator.error
+```
+
+---
+
+## Models
+
+### AdminUserAttributes
+
+The mutable user fields used by `createUser` and `updateUserById`. All fields are
+optional; on update, only non-null fields are changed. `toString()` masks
+`password`.
+
+```kotlin
+data class AdminUserAttributes(
+    val email: String? = null,
+    val phone: String? = null,
+    val password: String? = null,
+    val userMetadata: JsonObject? = null,   // user_metadata
+    val appMetadata: JsonObject? = null,     // app_metadata
+    val emailConfirm: Boolean? = null,       // email_confirm
+    val phoneConfirm: Boolean? = null,       // phone_confirm
+    val banDuration: String? = null,         // ban_duration, e.g. "24h" or "none"
+    val role: String? = null,
+)
+```
+
+### GenerateLinkType
+
+The kind of action link to generate.
+
+```kotlin
+enum class GenerateLinkType {
+    SIGNUP,                // signup
+    INVITE,                // invite
+    MAGIC_LINK,            // magiclink
+    RECOVERY,              // recovery
+    EMAIL_CHANGE_CURRENT,  // email_change_current
+    EMAIL_CHANGE_NEW,      // email_change_new
+}
+```
+
+### GenerateLinkRequest
+
+Input to `generateLink`.
+
+```kotlin
+data class GenerateLinkRequest(
+    val type: GenerateLinkType,
+    val email: String,
+    val password: String? = null,
+    val newEmail: String? = null,     // new_email (for email-change links)
+    val data: JsonObject? = null,
+    val redirectTo: String? = null,   // redirect_to
+)
+```
+
+### GenerateLinkResponse
+
+Result of `generateLink`.
+
+```kotlin
+data class GenerateLinkResponse(
+    val properties: GenerateLinkProperties,
+    val user: User? = null,
+)
+```
+
+### GenerateLinkProperties
+
+The generated link and its associated tokens.
+
+```kotlin
+data class GenerateLinkProperties(
+    val actionLink: String,            // action_link
+    val emailOtp: String? = null,      // email_otp
+    val hashedToken: String? = null,   // hashed_token
+    val redirectTo: String? = null,    // redirect_to
+    val verificationType: String? = null, // verification_type
+)
+```
+
+### ListUsersResponse
+
+A page of users from `listUsers`.
+
+```kotlin
+data class ListUsersResponse(
+    val users: List<User> = emptyList(),
+    val aud: String? = null,
+)
+```
+
+### MfaAdminListFactorsResponse
+
+A user's MFA factors from `listFactors`.
+
+```kotlin
+data class MfaAdminListFactorsResponse(
+    val factors: List<MfaFactor> = emptyList(),
+)
+```
+
+### MfaAdminDeleteFactorResponse
+
+Result of `deleteFactor` — the deleted factor's id.
+
+```kotlin
+data class MfaAdminDeleteFactorResponse(
+    val id: String,
+)
+```
+
+### OAuthClientType
+
+The OAuth client type. `UNKNOWN` is returned for any type this version does not
+recognise. Each entry exposes its wire `value`.
+
+```kotlin
+enum class OAuthClientType(val value: String) {
+    PUBLIC("public"),
+    CONFIDENTIAL("confidential"),
+    UNKNOWN("unknown"),
+}
+```
+
+### OAuthClientRegistrationType
+
+How an OAuth client was registered. `UNKNOWN` covers unrecognised values.
+
+```kotlin
+enum class OAuthClientRegistrationType(val value: String) {
+    DYNAMIC("dynamic"),
+    MANUAL("manual"),
+    UNKNOWN("unknown"),
+}
+```
+
+### OAuthClientTokenEndpointAuthMethod
+
+The token-endpoint authentication method an OAuth client uses. `UNKNOWN` covers
+unrecognised values.
+
+```kotlin
+enum class OAuthClientTokenEndpointAuthMethod(val value: String) {
+    NONE("none"),
+    CLIENT_SECRET_BASIC("client_secret_basic"),
+    CLIENT_SECRET_POST("client_secret_post"),
+    UNKNOWN("unknown"),
+}
+```
+
+### OAuthClient
+
+A registered OAuth client. Optional fields that GoTrue omits when empty decode to
+`null` / empty defaults. `toString()` masks `clientSecret`.
+
+```kotlin
+data class OAuthClient(
+    val clientId: String,                              // client_id
+    val clientName: String? = null,                    // client_name
+    val clientSecret: String? = null,                  // client_secret
+    val clientType: OAuthClientType = OAuthClientType.UNKNOWN, // client_type
+    val tokenEndpointAuthMethod: OAuthClientTokenEndpointAuthMethod =
+        OAuthClientTokenEndpointAuthMethod.UNKNOWN,    // token_endpoint_auth_method
+    val registrationType: OAuthClientRegistrationType =
+        OAuthClientRegistrationType.UNKNOWN,           // registration_type
+    val clientUri: String? = null,                     // client_uri
+    val logoUri: String? = null,                       // logo_uri
+    val redirectUris: List<String> = emptyList(),      // redirect_uris
+    val grantTypes: List<String> = emptyList(),        // grant_types
+    val responseTypes: List<String> = emptyList(),     // response_types
+    val scope: String? = null,
+    val createdAt: String? = null,                     // created_at
+    val updatedAt: String? = null,                     // updated_at
+)
+```
+
+### OAuthClientCreateRequest
+
+Input to `createOAuthClient`.
+
+```kotlin
+data class OAuthClientCreateRequest(
+    val clientName: String,                            // client_name
+    val redirectUris: List<String>,                    // redirect_uris
+    val clientUri: String? = null,                     // client_uri
+    val grantTypes: List<String>? = null,              // grant_types
+    val responseTypes: List<String>? = null,           // response_types
+    val scope: String? = null,
+    val tokenEndpointAuthMethod: OAuthClientTokenEndpointAuthMethod? = null, // token_endpoint_auth_method
+)
+```
+
+### OAuthClientUpdateRequest
+
+Input to `updateOAuthClient`. Only non-null fields are changed.
+
+```kotlin
+data class OAuthClientUpdateRequest(
+    val clientName: String? = null,                    // client_name
+    val clientUri: String? = null,                     // client_uri
+    val logoUri: String? = null,                       // logo_uri
+    val redirectUris: List<String>? = null,            // redirect_uris
+    val grantTypes: List<String>? = null,              // grant_types
+    val tokenEndpointAuthMethod: OAuthClientTokenEndpointAuthMethod? = null, // token_endpoint_auth_method
+)
+```
+
+### OAuthClientListResponse
+
+A page of OAuth clients from `listOAuthClients`.
+
+```kotlin
+data class OAuthClientListResponse(
+    val clients: List<OAuthClient> = emptyList(),
+    val aud: String? = null,
+)
+```
+
+### CustomProviderType
+
+The custom-provider type. `UNKNOWN` covers unrecognised values.
+
+```kotlin
+enum class CustomProviderType(val value: String) {
+    OAUTH2("oauth2"),
+    OIDC("oidc"),
+    UNKNOWN("unknown"),
+}
+```
+
+### OidcDiscoveryDocument
+
+The resolved OIDC discovery document attached to a custom provider.
+
+```kotlin
+data class OidcDiscoveryDocument(
+    val issuer: String,
+    val authorizationEndpoint: String,                 // authorization_endpoint
+    val tokenEndpoint: String,                         // token_endpoint
+    val jwksUri: String,                               // jwks_uri
+    val userinfoEndpoint: String? = null,              // userinfo_endpoint
+    val revocationEndpoint: String? = null,            // revocation_endpoint
+    val supportedScopes: List<String>? = null,         // supported_scopes
+    val supportedResponseTypes: List<String>? = null,  // supported_response_types
+    val supportedSubjectTypes: List<String>? = null,   // supported_subject_types
+    val supportedIdTokenSigningAlgs: List<String>? = null, // supported_id_token_signing_algs
+)
+```
+
+### CustomProvider
+
+A configured custom OIDC/OAuth2 provider.
+
+```kotlin
+data class CustomProvider(
+    val id: String,
+    val providerType: CustomProviderType = CustomProviderType.UNKNOWN, // provider_type
+    val identifier: String,
+    val name: String,
+    val clientId: String,                              // client_id
+    val acceptableClientIds: List<String>? = null,     // acceptable_client_ids
+    val scopes: List<String>? = null,
+    val pkceEnabled: Boolean? = null,                  // pkce_enabled
+    val attributeMapping: JsonObject? = null,          // attribute_mapping
+    val authorizationParams: Map<String, String>? = null, // authorization_params
+    val enabled: Boolean? = null,
+    val emailOptional: Boolean? = null,                // email_optional
+    val issuer: String? = null,
+    val discoveryUrl: String? = null,                  // discovery_url
+    val skipNonceCheck: Boolean? = null,               // skip_nonce_check
+    val authorizationUrl: String? = null,              // authorization_url
+    val tokenUrl: String? = null,                      // token_url
+    val userinfoUrl: String? = null,                   // userinfo_url
+    val jwksUri: String? = null,                       // jwks_uri
+    val discoveryDocument: OidcDiscoveryDocument? = null, // discovery_document
+    val createdAt: String? = null,                     // created_at
+    val updatedAt: String? = null,                     // updated_at
+)
+```
+
+### CustomProviderCreateRequest
+
+Input to `createCustomProvider`. `toString()` masks `clientSecret`.
+
+```kotlin
+data class CustomProviderCreateRequest(
+    val providerType: CustomProviderType,              // provider_type
+    val identifier: String,
+    val name: String,
+    val clientId: String,                              // client_id
+    val clientSecret: String,                          // client_secret
+    val acceptableClientIds: List<String>? = null,     // acceptable_client_ids
+    val scopes: List<String>? = null,
+    val pkceEnabled: Boolean? = null,                  // pkce_enabled
+    val attributeMapping: JsonObject? = null,          // attribute_mapping
+    val authorizationParams: Map<String, String>? = null, // authorization_params
+    val enabled: Boolean? = null,
+    val emailOptional: Boolean? = null,                // email_optional
+    val issuer: String? = null,
+    val discoveryUrl: String? = null,                  // discovery_url
+    val skipNonceCheck: Boolean? = null,               // skip_nonce_check
+    val authorizationUrl: String? = null,              // authorization_url
+    val tokenUrl: String? = null,                      // token_url
+    val userinfoUrl: String? = null,                   // userinfo_url
+    val jwksUri: String? = null,                       // jwks_uri
+)
+```
+
+### CustomProviderUpdateRequest
+
+Input to `updateCustomProvider`. Only non-null fields are changed. `toString()`
+masks `clientSecret`.
+
+```kotlin
+data class CustomProviderUpdateRequest(
+    val name: String? = null,
+    val clientId: String? = null,                      // client_id
+    val clientSecret: String? = null,                  // client_secret
+    val acceptableClientIds: List<String>? = null,     // acceptable_client_ids
+    val scopes: List<String>? = null,
+    val pkceEnabled: Boolean? = null,                  // pkce_enabled
+    val attributeMapping: JsonObject? = null,          // attribute_mapping
+    val authorizationParams: Map<String, String>? = null, // authorization_params
+    val enabled: Boolean? = null,
+    val emailOptional: Boolean? = null,                // email_optional
+    val issuer: String? = null,
+    val discoveryUrl: String? = null,                  // discovery_url
+    val skipNonceCheck: Boolean? = null,               // skip_nonce_check
+    val authorizationUrl: String? = null,              // authorization_url
+    val tokenUrl: String? = null,                      // token_url
+    val userinfoUrl: String? = null,                   // userinfo_url
+    val jwksUri: String? = null,                       // jwks_uri
+)
+```
+
+### CustomProviderListResponse
+
+The result of `listCustomProviders`.
+
+```kotlin
+data class CustomProviderListResponse(
+    val providers: List<CustomProvider> = emptyList(),
+)
+```
+
+### SsoProviderSaml
+
+The SAML configuration block of an SSO provider.
+
+```kotlin
+data class SsoProviderSaml(
+    val entityId: String? = null,           // entity_id
+    val metadataUrl: String? = null,        // metadata_url
+    val metadataXml: String? = null,        // metadata_xml
+    val attributeMapping: JsonObject? = null, // attribute_mapping
+    val nameIdFormat: String? = null,       // name_id_format
+)
+```
+
+### SsoDomain
+
+A domain bound to a SAML SSO provider.
+
+```kotlin
+data class SsoDomain(
+    val id: String? = null,
+    val domain: String? = null,
+    val createdAt: String? = null,          // created_at
+    val updatedAt: String? = null,          // updated_at
+)
+```
+
+### SsoProvider
+
+A registered SAML SSO identity provider.
+
+```kotlin
+data class SsoProvider(
+    val id: String,
+    val type: String? = null,
+    val resourceId: String? = null,         // resource_id
+    val disabled: Boolean? = null,
+    val saml: SsoProviderSaml? = null,
+    val domains: List<SsoDomain> = emptyList(),
+    val createdAt: String? = null,          // created_at
+    val updatedAt: String? = null,          // updated_at
+)
+```
+
+### SsoProviderCreateRequest
+
+Input to `createSsoProvider`. Provide either `metadataUrl` or `metadataXml`. The
+`type` field is always serialised even though it defaults to `"saml"`.
+
+```kotlin
+data class SsoProviderCreateRequest(
+    val type: String = "saml",              // always encoded
+    val metadataUrl: String? = null,        // metadata_url
+    val metadataXml: String? = null,        // metadata_xml
+    val domains: List<String>? = null,
+    val attributeMapping: JsonObject? = null, // attribute_mapping
+    val nameIdFormat: String? = null,       // name_id_format
+    val resourceId: String? = null,         // resource_id
+    val disabled: Boolean? = null,
+)
+```
+
+### SsoProviderUpdateRequest
+
+Input to `updateSsoProvider`. Omitted `domains` / `attributeMapping` keep their
+existing values. The `type` field is always serialised.
+
+```kotlin
+data class SsoProviderUpdateRequest(
+    val type: String = "saml",              // always encoded
+    val metadataUrl: String? = null,        // metadata_url
+    val metadataXml: String? = null,        // metadata_xml
+    val domains: List<String>? = null,
+    val attributeMapping: JsonObject? = null, // attribute_mapping
+    val nameIdFormat: String? = null,       // name_id_format
+    val resourceId: String? = null,         // resource_id
+    val disabled: Boolean? = null,
+)
+```
+
+### SsoProviderListResponse
+
+The raw `{ "items": [...] }` wrapper returned by the SSO list endpoint.
+`listSsoProviders` unwraps this for you, but the type is public for direct use.
+
+```kotlin
+data class SsoProviderListResponse(
+    val items: List<SsoProvider> = emptyList(),
+)
+```
+
+### Passkey
+
+A passkey registered to a user.
+
+```kotlin
+data class Passkey(
+    val id: String,
+    val friendlyName: String? = null,       // friendly_name
+    val createdAt: String,                  // created_at
+    val lastUsedAt: String? = null,         // last_used_at
+)
+```
+
+### AuditLogEntry
+
+A single audit-log entry from `listAuditLogEvents`. The `payload` shape depends on
+the recorded action, so it is kept as a raw `JsonObject` rather than a typed model.
+
+```kotlin
+data class AuditLogEntry(
+    val id: String,
+    val payload: JsonObject? = null,
+    val createdAt: String? = null,          // created_at
+    val ipAddress: String? = null,          // ip_address
+)
+```
+
+---
+
+## Related types
+
+These types come from other modules and appear in admin signatures:
+
+- `SupabaseResult<T>` — the result wrapper every method returns (`supabase-core`).
+- `User`, `MfaFactor`, `SignOutScope` — shared auth models (`supabase-auth`).
+- `Paginator<T>` — the demand-driven pager returned by `usersPaginator` (`supabase-core`).
+- `SupabaseClient` — the base client passed to `createAuthAdminClient`.

--- a/website/pages/reference/auth-native.mdx
+++ b/website/pages/reference/auth-native.mdx
@@ -1,0 +1,389 @@
+---
+title: Native Sign-In — API Reference
+description: API reference for the optional supabase-auth-google, supabase-auth-apple and supabase-auth-passkey add-on modules, which layer native platform credential flows on top of supabase-auth.
+---
+
+import { Callout } from 'nextra/components'
+
+# Native Sign-In — API Reference
+
+These are three **optional add-on modules** that sit on top of `supabase-auth`.
+Each drives a platform-native credential flow — a Google account chooser, "Sign
+in with Apple", or a WebAuthn passkey ceremony — and hands the resulting
+credential back to the core SDK to redeem for a Supabase session. The core never
+bundles a provider SDK you did not ask for, so you only pull in the piece you
+use.
+
+Add whichever you need (version `1.0.0`):
+
+```kotlin
+implementation("io.github.androidpoet:supabase-auth-google:1.0.0")
+implementation("io.github.androidpoet:supabase-auth-apple:1.0.0")
+implementation("io.github.androidpoet:supabase-auth-passkey:1.0.0")
+```
+
+<Callout type="info">
+  The Google and Apple modules produce a
+  [`NativeAuthProvider`](#how-the-pieces-fit) that you pass to
+  `AuthClient.signInWith(...)`. The passkey module instead exposes
+  `registerPasskey` / `signInWithPasskey` extensions that run the whole ceremony
+  for you. All public functions are `suspend` and return a
+  `SupabaseResult<T>` — `SupabaseResult.Success` carries the value,
+  `SupabaseResult.Failure` carries a `SupabaseError`. A user-cancelled sheet is a
+  `Failure` with a stable, branchable `code`, never a thrown exception.
+</Callout>
+
+### How the pieces fit
+
+All three modules build on two core symbols already in `supabase-auth`:
+
+- `NativeAuthProvider` — the SDK's single extension point for native sign-in.
+  `googleAuthProvider(...)` and `appleAuthProvider(...)` return one. You hand it
+  to `suspend fun AuthClient.signInWith(provider, captchaToken, onCredential): SupabaseResult<Session>`,
+  which runs the native flow, then exchanges the returned ID token for a session.
+- `generateNonce(byteCount: Int = 32): String` — a CSPRNG-backed, URL-safe,
+  single-use nonce. Pass it to a config's `nonce` and the provider hashes it for
+  the platform while returning the raw value for Supabase to validate. Throws
+  `IllegalArgumentException` if `byteCount` is below 16.
+
+---
+
+## Google
+
+**Artifact:** `io.github.androidpoet:supabase-auth-google`
+
+**Supported platforms.** The shared `GoogleSignInConfig` is available on every
+target the module publishes (Android, JVM, iOS, macOS, Wasm/JS). The native
+ceremony itself is **Android-only**: the `googleAuthProvider(...)` factory is
+declared solely in the Android source set and is backed by Android's Credential
+Manager plus Google Identity Services. There is no native Google flow on iOS,
+macOS, JVM or the browser in this module — on those platforms supply your own
+`NativeAuthProvider` or use a different sign-in method.
+
+### `GoogleSignInConfig`
+
+Configuration for a native Google sign-in flow.
+
+```kotlin
+public data class GoogleSignInConfig(
+    public val serverClientId: String,
+    public val nonce: String? = null,
+    public val filterByAuthorizedAccounts: Boolean = false,
+    public val autoSelectEnabled: Boolean = false,
+)
+```
+
+- `serverClientId` — your Google **Web** client ID (the OAuth client of type
+  "Web application"), the same value configured as the Supabase Google provider's
+  client ID. The returned ID token is audienced for it so Supabase can validate
+  the token.
+- `nonce` — optional raw nonce. When set it is hashed and forwarded to Google,
+  and the raw value is carried back in the credential so Supabase can validate
+  the token's hashed `nonce` claim. Use a fresh value per sign-in from
+  `generateNonce()`. Default `null`.
+- `filterByAuthorizedAccounts` — when `true`, only accounts that previously
+  authorized this app are offered; set `false` to allow first-time sign-ups.
+  Default `false`.
+- `autoSelectEnabled` — enables Google's auto sign-in when a single matching
+  credential exists. Default `false`.
+
+Being a `data class`, it also exposes `copy`, `equals`, `hashCode`, `toString`
+and `componentN` destructuring.
+
+### `googleAuthProvider` (Android)
+
+Creates a Google `NativeAuthProvider` backed by Credential Manager and Google
+Identity Services.
+
+```kotlin
+public fun googleAuthProvider(
+    context: Context,
+    config: GoogleSignInConfig,
+): NativeAuthProvider
+```
+
+- `context` — an **Activity** context; Credential Manager presents its UI from it.
+- `config` — the `GoogleSignInConfig` above.
+
+Returns a `NativeAuthProvider` synchronously. Its `signIn()` returns
+`SupabaseResult<NativeAuthCredential>` — a `Failure` with code
+`google_sign_in_cancelled` (user dismissed the sheet),
+`google_no_credentials` (no eligible account) or `google_sign_in_failed`
+(any other error). Pass the provider to `AuthClient.signInWith(...)` to obtain a
+`Session`.
+
+```kotlin
+// Android
+val config = GoogleSignInConfig(
+    serverClientId = "YOUR_WEB_CLIENT_ID.apps.googleusercontent.com",
+    nonce = generateNonce(),
+)
+val provider = googleAuthProvider(activity, config)
+
+when (val result = supabase.auth.signInWith(provider)) {
+    is SupabaseResult.Success -> println("Signed in: ${result.value.user?.email}")
+    is SupabaseResult.Failure -> println("Sign-in failed: ${result.error.code}")
+}
+```
+
+---
+
+## Apple
+
+**Artifact:** `io.github.androidpoet:supabase-auth-apple`
+
+**Supported platforms.** The shared `AppleSignInConfig` is available on every
+published target (Android, JVM, iOS, macOS, Wasm/JS). The native ceremony is
+restricted to **Apple targets only** — `iosArm64`, `iosSimulatorArm64`,
+`iosX64`, `macosArm64`, `macosX64` — where `appleAuthProvider(...)` is backed by
+the system `AuthenticationServices` sheet. The factory is not present on Android,
+JVM or the browser; "Sign in with Apple" is not offered there by this module.
+
+### `AppleSignInConfig`
+
+Configuration for a native "Sign in with Apple" flow.
+
+```kotlin
+public data class AppleSignInConfig(
+    public val nonce: String? = null,
+    public val requestEmail: Boolean = true,
+    public val requestFullName: Boolean = true,
+)
+```
+
+- `nonce` — optional raw nonce. When set, its SHA-256 hash is sent to Apple and
+  the raw value is returned in the credential so Supabase can validate the
+  token's hashed `nonce` claim. Use a fresh value per sign-in from
+  `generateNonce()`. Default `null`.
+- `requestEmail` — request the email scope. When granted, the email is surfaced
+  on the **first** authorization in the credential's `email`. Default `true`.
+- `requestFullName` — request the full-name scope. When granted, the name is
+  surfaced on the **first** authorization in the credential's `fullName`. Apple
+  returns the name and email only once, so persist them on that first sign-in.
+  Default `true`.
+
+Being a `data class`, it also exposes `copy`, `equals`, `hashCode`, `toString`
+and `componentN` destructuring.
+
+### `appleAuthProvider` (Apple targets)
+
+Creates a "Sign in with Apple" `NativeAuthProvider` backed by
+`AuthenticationServices`.
+
+```kotlin
+public fun appleAuthProvider(
+    config: AppleSignInConfig,
+): NativeAuthProvider
+```
+
+- `config` — the `AppleSignInConfig` above.
+
+Returns a `NativeAuthProvider` synchronously. Its `signIn()` returns
+`SupabaseResult<NativeAuthCredential>` — a `Failure` with code
+`apple_sign_in_cancelled` (user dismissed) or `apple_sign_in_failed` (no
+identity token, or any other error). Because the name and email only arrive on
+the first authorization and are absent from the ID token, capture them via the
+`onCredential` hook of `signInWith` before the token is redeemed.
+
+```kotlin
+// iOS / macOS
+val provider = appleAuthProvider(AppleSignInConfig(nonce = generateNonce()))
+
+val result = supabase.auth.signInWith(provider) { credential ->
+    // Apple returns these only on the first sign-in — persist them now.
+    credential.fullName?.let { saveDisplayName(it) }
+    credential.email?.let { saveEmail(it) }
+}
+when (result) {
+    is SupabaseResult.Success -> println("Signed in")
+    is SupabaseResult.Failure -> println("Failed: ${result.error.code}")
+}
+```
+
+---
+
+## Passkey
+
+**Artifact:** `io.github.androidpoet:supabase-auth-passkey`
+
+**Supported platforms.** This module is published for Android, JVM, iOS, macOS
+and Wasm/JS. A passkey flow has three steps — Supabase returns options (a
+challenge), the device's authenticator produces a credential, and Supabase
+verifies it. The HTTP steps live in `supabase-auth`; this module provides the
+middle (ceremony) step plus the extensions that stitch all three together. Two
+authenticators ship:
+
+- `PasskeysKmpAuthenticator` — common to **every** target; it drives a real
+  native WebAuthn ceremony on each platform through a cross-platform passkey
+  client.
+- `CredentialManagerPasskeyAuthenticator` — **Android-only**, backed by AndroidX
+  Credential Manager directly.
+
+The `registerPasskey` / `signInWithPasskey` extensions are common and run on any
+target; they are only as portable as the `PasskeyAuthenticator` you give them.
+
+### `PasskeyAuthenticator`
+
+The contract for driving the platform's WebAuthn ceremony — the one step the
+Supabase HTTP API cannot perform. Implement it to support a platform yourself;
+cancellation or authenticator failure must be reported as a `Failure`, not
+thrown.
+
+```kotlin
+public interface PasskeyAuthenticator {
+    public suspend fun createCredential(options: JsonObject): SupabaseResult<JsonObject>
+    public suspend fun getCredential(options: JsonObject): SupabaseResult<JsonObject>
+}
+```
+
+- `createCredential(options)` — runs the registration ceremony
+  (`navigator.credentials.create`): prompts the user to create a passkey for the
+  WebAuthn `options` and returns the credential JSON for the registration verify
+  endpoint.
+- `getCredential(options)` — runs the authentication ceremony
+  (`navigator.credentials.get`): prompts the user to assert an existing passkey
+  for the `options` and returns the credential JSON for the authentication verify
+  endpoint.
+
+Both take the WebAuthn options object Supabase returned and yield a
+`SupabaseResult<JsonObject>` — the credential JSON on `Success`.
+
+### `PasskeysKmpAuthenticator` (all targets)
+
+A `PasskeyAuthenticator` backed by a cross-platform passkey client, giving a real
+native ceremony on Android, iOS, macOS, JVM/Compose Desktop and the browser from
+a single adapter. Authenticator failures are mapped to stable codes
+(`passkey_cancelled`, `passkey_no_credentials`, `passkey_unsupported`,
+`passkey_ceremony_failed`) so callers branch identically regardless of platform.
+
+```kotlin
+public class PasskeysKmpAuthenticator(
+    client: PasskeyClient,
+) : PasskeyAuthenticator
+```
+
+- `client` — the cross-platform passkey client for the current platform,
+  constructed with the right presentation anchor.
+
+It implements the interface's `createCredential` and `getCredential`, each
+returning `SupabaseResult<JsonObject>`.
+
+```kotlin
+// Compose Multiplatform — anchor resolved for you
+val authenticator = PasskeysKmpAuthenticator(rememberPasskeyClient())
+supabase.signInWithPasskey(authenticator)
+```
+
+### `CredentialManagerPasskeyAuthenticator` (Android)
+
+A `PasskeyAuthenticator` backed by AndroidX Credential Manager, which speaks the
+W3C WebAuthn JSON serialization directly. It maps Credential Manager's exceptions
+to the same stable codes as the cross-platform authenticator.
+
+```kotlin
+public class CredentialManagerPasskeyAuthenticator(
+    context: Context,
+    credentialManager: CredentialManager = CredentialManager.create(context),
+) : PasskeyAuthenticator
+```
+
+- `context` — an **Activity** context; Credential Manager shows system UI and
+  needs an activity to host it.
+- `credentialManager` — overridable for testing; defaults to one created from
+  `context`.
+
+It implements `createCredential` and `getCredential`, each returning
+`SupabaseResult<JsonObject>`.
+
+### `AuthClient.registerPasskey`
+
+Registers a new passkey for the signed-in user, driving the whole ceremony:
+fetch registration options from Supabase, run the device authenticator, then
+verify the resulting credential. Short-circuits to `Failure` at the first failing
+step.
+
+```kotlin
+public suspend fun AuthClient.registerPasskey(
+    accessToken: String,
+    authenticator: PasskeyAuthenticator,
+): SupabaseResult<PasskeyMetadata>
+```
+
+- `accessToken` — the current session's access token.
+- `authenticator` — the platform ceremony driver.
+
+Returns `SupabaseResult<PasskeyMetadata>` — the registered passkey's metadata on
+`Success`.
+
+### `AuthClient.signInWithPasskey`
+
+Signs in passwordlessly with a passkey, driving the whole ceremony: fetch
+authentication options, run the device authenticator, then verify the assertion
+to obtain a `Session`. Short-circuits to `Failure` at the first failing step.
+
+```kotlin
+public suspend fun AuthClient.signInWithPasskey(
+    authenticator: PasskeyAuthenticator,
+    captchaToken: String? = null,
+): SupabaseResult<Session>
+```
+
+- `authenticator` — the platform ceremony driver.
+- `captchaToken` — optional CAPTCHA token when bot protection is enabled.
+  Default `null`.
+
+Returns `SupabaseResult<Session>` — the new session on `Success`. Note this
+`AuthClient` variant does not apply the session to the client; use the
+`SupabaseClient` variant below for that.
+
+### `SupabaseClient.registerPasskey`
+
+The client-level convenience over `AuthClient.registerPasskey`: registers a
+passkey for the currently signed-in user using this client's own access token.
+Fails with a `Failure` if no session is active.
+
+```kotlin
+public suspend fun SupabaseClient.registerPasskey(
+    authenticator: PasskeyAuthenticator,
+): SupabaseResult<PasskeyMetadata>
+```
+
+- `authenticator` — the platform ceremony driver.
+
+Returns `SupabaseResult<PasskeyMetadata>`.
+
+### `SupabaseClient.signInWithPasskey`
+
+The client-level counterpart to `AuthClient.signInWithPasskey`: signs in and, on
+success, applies the returned access token to this client so subsequent requests
+are authenticated. For persisted or multi-session apps, prefer a `SessionManager`
+instead.
+
+```kotlin
+public suspend fun SupabaseClient.signInWithPasskey(
+    authenticator: PasskeyAuthenticator,
+    captchaToken: String? = null,
+): SupabaseResult<Session>
+```
+
+- `authenticator` — the platform ceremony driver.
+- `captchaToken` — optional CAPTCHA token when bot protection is enabled.
+  Default `null`.
+
+Returns `SupabaseResult<Session>`.
+
+```kotlin
+val authenticator = PasskeysKmpAuthenticator(rememberPasskeyClient())
+
+// Register a passkey for the signed-in user.
+when (val reg = supabase.registerPasskey(authenticator)) {
+    is SupabaseResult.Success -> println("Passkey registered: ${reg.value}")
+    is SupabaseResult.Failure -> println("Register failed: ${reg.error.code}")
+}
+
+// Later, sign in passwordlessly — applies the session to `supabase` on success.
+when (val result = supabase.signInWithPasskey(authenticator)) {
+    is SupabaseResult.Success -> println("Signed in")
+    is SupabaseResult.Failure -> println("Failed: ${result.error.code}")
+}
+```

--- a/website/pages/reference/auth.mdx
+++ b/website/pages/reference/auth.mdx
@@ -1,0 +1,1780 @@
+---
+title: Authentication — API Reference
+description: Complete API reference for the supabase-auth module — AuthClient methods, session management, OAuth, MFA, passkeys, JWT helpers, and every public model type.
+---
+
+import { Callout } from 'nextra/components'
+
+# Authentication — API Reference
+
+`supabase-auth` is a typed Kotlin Multiplatform client over Supabase's GoTrue auth
+API: email/phone/anonymous sign-in, OTP and magic links, OAuth (17 providers), MFA,
+passkeys, identity linking, Web3, SSO, and local JWT/JWKS verification. The module is
+published as `io.github.androidpoet:supabase-auth`. The entry point is
+`createAuthClient(client)`, or the `SupabaseClient.auth` shortcut property.
+
+<Callout type="info">
+Every suspending call follows the **Result-first** contract: HTTP and parse errors
+come back as `SupabaseResult.Failure` rather than being thrown. `SupabaseResult<T>`
+is a sealed type with `Success(value)` and `Failure(error)` arms — it is **not**
+`kotlin.Result`. The core `AuthClient` is *stateless* with respect to the session:
+its methods return a `Session` (or take an `accessToken` you pass in) but never
+persist or refresh it. Layer a `SessionManager` on top, or use the `…AndSaveSession`
+extensions, for storage and auto-refresh.
+</Callout>
+
+## Entry points
+
+### `createAuthClient`
+
+```kotlin
+public fun createAuthClient(supabaseClient: SupabaseClient): AuthClient
+```
+
+Builds an `AuthClient` over an existing `SupabaseClient`. The returned client is a
+thin, stateless wrapper — creating one is cheap.
+
+- `supabaseClient` — the configured project client.
+
+```kotlin
+val auth = createAuthClient(client)
+```
+
+### `SupabaseClient.auth`
+
+```kotlin
+public val SupabaseClient.auth: AuthClient
+```
+
+A discoverable shortcut for `createAuthClient(this)`, so you can write
+`client.auth.signInWithEmail(...)`. Reading it repeatedly is cheap and always talks
+to the same underlying transport.
+
+```kotlin
+val session = client.auth.signInWithEmail("a@b.com", "secret")
+```
+
+---
+
+## AuthClient — sign-up & sign-in
+
+### `signUpWithEmail`
+
+```kotlin
+public suspend fun signUpWithEmail(
+    email: String,
+    password: String,
+    data: JsonObject? = null,
+    emailRedirectTo: String? = null,
+    captchaToken: String? = null,
+    pkceParams: PkceParams? = null,
+): SupabaseResult<Session>
+```
+
+Signs up a new user against `POST /signup`. When email confirmation is enabled the
+returned `Session` may carry no tokens until the user confirms; otherwise it is fully
+authenticated.
+
+- `email` — new user's email; fails if blank.
+- `password` — chosen password.
+- `data` — optional `user_metadata` stored on the new user. Default `null`.
+- `emailRedirectTo` — URL the confirmation email links back to (`redirect_to` query param). Default `null`.
+- `captchaToken` — captcha response when bot protection is enabled. Default `null`.
+- `pkceParams` — PKCE challenge to bind a PKCE-flow sign-up; complete via `exchangeCodeForSession`. Default `null` (implicit flow).
+
+Returns `SupabaseResult<Session>`. Success carries the new session; Failure carries a `SupabaseError`.
+
+```kotlin
+when (val r = auth.signUpWithEmail("a@b.com", "secret")) {
+    is SupabaseResult.Success -> println(r.value.user.id)
+    is SupabaseResult.Failure -> println(r.error.message)
+}
+```
+
+### `signUpWithPhone`
+
+```kotlin
+public suspend fun signUpWithPhone(
+    phone: String,
+    password: String,
+    data: JsonObject? = null,
+    redirectTo: String? = null,
+    captchaToken: String? = null,
+    pkceParams: PkceParams? = null,
+    channel: MessagingChannel? = null,
+): SupabaseResult<Session>
+```
+
+Signs up a new user with phone + password against `POST /signup`. When phone
+confirmation (SMS OTP) is enabled the user must verify before the session is usable.
+
+- `phone` — new user's phone; fails if blank.
+- `password` — chosen password.
+- `data` — optional `user_metadata`. Default `null`.
+- `redirectTo` — post-confirmation redirect (`redirect_to`). Default `null`.
+- `captchaToken` — captcha response. Default `null`.
+- `pkceParams` — PKCE challenge for a PKCE-flow sign-up. Default `null`.
+- `channel` — phone delivery channel (`SMS` server default, or `WHATSAPP`). Default `null`.
+
+Returns `SupabaseResult<Session>`.
+
+### `signInWithEmail`
+
+```kotlin
+public suspend fun signInWithEmail(
+    email: String,
+    password: String,
+    captchaToken: String? = null,
+): SupabaseResult<Session>
+```
+
+Signs in via the `password` grant (`POST /token?grant_type=password`).
+
+- `email` — registered email.
+- `password` — the password.
+- `captchaToken` — captcha response. Default `null`.
+
+Returns `SupabaseResult<Session>`. Failure on bad credentials.
+
+### `signInWithPhone`
+
+```kotlin
+public suspend fun signInWithPhone(
+    phone: String,
+    password: String,
+    captchaToken: String? = null,
+): SupabaseResult<Session>
+```
+
+Signs in with phone + password via the `password` grant. Same parameters and return
+contract as `signInWithEmail`, keyed by `phone`.
+
+### `signInAnonymously`
+
+```kotlin
+public suspend fun signInAnonymously(
+    data: JsonObject? = null,
+    captchaToken: String? = null,
+): SupabaseResult<Session>
+```
+
+Creates and signs in an anonymous user via `POST /signup` with no credentials,
+yielding a session whose `User.isAnonymous` is `true`. Later convertible to a
+permanent account by adding an email/phone identity.
+
+- `data` — optional `user_metadata` for the anonymous user. Default `null`.
+- `captchaToken` — captcha response. Default `null`.
+
+Returns `SupabaseResult<Session>`.
+
+### `signInWithIdToken`
+
+```kotlin
+public suspend fun signInWithIdToken(
+    provider: OAuthProvider,
+    idToken: String,
+    accessToken: String? = null,
+    nonce: String? = null,
+    captchaToken: String? = null,
+    clientId: String? = null,
+    issuer: String? = null,
+): SupabaseResult<Session>
+```
+
+Signs in with an OpenID Connect ID token from a native provider SDK (Sign in with
+Apple, Google One Tap, …) via the `id_token` grant. No browser redirect is involved.
+
+- `provider` — the OIDC provider the token came from.
+- `idToken` — the provider's ID token (a JWT).
+- `accessToken` — the provider's access token, when it also issues one. Default `null`.
+- `nonce` — the raw nonce bound into the ID token, for replay protection. Default `null`.
+- `captchaToken` — captcha response. Default `null`.
+- `clientId` — OIDC client id, when the provider requires it sent explicitly. Default `null`.
+- `issuer` — OIDC issuer to verify against; required for custom OIDC providers. Default `null`.
+
+Returns `SupabaseResult<Session>`.
+
+### `signInWithOAuth`
+
+```kotlin
+public suspend fun signInWithOAuth(
+    provider: OAuthProvider,
+    redirectTo: String? = null,
+    scopes: List<String> = emptyList(),
+    queryParams: Map<String, String> = emptyMap(),
+    skipBrowserRedirect: Boolean = false,
+    pkceParams: PkceParams? = null,
+    inviteToken: String? = null,
+): SupabaseResult<OAuthResponse>
+```
+
+Begins a browser-redirect OAuth flow by building the provider authorize URL — it
+does **not** perform a network call, it returns the `OAuthResponse` URL for your app
+to open. Complete the flow with `exchangeCodeForSession` (PKCE) or by importing the
+redirect fragment. Equivalent to `getOAuthSignInUrl` wrapped in a result.
+
+- `provider` — the OAuth provider.
+- `redirectTo` — where the provider sends the user back after consent. Default `null`.
+- `scopes` — provider scopes (space-joined on the wire). Default `emptyList()`.
+- `queryParams` — extra authorize-URL params (e.g. `prompt`, or a CSRF `state`). Default `emptyMap()`.
+- `skipBrowserRedirect` — adds `skip_http_redirect=true` so the endpoint returns JSON instead of a 302. Default `false`.
+- `pkceParams` — PKCE challenge to bind the request. Default `null`.
+- `inviteToken` — a prior invitation token to complete on success (`invite_token`). Default `null`.
+
+Returns `SupabaseResult<OAuthResponse>` (the `url` to open and the `provider`).
+
+```kotlin
+val pkce = auth.generatePkceParams()
+val r = auth.signInWithOAuth(OAuthProvider.GITHUB, pkceParams = pkce)
+// open r.value.url in a browser/custom tab
+```
+
+### `signInWithWeb3`
+
+```kotlin
+public suspend fun signInWithWeb3(
+    chain: Web3Chain,
+    message: String,
+    signature: String,
+    captchaToken: String? = null,
+): SupabaseResult<Session>
+```
+
+Signs in by proving control of a Web3 wallet via the `web3` grant: the user signs
+`message` with their wallet and `signature` is verified server-side for the given
+`chain` (Ethereum/Solana).
+
+- `chain` — `Web3Chain.ETHEREUM` or `Web3Chain.SOLANA`.
+- `message` — the signed message.
+- `signature` — the wallet signature.
+- `captchaToken` — captcha response. Default `null`.
+
+Returns `SupabaseResult<Session>`.
+
+---
+
+## OTP & passwordless
+
+### `signInWithOtp`
+
+```kotlin
+public suspend fun signInWithOtp(
+    email: String? = null,
+    phone: String? = null,
+    createUser: Boolean? = null,
+    captchaToken: String? = null,
+    emailRedirectTo: String? = null,
+    channel: MessagingChannel? = null,
+    data: JsonObject? = null,
+    pkceParams: PkceParams? = null,
+): SupabaseResult<Unit>
+```
+
+Starts a passwordless OTP / magic-link sign-in by requesting a one-time code be sent
+to an email or phone (`POST /otp`). Complete the flow with `verifyOtp`. Set exactly
+one of `email` or `phone`.
+
+- `email` / `phone` — the recipient; provide exactly one. Default `null`.
+- `createUser` — auto-create the user if absent (server default when `null`). Default `null`.
+- `captchaToken` — captcha response. Default `null`.
+- `emailRedirectTo` — magic-link redirect for the email channel. Default `null`.
+- `channel` — phone delivery channel (`SMS`/`WHATSAPP`); ignored for email. Default `null`.
+- `data` — `user_metadata` stored when the user is auto-created. Default `null`.
+- `pkceParams` — PKCE challenge for a PKCE-flow magic link. Default `null`.
+
+Returns `SupabaseResult<Unit>` (success on dispatch).
+
+### `verifyOtp`
+
+```kotlin
+public suspend fun verifyOtp(
+    email: String? = null,
+    phone: String? = null,
+    token: String,
+    type: OtpType,
+    captchaToken: String? = null,
+    redirectTo: String? = null,
+): SupabaseResult<OtpVerifyResult>
+```
+
+Verifies an OTP / magic-link code against `POST /verify`, completing a flow started by
+`signInWithOtp`, a confirmation, or a recovery. Pass the same `email`/`phone` the code
+was sent to.
+
+- `email` / `phone` — the recipient the code was sent to. Default `null`.
+- `token` — the user-entered code.
+- `type` — which OTP flow the token belongs to (`SIGNUP`, `RECOVERY`, …).
+- `captchaToken` — captcha response. Default `null`.
+- `redirectTo` — post-verification redirect, used by link-style flows. Default `null`.
+
+Returns `SupabaseResult<OtpVerifyResult>`. The sealed result distinguishes a
+verification that produced a session (`OtpVerifyResult.Authenticated`, the common
+case — reach the session via `.session`) from one that succeeded without one
+(`OtpVerifyResult.VerifiedNoSession`, e.g. some email-change confirmations), so a
+no-session success isn't reported as a failure.
+
+```kotlin
+when (val r = auth.verifyOtp(email = "a@b.com", token = "123456", type = OtpType.EMAIL)) {
+    is SupabaseResult.Success -> when (val v = r.value) {
+        is OtpVerifyResult.Authenticated -> save(v.session)
+        OtpVerifyResult.VerifiedNoSession -> {}
+    }
+    is SupabaseResult.Failure -> showError(r.error)
+}
+```
+
+### `verifyOtpWithTokenHash`
+
+```kotlin
+public suspend fun verifyOtpWithTokenHash(
+    tokenHash: String,
+    type: OtpType,
+    captchaToken: String? = null,
+): SupabaseResult<OtpVerifyResult>
+```
+
+Verifies an email-link confirmation by its `token_hash` (the value embedded in a
+Supabase confirmation/recovery link) rather than a user-entered code, via
+`POST /verify`. Use this when handling a deep link the user clicked.
+
+- `tokenHash` — the `token_hash` from the link.
+- `type` — the OTP flow.
+- `captchaToken` — captcha response. Default `null`.
+
+Returns `SupabaseResult<OtpVerifyResult>` (same shape as `verifyOtp`).
+
+### `resendEmailOtp`
+
+```kotlin
+public suspend fun resendEmailOtp(
+    type: OtpType,
+    email: String,
+    captchaToken: String? = null,
+    redirectTo: String? = null,
+): SupabaseResult<Unit>
+```
+
+Re-sends a pending email OTP / confirmation (`POST /resend`), e.g. after the first
+code expired.
+
+- `type` — the OTP flow to resend (e.g. `SIGNUP`, `EMAIL_CHANGE`).
+- `email` — the recipient.
+- `captchaToken` — captcha response. Default `null`.
+- `redirectTo` — magic-link redirect for the resent email. Default `null`.
+
+Returns `SupabaseResult<Unit>`.
+
+### `resendPhoneOtp`
+
+```kotlin
+public suspend fun resendPhoneOtp(
+    type: OtpType,
+    phone: String,
+    captchaToken: String? = null,
+): SupabaseResult<Unit>
+```
+
+Re-sends a pending phone OTP (`POST /resend`).
+
+- `type` — the OTP flow to resend (e.g. `SMS`, `PHONE_CHANGE`).
+- `phone` — the recipient.
+- `captchaToken` — captcha response. Default `null`.
+
+Returns `SupabaseResult<Unit>`.
+
+---
+
+## Password reset & reauthentication
+
+### `resetPasswordForEmail`
+
+```kotlin
+public suspend fun resetPasswordForEmail(
+    email: String,
+    redirectTo: String? = null,
+    captchaToken: String? = null,
+    pkceParams: PkceParams? = null,
+): SupabaseResult<Unit>
+```
+
+Sends a password-reset email (`POST /recover`); the link lets the user set a new
+password.
+
+- `email` — the recipient.
+- `redirectTo` — where the recovery link returns the user (`redirect_to`). Default `null`.
+- `captchaToken` — captcha response. Default `null`.
+- `pkceParams` — PKCE challenge for a PKCE-flow recovery. Default `null`.
+
+Returns `SupabaseResult<Unit>` (success on dispatch).
+
+### `reauthenticate`
+
+```kotlin
+public suspend fun reauthenticate(accessToken: String): SupabaseResult<Unit>
+```
+
+Requests a reauthentication nonce for the user identified by `accessToken`
+(`GET /reauthenticate`). Sends a one-time code the user must supply when performing a
+sensitive change such as a password update without the current password.
+
+- `accessToken` — the current session's access token.
+
+Returns `SupabaseResult<Unit>`.
+
+---
+
+## Session tokens & user
+
+### `refreshToken`
+
+```kotlin
+public suspend fun refreshToken(refreshToken: String): SupabaseResult<Session>
+```
+
+Exchanges a `refreshToken` for a fresh `Session` via the `refresh_token` grant. The
+returned session carries new access and refresh tokens.
+
+- `refreshToken` — the current refresh token.
+
+Returns `SupabaseResult<Session>`.
+
+### `getUser`
+
+```kotlin
+public suspend fun getUser(accessToken: String): SupabaseResult<User>
+```
+
+Fetches the user the `accessToken` belongs to (`GET /user`). Because this hits the
+Auth server, it also validates the token; for purely local claim checks without a
+round-trip see [`getClaims`](#getclaims).
+
+- `accessToken` — the access token to inspect.
+
+Returns `SupabaseResult<User>`.
+
+### `getUserIdentities`
+
+```kotlin
+public suspend fun getUserIdentities(accessToken: String): SupabaseResult<List<UserIdentity>>
+```
+
+Returns the linked third-party identities of the `accessToken`'s user — the
+`identities` of `getUser`.
+
+Returns `SupabaseResult<List<UserIdentity>>`.
+
+### `updateUser`
+
+```kotlin
+public suspend fun updateUser(
+    accessToken: String,
+    updates: UserUpdateRequest,
+): SupabaseResult<User>
+```
+
+Updates the authenticated user (`PUT /user`) with the non-null fields of `updates` —
+email, phone, password, or `user_metadata`. Changing email/phone may require
+confirmation; a password change may require `currentPassword`/`nonce` (see
+`reauthenticate`).
+
+- `accessToken` — the current session's access token.
+- `updates` — the fields to change, as a `UserUpdateRequest`.
+
+Returns `SupabaseResult<User>`.
+
+### `signOut`
+
+```kotlin
+public suspend fun signOut(accessToken: String): SupabaseResult<Unit>
+public suspend fun signOut(accessToken: String, scope: SignOutScope): SupabaseResult<Unit>
+```
+
+Signs out via `POST /logout`. The single-arg overload uses `SignOutScope.LOCAL`. The
+two-arg overload revokes refresh tokens for the chosen `scope`: just this session
+(`LOCAL`), every session (`GLOBAL`), or all *other* sessions (`OTHERS`).
+
+- `accessToken` — the session's access token.
+- `scope` — which sessions to revoke (two-arg overload).
+
+Returns `SupabaseResult<Unit>`.
+
+---
+
+## OAuth URLs, PKCE & state
+
+### `getOAuthSignInUrl`
+
+```kotlin
+public fun getOAuthSignInUrl(
+    provider: OAuthProvider,
+    redirectTo: String? = null,
+    scopes: List<String> = emptyList(),
+    queryParams: Map<String, String> = emptyMap(),
+    skipBrowserRedirect: Boolean = false,
+    pkceParams: PkceParams? = null,
+    inviteToken: String? = null,
+): String
+```
+
+Builds the absolute provider authorize URL (`GET /authorize?provider=…`) **locally,
+without a network call** — the synchronous core behind `signInWithOAuth`. Open the
+returned URL in a browser/custom tab to start the flow. Parameters match
+`signInWithOAuth`; returns the URL `String` directly (not a `SupabaseResult`).
+
+### `generatePkceParams`
+
+```kotlin
+public fun generatePkceParams(sha256: ((ByteArray) -> ByteArray)? = null): PkceParams
+```
+
+Generates a PKCE `PkceParams` (verifier + challenge) for an OAuth flow, drawing the
+verifier from a cryptographically secure RNG per RFC 7636. Persist the `codeVerifier`
+and pass it to `exchangeCodeForSession` on callback.
+
+- `sha256` — a SHA-256 implementation to derive an `S256` challenge; when `null`, falls back to a `plain` challenge (verifier used verbatim). Default `null`.
+
+Returns `PkceParams`.
+
+### `generateOAuthState`
+
+```kotlin
+public fun generateOAuthState(): String
+```
+
+Generates a cryptographically-random opaque `state` value for CSRF protection on the
+OAuth implicit/redirect flow. Pass it via `queryParams = mapOf("state" to ...)`,
+persist it, and on callback compare it with `verifyOAuthState`. The PKCE flow already
+binds the request via `code_verifier`, so `state` is additive there; it matters most
+for the implicit flow.
+
+Returns the `state` `String`.
+
+### `exchangeCodeForSession`
+
+```kotlin
+public suspend fun exchangeCodeForSession(
+    authCode: String,
+    codeVerifier: String,
+): SupabaseResult<Session>
+```
+
+Completes the PKCE flow by exchanging the authorization `authCode` for a `Session`
+via the `pkce` grant (`POST /token?grant_type=pkce`).
+
+- `authCode` — the authorization code from the redirect.
+- `codeVerifier` — the `codeVerifier` from the `generatePkceParams` used to start the flow.
+
+Returns `SupabaseResult<Session>`.
+
+---
+
+## Identity linking
+
+### `linkIdentity`
+
+```kotlin
+public suspend fun linkIdentity(
+    accessToken: String,
+    provider: OAuthProvider,
+    redirectTo: String? = null,
+    scopes: List<String> = emptyList(),
+    queryParams: Map<String, String> = emptyMap(),
+    pkceParams: PkceParams? = null,
+): SupabaseResult<LinkIdentityResponse>
+```
+
+Starts linking an additional OAuth identity to the signed-in user, returning a
+`LinkIdentityResponse` whose `url` your app opens to complete provider consent
+(`GET /user/identities/authorize`). The new identity attaches to the existing account
+rather than creating a new user.
+
+- `accessToken` — the current session's access token.
+- `provider` — the provider to link.
+- `redirectTo` — where the provider returns the user. Default `null`.
+- `scopes` — provider scopes. Default `emptyList()`.
+- `queryParams` — extra authorize-URL params. Default `emptyMap()`.
+- `pkceParams` — PKCE challenge to bind the link. Default `null`.
+
+Returns `SupabaseResult<LinkIdentityResponse>`.
+
+### `linkIdentityWithIdToken`
+
+```kotlin
+public suspend fun linkIdentityWithIdToken(
+    accessToken: String,
+    provider: OAuthProvider,
+    idToken: String,
+    providerAccessToken: String? = null,
+    nonce: String? = null,
+): SupabaseResult<Session>
+```
+
+Links an OAuth identity using a provider ID token (the native-SDK counterpart to
+`linkIdentity`) via the `id_token` grant with `link_identity` set, returning the
+updated `Session`. No browser redirect is involved.
+
+- `accessToken` — the current session's access token.
+- `provider` — the provider to link.
+- `idToken` — the provider's ID token.
+- `providerAccessToken` — the provider's access token, when it issues one. Default `null`.
+- `nonce` — the nonce bound into the ID token. Default `null`.
+
+Returns `SupabaseResult<Session>`.
+
+### `unlinkIdentity`
+
+```kotlin
+public suspend fun unlinkIdentity(
+    accessToken: String,
+    identityId: String,
+): SupabaseResult<Unit>
+```
+
+Removes a linked identity from the signed-in user
+(`DELETE /user/identities/{id}`).
+
+- `accessToken` — the current session's access token.
+- `identityId` — the identity's primary key — pass `UserIdentity.id`, **not** `UserIdentity.identityId`.
+
+Returns `SupabaseResult<Unit>`.
+
+---
+
+## SSO
+
+### `getSsoUrl`
+
+```kotlin
+public suspend fun getSsoUrl(
+    accessToken: String? = null,
+    domain: String? = null,
+    providerId: String? = null,
+    redirectTo: String? = null,
+    pkceParams: PkceParams? = null,
+    captchaToken: String? = null,
+): SupabaseResult<SsoResponse>
+```
+
+Resolves the SSO sign-in URL for an enterprise provider (`POST /sso`), identified by
+exactly one of `domain` or `providerId`; the returned `SsoResponse.url` is opened to
+start the IdP flow. Fails if neither or both identifiers are supplied.
+
+- `accessToken` — optional bearer token (some SSO setups require an authenticated caller). Default `null`.
+- `domain` — the org domain (one of domain/providerId). Default `null`.
+- `providerId` — the SSO provider id (one of domain/providerId). Default `null`.
+- `redirectTo` — where the IdP returns the user. Default `null`.
+- `pkceParams` — PKCE challenge for a PKCE-flow SSO. Default `null`.
+- `captchaToken` — captcha response. Default `null`.
+
+Returns `SupabaseResult<SsoResponse>`.
+
+---
+
+## Server health & settings
+
+### `getSettings`
+
+```kotlin
+public suspend fun getSettings(): SupabaseResult<AuthSettings>
+```
+
+Fetches the Auth server's public settings (`GET /auth/v1/settings`) — which providers
+and flows are enabled. Requires only the project `apikey`. Returns
+`SupabaseResult<AuthSettings>`.
+
+### `getHealth`
+
+```kotlin
+public suspend fun getHealth(): SupabaseResult<AuthHealthStatus>
+```
+
+Fetches the Auth server's health status (`GET /auth/v1/health`), reporting its name
+and version. Requires only the project `apikey`. Returns
+`SupabaseResult<AuthHealthStatus>`.
+
+### `getJwks`
+
+```kotlin
+public suspend fun getJwks(): SupabaseResult<String>
+```
+
+Fetches the raw JSON Web Key Set (JWKS) from `/auth/v1/.well-known/jwks.json`. Used by
+`getClaims` to verify asymmetric token signatures locally without an Auth server
+round-trip. Returns `SupabaseResult<String>` (the raw JSON).
+
+### `resolveSigningKey`
+
+```kotlin
+public suspend fun resolveSigningKey(kid: String): SupabaseResult<Jwk?>
+```
+
+Resolves the signing key for `kid` from the project JWKS, backed by an in-memory cache
+so repeated local verifications don't re-fetch on every call. A cache miss forces
+exactly one refetch (to pick up a rotated key) before giving up. Concurrent callers
+share a single in-flight refetch.
+
+- `kid` — the key id from the JWT header.
+
+Returns `SupabaseResult<Jwk?>` — the key, `null` if absent even after a forced
+refetch, or `Failure` only when the JWKS fetch itself failed.
+
+---
+
+## MFA
+
+### `mfaEnroll`
+
+```kotlin
+public suspend fun mfaEnroll(
+    accessToken: String,
+    factorType: MfaFactorType,
+    friendlyName: String? = null,
+    issuer: String? = null,
+    phone: String? = null,
+): SupabaseResult<MfaEnrollResponse>
+```
+
+Enrols a new MFA factor (`POST /factors`). For a TOTP factor the response carries the
+QR code / secret to display; the factor starts unverified and must be confirmed via
+`mfaChallenge` + `mfaVerify`.
+
+- `accessToken` — the current session's access token (first parameter).
+- `factorType` — the factor kind (`TOTP`, `PHONE`, `WEBAUTHN`).
+- `friendlyName` — human-readable label. Default `null`.
+- `issuer` — issuer shown in authenticator apps (TOTP). Default `null`.
+- `phone` — destination number for a phone factor. Default `null`.
+
+Returns `SupabaseResult<MfaEnrollResponse>`.
+
+### `mfaChallenge`
+
+```kotlin
+public suspend fun mfaChallenge(
+    accessToken: String,
+    factorId: String,
+    channel: MessagingChannel? = null,
+): SupabaseResult<MfaChallengeResponse>
+```
+
+Creates a challenge for an enrolled factor (`POST /factors/{id}/challenge`), returning
+a `MfaChallengeResponse` whose `id` is passed to `mfaVerify`. For a phone factor this
+dispatches the code.
+
+- `accessToken` — the current session's access token.
+- `factorId` — the enrolled factor's id.
+- `channel` — phone delivery channel (`SMS`/`WHATSAPP`); ignored for TOTP. Default `null`.
+
+Returns `SupabaseResult<MfaChallengeResponse>`.
+
+### `mfaVerify`
+
+```kotlin
+public suspend fun mfaVerify(
+    accessToken: String,
+    factorId: String,
+    challengeId: String,
+    code: String,
+    webauthn: MfaWebauthnVerification? = null,
+): SupabaseResult<MfaVerifyResponse>
+```
+
+Verifies a challenge by submitting the user's `code` (`POST /factors/{id}/verify`). On
+success the `MfaVerifyResponse` carries a new AAL2 session that upgrades the caller's
+assurance level.
+
+- `accessToken` — the current session's access token.
+- `factorId` — the factor being verified.
+- `challengeId` — the `id` returned by `mfaChallenge`.
+- `code` — the user-entered code.
+- `webauthn` — for a WebAuthn factor, the device's credential response (stands in for `code`). Default `null`.
+
+Returns `SupabaseResult<MfaVerifyResponse>`.
+
+### `mfaUnenroll`
+
+```kotlin
+public suspend fun mfaUnenroll(
+    accessToken: String,
+    factorId: String,
+): SupabaseResult<MfaUnenrollResponse>
+```
+
+Removes an enrolled factor by `factorId` (`DELETE /factors/{id}`). Returns
+`SupabaseResult<MfaUnenrollResponse>`.
+
+### `mfaListFactors`
+
+```kotlin
+public suspend fun mfaListFactors(accessToken: String): SupabaseResult<MfaListFactorsResponse>
+```
+
+Lists the user's enrolled MFA factors, grouped by type. Derived from the `factors` of
+`getUser`, so it reflects both verified and unverified factors. Returns
+`SupabaseResult<MfaListFactorsResponse>`.
+
+### `mfaGetAuthenticatorAssuranceLevel`
+
+```kotlin
+public suspend fun mfaGetAuthenticatorAssuranceLevel(accessToken: String): SupabaseResult<AuthenticatorAssuranceLevel>
+```
+
+Returns the *current* authenticator assurance level of the session, read from the
+`aal` claim of `accessToken`. Returns `SupabaseResult<AuthenticatorAssuranceLevel>`.
+
+### `mfaGetAuthenticatorAssuranceLevels`
+
+```kotlin
+public suspend fun mfaGetAuthenticatorAssuranceLevels(accessToken: String): SupabaseResult<AuthenticatorAssuranceLevels>
+```
+
+Returns both the *current* level (from the `aal` claim) and the *next* level the
+session could reach (derived from the user's enrolled factors). Returns
+`SupabaseResult<AuthenticatorAssuranceLevels>`.
+
+---
+
+## Passkeys
+
+### `passkeyStartRegistration`
+
+```kotlin
+public suspend fun passkeyStartRegistration(accessToken: String): SupabaseResult<PasskeyRegistrationOptionsResponse>
+```
+
+Requests WebAuthn registration options for the signed-in user — step one of adding a
+passkey. The response carries the `challengeId` and the WebAuthn `options` to hand to
+the device authenticator; the produced credential is sent back via
+`passkeyVerifyRegistration`. Returns `SupabaseResult<PasskeyRegistrationOptionsResponse>`.
+
+### `passkeyVerifyRegistration`
+
+```kotlin
+public suspend fun passkeyVerifyRegistration(
+    accessToken: String,
+    challengeId: String,
+    credential: JsonObject,
+): SupabaseResult<PasskeyMetadata>
+```
+
+Verifies a freshly created passkey `credential` against the `challengeId` from
+`passkeyStartRegistration`, persisting the passkey.
+
+- `accessToken` — the current session's access token.
+- `challengeId` — from `passkeyStartRegistration`.
+- `credential` — the device's WebAuthn credential as a `JsonObject`.
+
+Returns `SupabaseResult<PasskeyMetadata>`.
+
+### `passkeyStartAuthentication`
+
+```kotlin
+public suspend fun passkeyStartAuthentication(captchaToken: String? = null): SupabaseResult<PasskeyAuthenticationOptionsResponse>
+```
+
+Requests WebAuthn authentication options — step one of passwordless passkey sign-in
+(no access token needed). The result is verified via `passkeyVerifyAuthentication`.
+
+- `captchaToken` — captcha response. Default `null`.
+
+Returns `SupabaseResult<PasskeyAuthenticationOptionsResponse>`.
+
+### `passkeyVerifyAuthentication`
+
+```kotlin
+public suspend fun passkeyVerifyAuthentication(
+    challengeId: String,
+    credential: JsonObject,
+): SupabaseResult<Session>
+```
+
+Verifies a passkey assertion `credential` against the `challengeId` from
+`passkeyStartAuthentication`, returning the authenticated `Session`. Returns
+`SupabaseResult<Session>`.
+
+### `passkeyList`
+
+```kotlin
+public suspend fun passkeyList(accessToken: String): SupabaseResult<List<Passkey>>
+```
+
+Lists the signed-in user's registered passkeys. Returns
+`SupabaseResult<List<Passkey>>`.
+
+### `passkeyUpdate`
+
+```kotlin
+public suspend fun passkeyUpdate(
+    accessToken: String,
+    passkeyId: String,
+    friendlyName: String,
+): SupabaseResult<Passkey>
+```
+
+Renames a registered passkey by `passkeyId`, returning the updated `Passkey`. Returns
+`SupabaseResult<Passkey>`.
+
+### `passkeyDelete`
+
+```kotlin
+public suspend fun passkeyDelete(
+    accessToken: String,
+    passkeyId: String,
+): SupabaseResult<Unit>
+```
+
+Deletes a registered passkey by `passkeyId`. Returns `SupabaseResult<Unit>`.
+
+---
+
+## Acting as an OAuth provider (consent)
+
+These methods are used when *this* project acts as an OAuth provider and must render a
+consent screen for a third-party client.
+
+### `oauthGetAuthorizationDetails`
+
+```kotlin
+public suspend fun oauthGetAuthorizationDetails(
+    accessToken: String,
+    authorizationId: String,
+): SupabaseResult<OAuthAuthorizationDetails>
+```
+
+Fetches the details of a pending OAuth authorization request by `authorizationId` —
+the requesting client, user and scopes. Returns
+`SupabaseResult<OAuthAuthorizationDetails>`.
+
+### `oauthApproveAuthorization` / `oauthDenyAuthorization`
+
+```kotlin
+public suspend fun oauthApproveAuthorization(accessToken: String, authorizationId: String): SupabaseResult<OAuthRedirect>
+public suspend fun oauthDenyAuthorization(accessToken: String, authorizationId: String): SupabaseResult<OAuthRedirect>
+```
+
+Approve (grant consent) or deny a pending OAuth authorization, returning the
+`OAuthRedirect` URL to send the third-party client back to.
+
+### `oauthListGrants`
+
+```kotlin
+public suspend fun oauthListGrants(accessToken: String): SupabaseResult<List<OAuthGrant>>
+```
+
+Lists the OAuth grants (consents) the user has previously given to third-party
+clients. Returns `SupabaseResult<List<OAuthGrant>>`.
+
+### `oauthRevokeGrant`
+
+```kotlin
+public suspend fun oauthRevokeGrant(accessToken: String, clientId: String): SupabaseResult<Unit>
+```
+
+Revokes a previously granted OAuth consent for the client identified by `clientId`.
+Returns `SupabaseResult<Unit>`.
+
+---
+
+## JWT & claims helpers
+
+These are top-level / extension functions on `AuthClient` (package
+`io.github.androidpoet.supabase.auth`).
+
+### `getClaims`
+
+```kotlin
+public suspend fun AuthClient.getClaims(
+    jwt: String,
+    verify: Boolean = true,
+    allowExpired: Boolean = false,
+    expectedIssuer: String? = null,
+    expectedAudience: String? = null,
+): SupabaseResult<JwtClaimsResult>
+```
+
+Decodes and (by default) verifies the claims of a Supabase JWT. The header and payload
+are decoded locally into `JwtClaims`. When `verify` is true: an asymmetric `ES256`
+(ECDSA P-256) token is verified **locally** against the project's JWKS (no network
+round-trip); any other case (symmetric `HS256`, missing `kid`, unreachable JWKS, or a
+platform without local crypto) falls back to validating against the Auth server (the
+same check `getUser` performs — always safe). `exp`/`nbf` are always checked with
+clock-skew leeway; `iss`/`aud` only when an expected value is given.
+
+- `jwt` — the JWT to inspect, e.g. a session access token.
+- `verify` — verify the signature before returning. Default `true`.
+- `allowExpired` — when `false`, a token whose `exp` is past is rejected without a network call. Default `false`.
+- `expectedIssuer` — when non-null, the token's `iss` must equal this. Default `null`.
+- `expectedAudience` — when non-null, the token's `aud` must contain this. Default `null`.
+
+Returns `SupabaseResult<JwtClaimsResult>`.
+
+```kotlin
+val claims = auth.getClaims(session.accessToken)
+```
+
+### `parseJwtClaims`
+
+```kotlin
+public fun parseJwtClaims(jwt: String): SupabaseResult<JsonObject>
+```
+
+Decodes the payload of a `jwt` into its raw claims `JsonObject` **without verifying the
+signature** — a cheap local read for claims you don't need to trust. When the
+signature matters, use `getClaims`. Returns `SupabaseResult<JsonObject>`.
+
+### `verifyOAuthState`
+
+```kotlin
+public fun verifyOAuthState(expected: String, returned: String?): SupabaseResult<Unit>
+```
+
+Verifies an OAuth `state` (CSRF) parameter on callback. Succeeds only when `expected`
+(the value you persisted from `generateOAuthState`) matches `returned` (the `state`
+query param the provider sent back). A blank/absent `returned` is always a failure;
+the comparison is constant-time. Returns `SupabaseResult<Unit>`.
+
+---
+
+## Implicit-flow redirect helpers
+
+Top-level functions and `AuthClient`/`SessionManager` extensions for adopting tokens
+that arrive in a redirect URL fragment.
+
+### `ParsedSessionTokens`
+
+```kotlin
+public data class ParsedSessionTokens(
+    public val accessToken: String,
+    public val refreshToken: String,
+    public val expiresIn: Long,
+    public val tokenType: String,
+)
+```
+
+Session tokens parsed out of an implicit-flow redirect URL fragment.
+
+### `parseSessionTokensFromFragment` / `parseSessionTokensFromUrl`
+
+```kotlin
+public fun parseSessionTokensFromFragment(fragment: String): SupabaseResult<ParsedSessionTokens>
+public fun parseSessionTokensFromUrl(url: String): SupabaseResult<ParsedSessionTokens>
+```
+
+Parses `ParsedSessionTokens` from an OAuth implicit-flow URL fragment (the
+`#access_token=…&refresh_token=…&expires_in=…&token_type=…` part). A leading `#` is
+tolerated and components are percent-decoded. `parseSessionTokensFromUrl` extracts the
+fragment from a full `url` first. Returns `Failure` if any required field is missing.
+
+### `importSessionFromFragment` / `importSessionFromUrl`
+
+```kotlin
+public suspend fun AuthClient.importSessionFromFragment(fragment: String, sessionManager: SessionManager): SupabaseResult<Session>
+public suspend fun AuthClient.importSessionFromUrl(url: String, sessionManager: SessionManager): SupabaseResult<Session>
+```
+
+Parse tokens from an implicit-flow redirect, fetch the matching `User`, build a
+`Session` and save it to `sessionManager` — the implicit-flow counterpart to
+`exchangeCodeForSessionAndSave`. Returns `SupabaseResult<Session>`.
+
+### `exchangeCodeForSessionAndSave`
+
+```kotlin
+public suspend fun AuthClient.exchangeCodeForSessionAndSave(
+    authCode: String,
+    codeVerifier: String,
+    sessionManager: SessionManager,
+): SupabaseResult<Session>
+```
+
+Exchanges a PKCE auth code for a session and saves it on success. Returns
+`SupabaseResult<Session>`.
+
+---
+
+## AuthClient convenience extensions
+
+Shorthands over the core methods, in package `io.github.androidpoet.supabase.auth`.
+All return the same `SupabaseResult<T>` contract as the method they wrap.
+
+| Extension | Wraps |
+| --- | --- |
+| `signUp(email, password, data?)` | `signUpWithEmail` |
+| `signIn(email, password)` | `signInWithEmail` |
+| `signUpPhone(phone, password, data?)` | `signUpWithPhone` |
+| `signInPhone(phone, password)` | `signInWithPhone` |
+| `sendOtp(email)` | `signInWithOtp` (email) |
+| `sendPhoneOtp(phone, channel?)` | `signInWithOtp` (phone) |
+| `resendSignUpEmailOtp(email, captchaToken?, redirectTo?)` | `resendEmailOtp` with `OtpType.EMAIL` |
+| `resendPhoneSignInOtp(phone, captchaToken?)` | `resendPhoneOtp` with `OtpType.SMS` |
+| `verifyEmailOtp(email, token, type, captchaToken?)` | `verifyOtp` (email) |
+| `verifyPhoneOtp(phone, token, type, captchaToken?)` | `verifyOtp` (phone) |
+| `verifyEmailSignUpOtp(email, token, captchaToken?)` | `verifyEmailOtp` with `OtpType.EMAIL` |
+| `verifyPhoneSignInOtp(phone, token, captchaToken?)` | `verifyPhoneOtp` with `OtpType.SMS` |
+| `verifyEmailOtpWithTokenHash(tokenHash, type, captchaToken?)` | `verifyOtpWithTokenHash` |
+| `forgotPassword(email, redirectTo?, captchaToken?)` | `resetPasswordForEmail` |
+| `signOutGlobal/signOutLocal/signOutOthers(accessToken)` | `signOut` with the matching scope |
+| `mfaChallengeAndVerify(factorId, code, accessToken)` | `mfaChallenge` then `mfaVerify` in one call |
+
+### Session-aware extensions (require a `SessionManager`)
+
+These read/refresh/persist the current session. Each fails with a `SupabaseError`
+(`"No active session"`) when there is no active session, unless noted.
+
+- `getUserForCurrentSession(sessionManager, updateStoredSession = false): SupabaseResult<User>` — fetch the current user; when `updateStoredSession`, write the refreshed `User` back into stored session.
+- `reauthenticateCurrentSession(sessionManager): SupabaseResult<Unit>`
+- `updateUserForCurrentSession(sessionManager, updates, updateStoredSession = true): SupabaseResult<User>`
+- `refreshCurrentSession(sessionManager): SupabaseResult<Session>` — delegates to `SessionManager.refreshSession`.
+- `signOutCurrentSession(sessionManager, scope = SignOutScope.LOCAL, clearStoredSessionOnSuccess = true, succeedIfNoSession = true): SupabaseResult<Unit>` — signs out and clears storage; an absent session is an idempotent success when `succeedIfNoSession`.
+- `getSsoUrlForCurrentSession(sessionManager, domain?, providerId?, redirectTo?): SupabaseResult<SsoResponse>`
+- `getUserIdentitiesForCurrentSession(sessionManager): SupabaseResult<List<UserIdentity>>`
+- `linkIdentityForCurrentSession(sessionManager, provider, redirectTo?, scopes, queryParams): SupabaseResult<LinkIdentityResponse>`
+- `linkIdentityWithIdTokenForCurrentSession(sessionManager, provider, idToken, providerAccessToken?, nonce?, updateStoredSession = true): SupabaseResult<Session>`
+- `unlinkIdentityForCurrentSession(sessionManager, identityId, updateStoredSession = true): SupabaseResult<Unit>`
+- `unlinkIdentityAndUpdateSession(accessToken, identityId, sessionManager, updateStoredSession = true): SupabaseResult<Unit>` — unlinks and removes the identity from the stored session's user.
+- `importAuthToken(sessionManager, accessToken, refreshToken = "", expiresIn = 0L, tokenType = "bearer", retrieveUser = true): SupabaseResult<Session>` — adopts an externally minted token as a saved `Session`.
+- `getClaimsForCurrentSession(authClient, verify = true, allowExpired = false, expectedIssuer?, expectedAudience?): SupabaseResult<JwtClaimsResult>` — extension on `SessionManager`.
+- `parseCurrentSessionJwtClaims(): SupabaseResult<JsonObject>` — extension on `SessionManager`; parses the current access token's raw claims without verifying.
+
+### `…AndSaveSession` extensions
+
+Run the wrapped call and, on success, save the resulting session via
+`SessionManager.saveSession`. All return `SupabaseResult<Session>` (or
+`SupabaseResult<OtpVerifyResult>` for the OTP ones):
+
+`signInWithEmailAndSaveSession`, `signInWithPhoneAndSaveSession`,
+`signUpWithEmailAndSaveSession`, `signUpWithPhoneAndSaveSession`,
+`signInAnonymouslyAndSaveSession`, `signInWithIdTokenAndSaveSession`,
+`refreshTokenAndSaveSession`, `verifyOtpAndSaveSession`,
+`verifyOtpWithTokenHashAndSaveSession`. The two OTP variants save only when the result
+is `OtpVerifyResult.Authenticated`; a no-session verification is returned untouched.
+
+---
+
+## SupabaseClient sign-in helpers
+
+Package `io.github.androidpoet.supabase.auth`. These run the same call as the core
+`AuthClient` and, on success, apply the returned access token to the client so every
+following request is authenticated. Use these for "sign in and stay signed in for the
+process lifetime" without a full `SessionManager`.
+
+### `applySession`
+
+```kotlin
+public fun SupabaseClient.applySession(session: Session): Session
+```
+
+Stores `session`'s access token on this client so subsequent requests are
+authenticated. A blank token is ignored (e.g. a sign-up awaiting email confirmation).
+Returns `session` for chaining.
+
+### Sign-in / sign-up / sign-out
+
+```kotlin
+public suspend fun SupabaseClient.signInWithEmail(email: String, password: String): SupabaseResult<Session>
+public suspend fun SupabaseClient.signInWithPhone(phone: String, password: String): SupabaseResult<Session>
+public suspend fun SupabaseClient.signInAnonymously(data: JsonObject? = null, captchaToken: String? = null): SupabaseResult<Session>
+public suspend fun SupabaseClient.signInWithIdToken(provider: OAuthProvider, idToken: String, accessToken: String? = null, nonce: String? = null, captchaToken: String? = null): SupabaseResult<Session>
+public suspend fun SupabaseClient.signUpWithEmail(email: String, password: String, data: JsonObject? = null): SupabaseResult<Session>
+public suspend fun SupabaseClient.signOut(scope: SignOutScope = SignOutScope.GLOBAL): SupabaseResult<Unit>
+```
+
+Each sign-in/up authenticates the client on success (`signUpWithEmail` only when a
+session is returned, i.e. email confirmation isn't required). `signOut` clears the
+access token; if the client isn't authenticated it clears and returns success without
+a network call, and leaves the token in place if the server call fails so the sign-out
+can be retried.
+
+---
+
+## Native sign-in
+
+Package `io.github.androidpoet.supabase.auth.native`. The provider-agnostic hand-off
+for platform-native flows (Google, Apple, …).
+
+### `NativeAuthProvider`
+
+```kotlin
+public interface NativeAuthProvider {
+    public val provider: OAuthProvider
+    public suspend fun signIn(): SupabaseResult<NativeAuthCredential>
+}
+```
+
+The SDK's one extension point for native sign-in. Implement it for any provider,
+platform, or SDK. `signIn()` launches the native UI and returns the credential, or a
+failure if the user cancelled, the flow errored, or native sign-in isn't available.
+
+### `NativeAuthCredential`
+
+```kotlin
+public data class NativeAuthCredential(
+    public val provider: OAuthProvider,
+    public val idToken: String,
+    public val accessToken: String? = null,
+    public val nonce: String? = null,
+    public val fullName: String? = null,
+    public val email: String? = null,
+)
+```
+
+A credential obtained from a native sign-in flow, ready to exchange for a Supabase
+session.
+
+- `provider` — the Supabase provider the token came from.
+- `idToken` — the OIDC ID token (a JWT).
+- `accessToken` — optional provider access token. Default `null`.
+- `nonce` — the raw (un-hashed) nonce, if one was used. Default `null`.
+- `fullName` — the user's full name, if surfaced. Sign in with Apple returns it only on the **first** authorization. Default `null`.
+- `email` — the user's email, if surfaced out-of-band. Like `fullName`, Apple returns it only once. Default `null`.
+
+`toString()` masks the token/name/email fields so the credential is log-safe.
+
+### `signInWith` / `signInWithAndSaveSession`
+
+```kotlin
+public suspend fun AuthClient.signInWith(
+    provider: NativeAuthProvider,
+    captchaToken: String? = null,
+    onCredential: ((NativeAuthCredential) -> Unit)? = null,
+): SupabaseResult<Session>
+
+public suspend fun AuthClient.signInWithAndSaveSession(
+    sessionManager: SessionManager,
+    provider: NativeAuthProvider,
+    captchaToken: String? = null,
+    onCredential: ((NativeAuthCredential) -> Unit)? = null,
+): SupabaseResult<Session>
+```
+
+Runs the native flow via `NativeAuthProvider.signIn()` and, on success, redeems the
+credential through `signInWithIdToken`. `signInWithAndSaveSession` also persists the
+session to `sessionManager`.
+
+- `provider` — the native sign-in implementation to run.
+- `captchaToken` — captcha token forwarded to the token exchange. Default `null`.
+- `onCredential` — hook invoked with the raw credential on a successful native flow, **before** redemption — the only way to reach Apple's first-sign-in name/email. Default `null`.
+
+Returns `SupabaseResult<Session>`.
+
+### `generateNonce`
+
+```kotlin
+public fun generateNonce(byteCount: Int = 32): String
+```
+
+Generates a fresh, high-entropy, URL-safe nonce for a native sign-in flow, drawn from
+a cryptographically secure RNG. Pass the returned value to the provider config's
+`nonce`.
+
+- `byteCount` — number of characters to draw (6 bits each). Default `32` (192 bits); must be at least 16. Throws `IllegalArgumentException` if below 16.
+
+Returns the nonce `String`.
+
+---
+
+## Session management
+
+Package `io.github.androidpoet.supabase.auth.session`.
+
+### `createSessionManager`
+
+```kotlin
+public fun createSessionManager(
+    authClient: AuthClient,
+    supabaseClient: SupabaseClient,
+    config: SessionConfig = SessionConfig(),
+): SessionManager
+```
+
+Builds a `SessionManager` that persists, restores, and (optionally) auto-refreshes the
+session, applying the access token to `supabaseClient` as it changes.
+
+- `authClient` — the auth client used for refresh.
+- `supabaseClient` — the client whose access token is kept in sync.
+- `config` — storage and refresh configuration. Default `SessionConfig()`.
+
+### `SessionManager`
+
+```kotlin
+public interface SessionManager {
+    public val sessionState: StateFlow<SessionState>
+    public val currentSession: Session?
+    public val accessToken: String?
+
+    public suspend fun saveSession(session: Session)
+    public suspend fun clearSession()
+    public suspend fun refreshSession(): SupabaseResult<Session>
+    public suspend fun restoreSession(): SupabaseResult<Session>
+    public suspend fun initialize(): SupabaseResult<Session>
+    public fun startAutoRefresh()
+    public fun stopAutoRefresh()
+    public fun dispose()
+    public fun close()
+}
+```
+
+- `sessionState` — a `StateFlow` of the current `SessionState`; observe it to drive UI.
+- `currentSession` — the active `Session`, or `null`.
+- `accessToken` — the active access token, or `null`.
+- `saveSession(session)` — persists a session, applies its token, and schedules refresh.
+- `clearSession()` — clears stored session (sign-out).
+- `refreshSession()` — refreshes and persists; returns `SupabaseResult<Session>`.
+- `restoreSession()` — loads a persisted session from storage.
+- `initialize()` — restores and starts auto-refresh; call at startup.
+- `startAutoRefresh()` / `stopAutoRefresh()` — control background token refresh.
+- `dispose()` / `close()` — release the manager's coroutine resources.
+
+```kotlin
+val sessions = createSessionManager(auth, client, SessionConfig(storage = myStorage))
+sessions.initialize()
+sessions.sessionState.collect { state -> /* update UI */ }
+```
+
+### `SessionState`
+
+```kotlin
+public sealed interface SessionState {
+    public data object NotAuthenticated : SessionState
+    public data object Loading : SessionState
+    public data class Authenticated(public val session: Session) : SessionState
+    public data class Expired(public val lastSession: Session) : SessionState
+}
+```
+
+The current authentication state. `Authenticated` carries the live `session`;
+`Expired` carries the `lastSession` whose access token has lapsed (refresh may
+recover it).
+
+### `SessionConfig`
+
+```kotlin
+public data class SessionConfig(
+    public val autoRefresh: Boolean = true,
+    public val refreshBufferSeconds: Long = 60,
+    public val storage: SessionStorage = InMemorySessionStorage(),
+)
+```
+
+- `autoRefresh` — refresh the access token in the background before it expires. Default `true`.
+- `refreshBufferSeconds` — how many seconds before expiry to refresh. Default `60`.
+- `storage` — where the session is persisted. Default `InMemorySessionStorage()`.
+
+<Callout type="warning">
+The default `InMemorySessionStorage` **does not survive a process restart** — the user
+is silently signed out when the app is killed. For production, provide a durable
+`SessionStorage` (e.g. a `KeyValueSessionStorage` over your platform's secure store).
+</Callout>
+
+### `SessionStorage`
+
+```kotlin
+public interface SessionStorage {
+    public suspend fun save(session: Session)
+    public suspend fun load(): Session?
+    public suspend fun clear()
+}
+```
+
+Where a session is persisted. Implement it (or use the provided implementations) and
+pass it via `SessionConfig.storage`.
+
+### `KeyValueStore` & `KeyValueSessionStorage`
+
+```kotlin
+public interface KeyValueStore {
+    public suspend fun get(key: String): String?
+    public suspend fun set(key: String, value: String)
+    public suspend fun remove(key: String)
+}
+
+public class KeyValueSessionStorage(
+    store: KeyValueStore,
+    key: String = KeyValueSessionStorage.DEFAULT_KEY,
+) : SessionStorage
+```
+
+`KeyValueStore` is the minimal persistent backend you implement over the platform's
+secure/persistent store (Keychain, `EncryptedSharedPreferences`/DataStore,
+`localStorage`, a file, …) — three string operations, serialization handled for you.
+`KeyValueSessionStorage` serializes the `Session` to JSON and defers to your
+`KeyValueStore`. It treats a corrupt or structurally-unusable payload (empty tokens,
+negative expiry) as "no session" rather than crashing. `DEFAULT_KEY` is
+`"io.github.androidpoet.supabase.session"`.
+
+```kotlin
+val storage = KeyValueSessionStorage(myKeychainStore)
+val sessions = createSessionManager(auth, client, SessionConfig(storage = storage))
+```
+
+### `InMemorySessionStorage`
+
+```kotlin
+public class InMemorySessionStorage : SessionStorage
+```
+
+A `SessionStorage` that keeps the session only in memory; **lost when the process is
+killed**. The `SessionConfig` default — fine for tests and short-lived processes, not
+production.
+
+### `onAuthStateChange` & `AuthStateChangeEvent`
+
+```kotlin
+public enum class AuthStateChangeEvent {
+    INITIAL_SESSION, SIGNED_IN, SIGNED_OUT, TOKEN_REFRESHED,
+    USER_UPDATED, PASSWORD_RECOVERY, MFA_CHALLENGE_VERIFIED,
+}
+
+public fun SessionManager.onAuthStateChange(
+    scope: CoroutineScope,
+    emitInitialSession: Boolean = true,
+    callback: suspend (event: AuthStateChangeEvent, session: Session?) -> Unit,
+): Job
+```
+
+Subscribes to `sessionState` and translates transitions into auth events, invoking
+`callback` for each. Returns the collecting `Job`.
+
+- `scope` — the coroutine scope the collection runs in.
+- `emitInitialSession` — emit `INITIAL_SESSION` with the current session immediately. Default `true`.
+- `callback` — invoked with the `event` and the session (or `null`).
+
+```kotlin
+sessions.onAuthStateChange(scope) { event, session ->
+    if (event == AuthStateChangeEvent.SIGNED_OUT) navigateToLogin()
+}
+```
+
+---
+
+## Models & data types
+
+Package `io.github.androidpoet.supabase.auth.models` unless noted. All are
+`@Serializable` `data class`es (or enums) except where stated.
+
+### `Session`
+
+```kotlin
+public data class Session(
+    val accessToken: String,
+    val refreshToken: String,
+    val expiresIn: Long,
+    val expiresAt: Long? = null,
+    val tokenType: String = "bearer",
+    val user: User,
+    val providerToken: String? = null,
+    val providerRefreshToken: String? = null,
+)
+```
+
+An authenticated session. `expiresAt` is the absolute Unix timestamp (seconds) at
+which `accessToken` expires (prefer it over `now + expiresIn` when present); `null` for
+older servers. `providerToken`/`providerRefreshToken` are present only for provider
+flows that return them. `toString()` masks all token fields.
+
+### `User`
+
+```kotlin
+public data class User(
+    val id: String,
+    val email: String? = null,
+    val phone: String? = null,
+    val createdAt: String? = null,
+    val updatedAt: String? = null,
+    val appMetadata: JsonObject? = null,
+    val userMetadata: JsonObject? = null,
+    val identities: List<UserIdentity>? = null,
+    val factors: List<MfaFactor>? = null,
+    val isAnonymous: Boolean? = null,
+    val role: String? = null,
+    val emailConfirmedAt: String? = null,
+    val phoneConfirmedAt: String? = null,
+    val confirmedAt: String? = null,
+    val lastSignInAt: String? = null,
+)
+```
+
+A Supabase auth user: stable `id` plus profile, metadata, linked `identities` and MFA
+`factors`. `isAnonymous` is `true` for anonymous sign-ins with no confirmed email or
+phone.
+
+### `UserIdentity`
+
+```kotlin
+public data class UserIdentity(
+    val id: String,
+    val identityId: String? = null,
+    val provider: String? = null,
+    val userId: String? = null,
+    val identityData: JsonObject? = null,
+)
+```
+
+One third-party identity linked to a `User`. Pass `id` (not `identityId`) to
+`unlinkIdentity`.
+
+### `UserUpdateRequest`
+
+```kotlin
+public data class UserUpdateRequest(
+    val email: String? = null,
+    val phone: String? = null,
+    val password: String? = null,
+    val currentPassword: String? = null,
+    val data: JsonObject? = null,
+    val nonce: String? = null,
+    val channel: String? = null,
+)
+```
+
+Fields to change on the authenticated user; only non-null fields are applied. `data`
+sets `user_metadata`; a password change may require `currentPassword` or a reauth
+`nonce`. `toString()` masks the password fields.
+
+### `OtpVerifyResult`
+
+```kotlin
+public sealed interface OtpVerifyResult {
+    public data class Authenticated(public val session: Session) : OtpVerifyResult
+    public data object VerifiedNoSession : OtpVerifyResult
+}
+```
+
+The outcome of an OTP verification: either a new `Session` was minted
+(`Authenticated.session`) or the code verified without one (`VerifiedNoSession`, e.g.
+an email change).
+
+### `PkceParams`
+
+```kotlin
+public data class PkceParams(
+    val codeVerifier: String,
+    val codeChallenge: String,
+    val codeChallengeMethod: String = "S256",
+)
+```
+
+PKCE parameters. Persist `codeVerifier` when starting the flow and replay it to
+`exchangeCodeForSession`; `codeChallenge`/`codeChallengeMethod` go into the authorize
+URL.
+
+### `OAuthResponse` / `LinkIdentityResponse` / `SsoResponse`
+
+```kotlin
+public data class OAuthResponse(val url: String, val provider: String)
+public data class LinkIdentityResponse(val url: String, val provider: String? = null)
+public data class SsoResponse(val url: String)
+```
+
+Each carries the `url` to open to continue a flow (OAuth authorize, identity-link
+consent, SSO IdP respectively).
+
+### MFA models
+
+```kotlin
+public data class MfaEnrollResponse(
+    val id: String,
+    val type: MfaFactorType = MfaFactorType.UNKNOWN,
+    val totp: MfaTotpDetails? = null,
+    val friendlyName: String? = null,
+    val phone: String? = null,
+)
+
+public data class MfaTotpDetails(val qrCode: String, val secret: String, val uri: String) // toString() masks secret + uri
+
+public data class MfaChallengeResponse(val id: String, val type: String? = null, val expiresAt: Long? = null)
+
+public data class MfaVerifyResponse(
+    val accessToken: String,
+    val refreshToken: String,
+    val tokenType: String = "bearer",
+    val expiresIn: Long,
+    val expiresAt: Long? = null,
+    val user: User,
+) // new AAL2 session; toString() masks the tokens
+
+public data class MfaUnenrollResponse(val id: String)
+
+public data class MfaListFactorsResponse(
+    val all: List<MfaFactor> = emptyList(),
+    val totp: List<MfaFactor> = emptyList(),
+    val phone: List<MfaFactor> = emptyList(),
+    val webauthn: List<MfaFactor> = emptyList(),
+)
+
+public data class MfaFactor(
+    val id: String,
+    val friendlyName: String? = null,
+    val factorType: MfaFactorType = MfaFactorType.UNKNOWN,
+    val status: MfaFactorStatus = MfaFactorStatus.UNKNOWN,
+    val createdAt: String? = null,
+    val updatedAt: String? = null,
+)
+
+public data class MfaWebauthnVerification(val type: String? = null, val credentialResponse: JsonObject? = null)
+
+public data class AuthenticatorAssuranceLevels(
+    val current: AuthenticatorAssuranceLevel,
+    val next: AuthenticatorAssuranceLevel,
+) // not @Serializable
+```
+
+`MfaEnrollResponse.totp` carries the QR/secret to present for a TOTP factor.
+`AuthenticatorAssuranceLevels.current` is read from the `aal` claim; `next` is `AAL2`
+when at least one verified factor exists, else `AAL1`.
+
+### Passkey models
+
+```kotlin
+public data class PasskeyRegistrationOptionsResponse(val challengeId: String, val options: JsonObject, val expiresAt: Long)
+public data class PasskeyAuthenticationOptionsResponse(val challengeId: String, val options: JsonObject, val expiresAt: Long)
+public data class PasskeyMetadata(val id: String, val friendlyName: String? = null, val createdAt: String)
+public data class Passkey(val id: String, val friendlyName: String? = null, val createdAt: String, val lastUsedAt: String? = null)
+```
+
+The `…OptionsResponse` types carry the `challengeId` and WebAuthn `options` for the
+device authenticator. `PasskeyMetadata` is returned by verify-registration; `Passkey`
+is returned when listing.
+
+### OAuth-provider (consent) models
+
+```kotlin
+public data class OAuthAuthorizationClient(val id: String, val name: String, val uri: String, val logoUri: String)
+public data class OAuthAuthorizationUser(val id: String, val email: String)
+public data class OAuthAuthorizationDetails(
+    val authorizationId: String? = null,
+    val redirectUrl: String? = null,
+    val redirectUri: String? = null,
+    val client: OAuthAuthorizationClient? = null,
+    val user: OAuthAuthorizationUser? = null,
+    val scope: String? = null,
+)
+public data class OAuthRedirect(val redirectUrl: String)
+public data class OAuthGrant(val client: OAuthAuthorizationClient, val scopes: List<String>, val grantedAt: String)
+```
+
+Used to render and act on a consent screen when the project acts as an OAuth provider.
+
+### JWT / JWKS models
+
+```kotlin
+public data class JwtHeader(val algorithm: String? = null, val type: String? = null, val keyId: String? = null)
+
+public data class JwtClaims(
+    val subject: String? = null,
+    val email: String? = null,
+    val phone: String? = null,
+    val role: String? = null,
+    val issuer: String? = null,
+    val expiresAt: Long? = null,
+    val notBefore: Long? = null,
+    val issuedAt: Long? = null,
+    val sessionId: String? = null,
+    val authenticatorAssuranceLevel: String? = null,
+    val isAnonymous: Boolean? = null,
+    val appMetadata: JsonObject? = null,
+    val userMetadata: JsonObject? = null,
+)
+
+public data class JwtClaimsResult(
+    val claims: JwtClaims,
+    val header: JwtHeader,
+    val signature: String,
+    val raw: JsonObject,
+) // not @Serializable
+
+public data class Jwk(
+    val keyType: String,
+    val algorithm: String? = null,
+    val keyId: String? = null,
+    val curve: String? = null,
+    val use: String? = null,
+    val x: String? = null,
+    val y: String? = null,
+    val modulus: String? = null,
+    val exponent: String? = null,
+)
+
+public data class JwkSet(val keys: List<Jwk> = emptyList())
+```
+
+`JwtClaims` is the strongly-typed view of standard Supabase claims; use
+`JwtClaimsResult.raw` for any non-standard claim. `Jwk` models only the fields needed
+to reconstruct a public key for signature verification.
+
+### `AuthSettings` / `AuthHealthStatus`
+
+```kotlin
+public data class AuthSettings(
+    val external: Map<String, Boolean>? = null,
+    val disableSignup: Boolean? = null,
+    val mailerAutoconfirm: Boolean? = null,
+    val phoneAutoconfirm: Boolean? = null,
+    val smsProvider: String? = null,
+    val mfaEnabled: Boolean? = null,
+    val samlEnabled: Boolean? = null,
+)
+
+public data class AuthHealthStatus(val name: String? = null, val version: String? = null, val description: String? = null)
+```
+
+`AuthSettings.external` is a per-provider enablement map (slug → enabled). Every field
+is nullable so a server that omits or adds a key still decodes.
+
+---
+
+## Enums
+
+### `OAuthProvider`
+
+The 17 supported third-party OAuth providers. Each has a `value` slug GoTrue expects on
+the wire:
+
+| Entry | Wire `value` |
+| --- | --- |
+| `GOOGLE` | `google` |
+| `APPLE` | `apple` |
+| `GITHUB` | `github` |
+| `GITLAB` | `gitlab` |
+| `BITBUCKET` | `bitbucket` |
+| `DISCORD` | `discord` |
+| `FACEBOOK` | `facebook` |
+| `TWITTER` | `twitter` |
+| `SLACK` | `slack` |
+| `SPOTIFY` | `spotify` |
+| `TWITCH` | `twitch` |
+| `AZURE` | `azure` |
+| `KEYCLOAK` | `keycloak` |
+| `LINKEDIN` | `linkedin_oidc` |
+| `NOTION` | `notion` |
+| `ZOOM` | `zoom` |
+| `FIGMA` | `figma` |
+
+### `OtpType`
+
+The flow an OTP / email-link belongs to: `SMS`, `EMAIL`, `RECOVERY`, `INVITE`,
+`EMAIL_CHANGE`, `PHONE_CHANGE`, `SIGNUP`, `MAGIC_LINK`.
+
+### `MessagingChannel`
+
+Delivery channel for a phone OTP / MFA challenge: `SMS` (server default) or
+`WHATSAPP`. Ignored for email OTP and TOTP factors.
+
+### `SignOutScope`
+
+How widely a sign-out revokes sessions: `GLOBAL` (all), `LOCAL` (just this one),
+`OTHERS` (all others).
+
+### `MfaFactorType`
+
+`TOTP`, `PHONE`, `WEBAUTHN`, `UNKNOWN` (a type this version doesn't recognise).
+
+### `MfaFactorStatus`
+
+`VERIFIED`, `UNVERIFIED`, `UNKNOWN`.
+
+### `AuthenticatorAssuranceLevel`
+
+`AAL1` (single factor) or `AAL2` (MFA satisfied).
+
+### `Web3Chain`
+
+Blockchain network for a Web3 wallet sign-in: `ETHEREUM` or `SOLANA`.

--- a/website/pages/reference/client.mdx
+++ b/website/pages/reference/client.mdx
@@ -1,0 +1,715 @@
+---
+title: Client — API Reference
+description: Full public API of the supabase-client module — the Supabase.create factory, its configuration DSL, the SupabaseClient transport interface, auth-state plumbing, and typed request helpers.
+---
+
+import { Callout } from 'nextra/components'
+
+# Client — API Reference
+
+`supabase-client` is the HTTP/transport foundation every feature client (Auth,
+PostgREST, Storage, Functions, Realtime, …) is built on: it owns the Ktor
+engine, base-URL resolution, authentication, retries, logging, and request
+observation in one seam. You build a client with the `Supabase.create` factory
+and tune it through a small configuration DSL. Maven artifact:
+`io.github.androidpoet:supabase-client`.
+
+All symbols live under `io.github.androidpoet.supabase.client` (auth-state types
+under `io.github.androidpoet.supabase.client.auth`).
+
+<Callout type="warning">
+In client apps (mobile, desktop, web) use the project's **anon** key. Never ship
+the **service-role** key in a distributed application — it bypasses Row Level
+Security and grants full access to your data.
+</Callout>
+
+## `Supabase.create`
+
+The single entry point. Validates its arguments, normalizes the project URL, and
+returns a ready-to-use [`SupabaseClient`](#supabaseclient).
+
+```kotlin
+fun create(
+    projectUrl: String,
+    apiKey: String,
+    engineFactory: HttpClientEngineFactory<*> = platformEngine(),
+    configure: SupabaseConfigBuilder.() -> Unit = {},
+): SupabaseClient
+```
+
+- `projectUrl` — your project's base URL. Must be non-blank and start with
+  `http://` or `https://`, or an `IllegalArgumentException` is thrown. A single
+  trailing slash is stripped so endpoint paths that begin with `/` don't produce
+  a doubled `//`.
+- `apiKey` — the project API key (use the **anon** key in client apps). Must be
+  non-blank. Sent on every request and used as the fallback bearer credential.
+- `engineFactory` — the Ktor HTTP engine factory. Defaults to the platform's
+  built-in engine via `platformEngine()`; override it to supply your own engine
+  (for example a custom-configured or mock engine in tests).
+- `configure` — the [config DSL](#supabaseconfigbuilder--config-dsl) block.
+  Optional; an empty block yields a working client.
+
+Returns a `SupabaseClient`. Because the client owns an HTTP engine it is
+`AutoCloseable` — call [`close()`](#lifecycle) when done.
+
+```kotlin
+val client = Supabase.create(
+    projectUrl = "https://your-project.supabase.co",
+    apiKey = "your-anon-key",
+) {
+    logging = true
+    logLevel = HttpLogLevel.HEADERS
+    headers["X-App-Version"] = "1.4.0"
+}
+```
+
+## `SupabaseConfigBuilder` — config DSL
+
+The receiver of the `configure` block. Every property has a default, so set only
+what you need. Reach for `httpClientConfig` only for raw transport tweaks the
+typed fields don't cover.
+
+| Option | Type | Default | Effect |
+| --- | --- | --- | --- |
+| `logging` | `Boolean` | `false` | Enable HTTP wire logging at `logLevel`. |
+| `logLevel` | `HttpLogLevel` | `NONE` | Verbosity of the wire log when `logging` is on. |
+| `headers` | `MutableMap<String, String>` | empty | Extra headers attached to every request, merged under any per-call headers. |
+| `retry` | `RetryConfig` | `RetryConfig.Default` | Backoff policy for transient (opt-in) retries. |
+| `logger` | `SupabaseLogger?` | `null` | Sink that routes wire logs into your logging framework. |
+| `interceptor` | `SupabaseInterceptor?` | `null` | Observation hooks fired around every request. |
+| `connectTimeoutMillis` | `Long?` | `null` | Max time to establish a connection; `null` is unbounded. |
+| `socketTimeoutMillis` | `Long?` | `null` | Max inactivity between data packets; `null` is unbounded. |
+| `requestTimeoutMillis` | `Long?` | `null` | Whole-request timeout including body; `null` is unbounded. |
+| `httpClientConfig` | `(HttpClientConfig<*>.() -> Unit)?` | `null` | Raw Ktor escape hatch applied after the library's own installs. |
+| `accessTokenProvider` | `(suspend () -> String?)?` | `null` | Per-request Bearer-token provider for third-party auth. |
+
+### `logging` / `logLevel`
+
+```kotlin
+var logging: Boolean = false
+var logLevel: HttpLogLevel = HttpLogLevel.NONE
+```
+
+`logging` turns HTTP wire logging on; `logLevel` controls how much it prints. The
+verbosity values are an SDK-owned enum (see [`HttpLogLevel`](#httploglevel)) so
+the transport's logging library isn't part of the public surface.
+
+```kotlin
+Supabase.create(url, key) {
+    logging = true
+    logLevel = HttpLogLevel.BODY
+}
+```
+
+### `headers`
+
+```kotlin
+val headers: MutableMap<String, String> = mutableMapOf()
+```
+
+Headers added to every request. Per-call headers passed to a request method are
+merged *over* these, so a request can override a default.
+
+```kotlin
+Supabase.create(url, key) {
+    headers["X-App-Version"] = "1.4.0"
+    headers["Accept-Language"] = "en"
+}
+```
+
+### `retry`
+
+```kotlin
+var retry: RetryConfig = RetryConfig.Default
+```
+
+The backoff policy applied when a call opts into retrying. See
+[`RetryConfig`](#retryconfig).
+
+```kotlin
+Supabase.create(url, key) {
+    retry = RetryConfig(maxRetries = 5)
+}
+```
+
+### `logger`
+
+```kotlin
+var logger: SupabaseLogger? = null
+```
+
+Routes wire logs into your own framework instead of the default
+`println`-style logger. Verbosity is still governed by `logLevel`; this only
+changes where the lines go. See [`SupabaseLogger`](#supabaselogger).
+
+### `interceptor`
+
+```kotlin
+var interceptor: SupabaseInterceptor? = null
+```
+
+Observation hooks fired before and after every request — for telemetry, tracing,
+and metrics. See [`SupabaseInterceptor`](#supabaseinterceptor).
+
+### Timeouts
+
+```kotlin
+var connectTimeoutMillis: Long? = null
+var socketTimeoutMillis: Long? = null
+var requestTimeoutMillis: Long? = null
+```
+
+- `connectTimeoutMillis` — maximum time to establish a connection. `null`
+  (default) leaves it unbounded. Safe to set without affecting streaming
+  responses.
+- `socketTimeoutMillis` — maximum inactivity between data packets. `null`
+  leaves it unbounded. Avoid combining with long-idle streams (SSE).
+- `requestTimeoutMillis` — maximum total time for a whole request *including the
+  response body*. `null` leaves it unbounded. Do **not** set this when streaming
+  (`streamLines` / SSE) or transferring large uploads/downloads — it caps the
+  entire transfer, not just connection setup.
+
+```kotlin
+Supabase.create(url, key) {
+    connectTimeoutMillis = 10_000
+    socketTimeoutMillis = 10_000
+}
+```
+
+### `httpClientConfig`
+
+```kotlin
+var httpClientConfig: (HttpClientConfig<*>.() -> Unit)? = null
+```
+
+A raw Ktor escape hatch applied to the underlying `HttpClientConfig` **after**
+the library's own installs (content negotiation, optional timeouts/logging, the
+default `apikey` / `X-Client-Info` headers). Use it to install arbitrary Ktor
+plugins or tweak engine behaviour the library doesn't expose — e.g. `HttpCache`,
+a proxy, custom TLS/cookies. This is the unfiltered Ktor builder, not a
+filtered plugin DSL, so anything you do here can override or conflict with the
+library's own configuration. Prefer the typed fields where they exist.
+
+```kotlin
+Supabase.create(url, key) {
+    httpClientConfig = {
+        // install or tweak any Ktor plugin here
+    }
+}
+```
+
+### `accessTokenProvider`
+
+```kotlin
+var accessTokenProvider: (suspend () -> String?)? = null
+```
+
+Supplies the `Authorization: Bearer` token per request, resolved fresh on every
+call. Intended for third-party-auth setups (e.g. Firebase/Auth0) where a JWT
+comes from an external identity provider rather than the library's session
+manager.
+
+When set and it returns a non-null value, that token wins over both the session
+token (`setAccessToken`) and the API key. Returning `null` falls back to the
+normal rules (session token, then the API key). A caller-supplied
+`Authorization` header on an individual request still takes precedence and is
+never overwritten.
+
+```kotlin
+Supabase.create(url, key) {
+    accessTokenProvider = { firebaseUser.getIdToken() }
+}
+```
+
+## `SupabaseConfig`
+
+The resolved, immutable configuration produced by the builder. It mirrors
+`SupabaseConfigBuilder` field-for-field and is constructed for you by
+`Supabase.create`; you rarely build it directly.
+
+```kotlin
+class SupabaseConfig(
+    val logging: Boolean,
+    val logLevel: HttpLogLevel,
+    val headers: Map<String, String>,
+    val retry: RetryConfig = RetryConfig.Default,
+    val logger: SupabaseLogger? = null,
+    val interceptor: SupabaseInterceptor? = null,
+    val connectTimeoutMillis: Long? = null,
+    val socketTimeoutMillis: Long? = null,
+    val requestTimeoutMillis: Long? = null,
+    val httpClientConfig: (HttpClientConfig<*>.() -> Unit)? = null,
+    val accessTokenProvider: (suspend () -> String?)? = null,
+)
+```
+
+It is intentionally not a `data class`: it carries function-typed fields whose
+reference-based equality would make a generated `copy`/`equals` meaningless, and
+a stable public config should not expose `copy`/`componentN`. See
+[`SupabaseConfigBuilder`](#supabaseconfigbuilder--config-dsl) for the meaning and
+defaults of each field.
+
+## `SupabaseClient`
+
+The transport interface returned by `Supabase.create`. Every feature module talks
+to Supabase through this one seam. Implementations resolve relative `endpoint`
+paths against `projectUrl`, attach the `apiKey` and the current bearer token, and
+are safe to share across coroutines.
+
+Every call returns a `SupabaseResult` — transport and non-2xx errors come back as
+`SupabaseResult.Failure` rather than being thrown. The one exception is
+[`streamLines`](#streaming), which surfaces errors as a terminal exception in its
+`Flow`.
+
+### Properties
+
+```kotlin
+val projectUrl: String
+val apiKey: String
+val accessTokenOrNull: String?
+```
+
+- `projectUrl` — base URL of the project; relative `endpoint` paths resolve
+  against it.
+- `apiKey` — the project's `apikey`, sent on every request and used as the
+  fallback bearer credential.
+- `accessTokenOrNull` — the bearer token currently applied to requests, or
+  `null` when no session/override token is set.
+
+### JSON request verbs
+
+The typed verbs cover the common JSON-over-REST case and return the response body
+as a `String`.
+
+```kotlin
+suspend fun get(
+    endpoint: String,
+    queryParams: List<Pair<String, String>> = emptyList(),
+    headers: Map<String, String> = emptyMap(),
+): SupabaseResult<String>
+
+suspend fun post(
+    endpoint: String,
+    body: String? = null,
+    headers: Map<String, String> = emptyMap(),
+): SupabaseResult<String>
+
+suspend fun put(endpoint: String, body: String? = null, headers: Map<String, String> = emptyMap()): SupabaseResult<String>
+suspend fun patch(endpoint: String, body: String? = null, headers: Map<String, String> = emptyMap()): SupabaseResult<String>
+suspend fun delete(endpoint: String, body: String? = null, headers: Map<String, String> = emptyMap()): SupabaseResult<String>
+```
+
+- `endpoint` — a path resolved against `projectUrl`.
+- `queryParams` (`get` only) — URL-encoded and appended to the query string.
+- `body` — the request body, typically JSON. Optional on `post`/`put`/`patch`/`delete`.
+- `headers` — per-call headers, merged *over* the client's defaults.
+
+`patch` is the verb for partial updates; otherwise these behave identically. A
+non-2xx status comes back as `SupabaseResult.Failure`.
+
+```kotlin
+val result = client.get(
+    endpoint = "/rest/v1/todos",
+    queryParams = listOf("select" to "*", "limit" to "10"),
+)
+```
+
+### Binary request verbs
+
+The raw-bytes counterparts to `post`/`put`, used for uploads where the payload
+isn't JSON (e.g. Storage object writes).
+
+```kotlin
+suspend fun postRaw(
+    url: String,
+    body: ByteArray,
+    contentType: String,
+    headers: Map<String, String> = emptyMap(),
+): SupabaseResult<String>
+
+suspend fun putRaw(
+    url: String,
+    body: ByteArray,
+    contentType: String,
+    headers: Map<String, String> = emptyMap(),
+): SupabaseResult<String>
+```
+
+- `url` — an endpoint path (prefixed with the project URL) **or** an
+  already-absolute `http(s)://…` URL, which is used verbatim and never
+  re-prefixed.
+- `body` — the raw bytes to send.
+- `contentType` — the MIME type of the body.
+- `headers` — per-call headers, merged over the client's defaults.
+
+```kotlin
+client.postRaw(
+    url = "/storage/v1/object/avatars/me.png",
+    body = pngBytes,
+    contentType = "image/png",
+)
+```
+
+### `rawRequest`
+
+Performs an arbitrary HTTP request and returns the status, headers, and raw body
+bytes — for needs the typed helpers can't express, notably `HEAD` and reading
+response headers (as required by resumable/TUS uploads).
+
+```kotlin
+suspend fun rawRequest(
+    method: SupabaseHttpMethod,
+    url: String,
+    body: ByteArray? = null,
+    contentType: String? = null,
+    headers: Map<String, String> = emptyMap(),
+): SupabaseResult<SupabaseHttpResponse>
+```
+
+- `method` — the [`SupabaseHttpMethod`](#supabasehttpmethod).
+- `url` — an absolute URL or an endpoint path (prefixed with the project URL).
+- `body` — optional raw request body.
+- `contentType` — optional MIME type for the body.
+- `headers` — per-call headers, merged over the client's defaults.
+
+Returns a [`SupabaseHttpResponse`](#supabasehttpresponse).
+
+```kotlin
+val res = client.rawRequest(SupabaseHttpMethod.HEAD, "/storage/v1/object/info/...")
+val offset = res.getOrNull()?.header("Upload-Offset")
+```
+
+### Streaming
+
+```kotlin
+fun streamLines(
+    endpoint: String,
+    body: String? = null,
+    contentType: String? = null,
+    headers: Map<String, String> = emptyMap(),
+): Flow<String>
+```
+
+Streams the body of a POST to `endpoint` as a cold `Flow` of decoded UTF-8 lines,
+read incrementally rather than buffered — for Server-Sent Events and other
+long-lived responses. The request is issued on collection; a non-2xx status
+surfaces as a *terminal exception in the flow* (not a `SupabaseResult`).
+`endpoint` may be a path or an absolute URL.
+
+This method has a default that throws `UnsupportedOperationException`, so existing
+non-streaming implementations (notably test fakes) keep compiling; the real
+client overrides it.
+
+```kotlin
+client.streamLines("/functions/v1/chat", body = requestJson)
+    .collect { line -> println(line) }
+```
+
+### Auth-token plumbing
+
+```kotlin
+fun setAccessToken(token: String)
+fun clearAccessToken()
+```
+
+- `setAccessToken` — sets the bearer token applied to subsequent requests
+  (typically the current session's access token), overriding the API-key fallback
+  until `clearAccessToken` is called.
+- `clearAccessToken` — clears any token set via `setAccessToken`, reverting to the
+  API-key credential.
+
+If the client was built with an `accessTokenProvider`, that provider always wins
+and these calls are ignored — drive auth through the provider instead, returning
+`null` from it to fall back to the API key.
+
+### Lifecycle
+
+```kotlin
+override fun close()
+```
+
+`SupabaseClient` is `AutoCloseable`; `close()` releases the underlying HTTP
+engine. After closing, the client must not be used again.
+
+## Typed request helpers
+
+Extension functions that issue a request and deserialize the JSON response body
+into `T` using [`defaultJson`](#defaultjson). Each mirrors a `SupabaseClient`
+verb and returns `SupabaseResult<T>`; a decode failure becomes a
+`SupabaseResult.Failure`.
+
+```kotlin
+suspend inline fun <reified T> SupabaseClient.getTyped(
+    endpoint: String,
+    queryParams: List<Pair<String, String>> = emptyList(),
+    headers: Map<String, String> = emptyMap(),
+): SupabaseResult<T>
+
+suspend inline fun <reified T> SupabaseClient.postTyped(endpoint: String, body: String? = null, headers: Map<String, String> = emptyMap()): SupabaseResult<T>
+suspend inline fun <reified T> SupabaseClient.putTyped(endpoint: String, body: String? = null, headers: Map<String, String> = emptyMap()): SupabaseResult<T>
+suspend inline fun <reified T> SupabaseClient.patchTyped(endpoint: String, body: String? = null, headers: Map<String, String> = emptyMap()): SupabaseResult<T>
+suspend inline fun <reified T> SupabaseClient.deleteTyped(endpoint: String, body: String? = null, headers: Map<String, String> = emptyMap()): SupabaseResult<T>
+```
+
+Parameters match the corresponding verb. `T` must be a
+`kotlinx.serialization`-serializable type.
+
+```kotlin
+@Serializable data class Todo(val id: Int, val title: String)
+
+val todos: SupabaseResult<List<Todo>> =
+    client.getTyped("/rest/v1/todos", queryParams = listOf("select" to "*"))
+```
+
+### `deserialize`
+
+The building block the `*Typed` helpers use — decode a `SupabaseResult<String>`
+into `SupabaseResult<T>`.
+
+```kotlin
+inline fun <reified T> SupabaseResult<String>.deserialize(): SupabaseResult<T>
+```
+
+On `Success`, decodes the string body into `T` (a thrown decode error becomes a
+`Failure`); a `Failure` is passed through unchanged.
+
+```kotlin
+val parsed: SupabaseResult<Todo> = client.get("/rest/v1/todos?id=eq.1").deserialize()
+```
+
+### `defaultJson`
+
+```kotlin
+val defaultJson: Json
+```
+
+The `kotlinx.serialization` `Json` instance used by the typed helpers, configured
+with `ignoreUnknownKeys = true`, `isLenient = true`, `explicitNulls = false`, and
+`coerceInputValues = true`. The coercion settings let an unknown enum value (or a
+null for a non-null field that has a default) fall back to that property's default
+rather than failing the whole decode.
+
+## `RetryConfig`
+
+The tunable backoff policy for transient request failures. Retries are opt-in per
+call (e.g. a PostgREST `select` with `retry = true`, which is safe for idempotent
+reads); this config controls *how* a retried call backs off and which statuses
+count as transient. A `Retry-After` response header always takes precedence over
+the computed backoff.
+
+```kotlin
+data class RetryConfig(
+    val maxRetries: Int = DEFAULT_MAX_RETRIES,            // 3
+    val baseDelayMillis: Long = DEFAULT_BASE_DELAY_MILLIS, // 1_000
+    val maxDelayMillis: Long = DEFAULT_MAX_DELAY_MILLIS,   // 30_000
+    val retryableStatuses: Set<Int> = DEFAULT_RETRYABLE_STATUSES, // {429,500,502,503,504,520}
+    val jitter: Boolean = true,
+)
+```
+
+- `maxRetries` — maximum retry attempts after the initial try; `0` disables
+  retries. Must be `>= 0`. Default `3`.
+- `baseDelayMillis` — base backoff for the first retry; doubles each subsequent
+  attempt. Must be `>= 0`. Default `1_000`.
+- `maxDelayMillis` — upper bound on a single backoff delay. Must be `>=
+  baseDelayMillis`. Default `30_000`.
+- `retryableStatuses` — HTTP status codes treated as transient and therefore
+  retryable. Default `{429, 500, 502, 503, 504, 520}`.
+- `jitter` — when `true` (default), randomise each backoff within its exponential
+  ceiling so clients that failed together don't all retry on the same beat.
+
+The constructor validates its bounds and throws `IllegalArgumentException` on
+violation.
+
+### `backoffMillis`
+
+```kotlin
+fun backoffMillis(attempt: Int): Long
+```
+
+The backoff delay (ms) before the given zero-based retry `attempt`. The ceiling is
+exponential — `min(maxDelayMillis, baseDelayMillis shl attempt)`. With `jitter`
+off it returns the ceiling; with `jitter` on it returns a uniform draw from
+`floor..ceiling`, where the floor is half the ceiling capped at `baseDelayMillis`.
+
+### `RetryConfig.Companion`
+
+| Member | Type | Value |
+| --- | --- | --- |
+| `DEFAULT_MAX_RETRIES` | `Int` | `3` |
+| `DEFAULT_BASE_DELAY_MILLIS` | `Long` | `1_000` |
+| `DEFAULT_MAX_DELAY_MILLIS` | `Long` | `30_000` |
+| `DEFAULT_RETRYABLE_STATUSES` | `Set<Int>` | `{429, 500, 502, 503, 504, 520}` |
+| `Default` | `RetryConfig` | the all-defaults policy (3 retries, 1s base, 30s cap) |
+
+```kotlin
+Supabase.create(url, key) {
+    retry = RetryConfig(maxRetries = 5, baseDelayMillis = 500)
+}
+```
+
+## `HttpLogLevel`
+
+SDK-owned enum controlling how verbose the HTTP wire log is when `logging` is on.
+
+```kotlin
+enum class HttpLogLevel { NONE, INFO, HEADERS, BODY, ALL }
+```
+
+- `NONE` — logs nothing.
+- `INFO` — the request line and status.
+- `HEADERS` — adds request/response headers.
+- `BODY` — adds bodies.
+- `ALL` — everything (the most verbose).
+
+## `SupabaseLogLevel`
+
+Severity for [`SupabaseLogger`](#supabaselogger) messages.
+
+```kotlin
+enum class SupabaseLogLevel { DEBUG, INFO, WARN, ERROR }
+```
+
+## `SupabaseLogger`
+
+A pluggable sink for the SDK's diagnostic output. Provide one via
+`SupabaseConfigBuilder.logger` to route HTTP wire logs into your app's logging
+framework instead of the default `println`-style logger. Verbosity is still
+governed by `logLevel`; this only changes where the lines go.
+
+```kotlin
+interface SupabaseLogger {
+    fun log(level: SupabaseLogLevel, message: String, throwable: Throwable? = null)
+}
+```
+
+- `level` — the message severity.
+- `message` — the log text.
+- `throwable` — an optional associated error; defaults to `null`.
+
+```kotlin
+class PrintlnLogger : SupabaseLogger {
+    override fun log(level: SupabaseLogLevel, message: String, throwable: Throwable?) {
+        println("[$level] $message")
+        throwable?.printStackTrace()
+    }
+}
+```
+
+## `SupabaseInterceptor`
+
+Observation hooks fired around every HTTP request — for telemetry, tracing, and
+metrics. All methods are `suspend` and default to no-ops, so implement only what
+you need. Hooks are observational: they must not throw and cannot alter the
+request or its result. Exactly one terminal hook fires per call: `onResponse`
+when an HTTP response is received (any status), or `onError` when no response was
+obtained (offline, DNS/TLS failure, timeout).
+
+```kotlin
+interface SupabaseInterceptor {
+    suspend fun onRequest(method: String, url: String) {}
+    suspend fun onResponse(method: String, url: String, statusCode: Int, durationMillis: Long) {}
+    suspend fun onError(method: String, url: String, error: SupabaseError, durationMillis: Long) {}
+}
+```
+
+- `onRequest` — fired before a request is sent.
+- `onResponse` — fired when an HTTP response is received, regardless of status;
+  `statusCode` is the HTTP status, `durationMillis` the elapsed time.
+- `onError` — fired when the request failed without a response; `error` is the
+  transport [`SupabaseError`](/results-and-errors), `durationMillis` the elapsed
+  time.
+
+```kotlin
+class TimingInterceptor : SupabaseInterceptor {
+    override suspend fun onResponse(method: String, url: String, statusCode: Int, durationMillis: Long) {
+        metrics.record(method, statusCode, durationMillis)
+    }
+}
+```
+
+## `SupabaseHttpMethod`
+
+The HTTP method enum used by [`rawRequest`](#rawrequest).
+
+```kotlin
+enum class SupabaseHttpMethod { GET, POST, PUT, PATCH, DELETE, HEAD }
+```
+
+## `SupabaseHttpResponse`
+
+A low-level HTTP response exposing the status code, response headers, and raw body
+bytes — returned by [`rawRequest`](#rawrequest) and used by features that need to
+read response headers (e.g. the resumable-upload `Location` / `Upload-Offset`).
+
+```kotlin
+class SupabaseHttpResponse(
+    val status: Int,
+    val headers: Map<String, String>,
+    val body: ByteArray,
+) {
+    fun header(name: String): String?
+}
+```
+
+- `status` — the HTTP status code.
+- `headers` — the response headers.
+- `body` — the raw response body bytes.
+- `header(name)` — case-insensitive header lookup; returns `null` if absent.
+
+```kotlin
+val res = client.rawRequest(SupabaseHttpMethod.HEAD, url).getOrNull()
+val length = res?.header("Content-Length")
+```
+
+## Auth state
+
+Helper types in `io.github.androidpoet.supabase.client.auth` that model the
+credential applied to a request. Feature modules use these to derive the
+`apikey` and `Authorization` headers.
+
+### `AuthState`
+
+A sealed interface with three cases.
+
+```kotlin
+sealed interface AuthState {
+    data object None : AuthState
+    data class ApiKey(val key: String) : AuthState
+    data class Bearer(val token: String) : AuthState
+}
+```
+
+- `None` — no credential.
+- `ApiKey(key)` — authenticate with the project API key; it also becomes the
+  bearer credential.
+- `Bearer(token)` — authenticate with an explicit bearer token (e.g. a session
+  access token).
+
+### `apiKeyHeader` / `authorizationHeader`
+
+```kotlin
+fun AuthState.apiKeyHeader(): String?
+fun AuthState.authorizationHeader(): String?
+```
+
+- `apiKeyHeader()` — the value for the `apikey` header: the key for `ApiKey`,
+  `null` for `None` and `Bearer`.
+- `authorizationHeader()` — the value for the `Authorization` header: `Bearer
+  <key>` for `ApiKey`, `Bearer <token>` for `Bearer`, `null` for `None`.
+
+```kotlin
+val state: AuthState = AuthState.Bearer(sessionToken)
+val auth = state.authorizationHeader() // "Bearer <token>"
+```
+
+## `SupabaseDsl`
+
+The `@DslMarker` annotation scoping the [`SupabaseConfigBuilder`](#supabaseconfigbuilder--config-dsl)
+receiver so nested DSLs can't accidentally leak into it. You don't apply it
+yourself; it shapes how the `configure` block resolves implicit receivers.
+
+```kotlin
+@DslMarker
+annotation class SupabaseDsl
+```

--- a/website/pages/reference/codegen.mdx
+++ b/website/pages/reference/codegen.mdx
@@ -1,0 +1,242 @@
+---
+title: Codegen — API & Plugin Reference
+description: Reference for supabase-codegen (the JVM CLI/library) and supabase-codegen-gradle (the Gradle plugin) — every CLI flag, programmatic entry point, Gradle extension property, generated task, output layout, and the --format sqldelight output.
+---
+
+import { Callout } from 'nextra/components'
+
+# Codegen — API & Plugin Reference
+
+The codegen reads a Supabase project's PostgREST OpenAPI document and writes typed
+Kotlin `@Serializable` models — one file per table and per enum — plus the matching
+`@SerialName` column tokens so the generated code decodes real PostgREST responses.
+The output uses only multiplatform-common types, so it drops straight into a
+`commonMain` source set.
+
+It ships in two Maven Central artifacts (group `io.github.androidpoet`):
+
+| Artifact | What it is |
+| --- | --- |
+| `io.github.androidpoet:supabase-codegen` | The JVM tool/library — a CLI `main` plus the public generator objects. |
+| `io.github.androidpoet:supabase-codegen-gradle` | The Gradle plugin (id `io.github.androidpoet.supabase.codegen`). |
+
+This page is the API/CLI/plugin reference. For task-oriented setup, modes, and the
+type-mapping table, see the [Codegen guide](/codegen).
+
+## 1. CLI / programmatic entry points
+
+### CLI
+
+The `supabase-codegen` tool runs the `main` in
+`io.github.androidpoet.supabase.codegen.MainKt`. It fetches the schema live from
+`--url`/`--key`, or reads a saved OpenAPI document from `--spec`:
+
+```bash
+supabase-codegen \
+  --url https://<ref>.supabase.co \
+  --key <service_role key> \
+  --package com.example.db \
+  --out src/commonMain/kotlin
+```
+
+Read from a local spec instead — no network, no key:
+
+```bash
+supabase-codegen --spec schema.json --package com.example.db --out src/commonMain/kotlin
+```
+
+Emit SQLDelight `.sq` files (and the optional adapter glue):
+
+```bash
+supabase-codegen --spec schema.json --package com.example.db \
+  --out src/commonMain/sqldelight --format sqldelight --adapters true
+```
+
+#### Flags
+
+Flags are parsed as `--name value` pairs (each flag takes the next argument as its
+value). Unknown flags are ignored.
+
+| Flag | Type | Default | Effect |
+| --- | --- | --- | --- |
+| `--url` | string | `$SUPABASE_URL` | Project URL, e.g. `https://<ref>.supabase.co`. Used only when `--spec` is absent. |
+| `--key` | string | `$SUPABASE_KEY` | API key whose role can read the target tables. Used only when `--spec` is absent. |
+| `--spec` | file path | none | Read the OpenAPI JSON from disk instead of fetching. When set, `--url`/`--key` are not needed and no network call is made. |
+| `--package` | string | `supabase.generated` | Base package for the generated code. |
+| `--out` | directory | `build/generated/supabase` | Root output directory. |
+| `--format` | `kotlin` \| `sqldelight` | `kotlin` | `kotlin` emits one file per table/enum; `sqldelight` emits one `.sq` per table. Any other value is an error. |
+| `--adapters` | boolean | `false` | Only meaningful with `--format sqldelight`: also emits `SupabaseAdapters.kt`. See [section 4](#4---format-sqldelight-output). |
+
+<Callout type="info">
+If neither `--spec` nor a usable URL/key pair (flags or `SUPABASE_URL` / `SUPABASE_KEY`)
+is provided, the tool exits with an error telling you to supply one. Before generating,
+it clears the output it owns (the `tables/`/`enums/` sub-packages for `kotlin`, the `.sq`
+files for `sqldelight`) so a dropped table or enum can't leave a stale file behind.
+</Callout>
+
+### Programmatic API
+
+The same generators that the CLI and Gradle plugin call are public, so you can embed
+codegen in your own JVM tooling. Each takes the raw OpenAPI JSON and a base package and
+returns `GeneratedFile`s — it does not write to disk:
+
+```kotlin
+public data class GeneratedFile(
+    public val relativePath: String,
+    public val contents: String,
+)
+```
+
+| Entry point | Signature | Returns |
+| --- | --- | --- |
+| `SchemaFetcher.fetch` | `fetch(projectUrl: String, apiKey: String): String` | Raw OpenAPI JSON fetched from `<url>/rest/v1/`. |
+| `SupabaseModelGenerator.generate` | `generate(specJson: String, packageName: String): List<GeneratedFile>` | Kotlin model files (one per table/enum). |
+| `SupabaseModelGenerator.generatedSubpackages` | `List<String>` | The sub-packages the generator owns (`["tables", "enums"]`) — clear these before re-writing. |
+| `SupabaseSqlDelightGenerator.generate` | `generate(specJson: String, packageName: String): List<GeneratedFile>` | One `.sq` file per table. |
+| `SupabaseSqlDelightAdapterGenerator.generate` | `generate(specJson: String, packageName: String): GeneratedFile` | A single `SupabaseAdapters.kt` file. |
+
+```kotlin
+import io.github.androidpoet.supabase.codegen.SchemaFetcher
+import io.github.androidpoet.supabase.codegen.SupabaseModelGenerator
+
+val specJson = SchemaFetcher.fetch("https://<ref>.supabase.co", "<service_role key>")
+val files = SupabaseModelGenerator.generate(specJson, "com.example.db")
+files.forEach { println(it.relativePath) }
+```
+
+## 2. Gradle plugin
+
+**Plugin id:** `io.github.androidpoet.supabase.codegen`
+(implementation `io.github.androidpoet.supabase.codegen.gradle.SupabaseCodegenPlugin`).
+
+Add Maven Central to your plugin repositories in `settings.gradle.kts`, then apply the
+plugin in the module that owns the generated models:
+
+```kotlin
+plugins {
+    id("io.github.androidpoet.supabase.codegen") version "1.0.0"
+}
+```
+
+### Extension DSL — `supabaseCodegen { }`
+
+```kotlin
+supabaseCodegen {
+    url.set(providers.environmentVariable("SUPABASE_URL"))
+    key.set(providers.environmentVariable("SUPABASE_KEY"))
+    packageName.set("com.example.db")
+    outputDir.set(layout.projectDirectory.dir("src/commonMain/kotlin"))
+    autoSync.set(false)
+}
+```
+
+| Property | Type | Default | Effect |
+| --- | --- | --- | --- |
+| `url` | `Property<String>` | falls back to `$SUPABASE_URL` | Project URL, e.g. `https://<ref>.supabase.co`. |
+| `key` | `Property<String>` | falls back to `$SUPABASE_KEY` | API key whose role can read the target tables. |
+| `packageName` | `Property<String>` | `supabase.generated` | Base package; models go under `.tables` / `.enums`. |
+| `outputDir` | `DirectoryProperty` | `build/generated/supabase` | Where files are written. |
+| `autoSync` | `Property<Boolean>` | `false` | When `true`, regenerate from the live schema before every Kotlin compile. |
+
+<Callout type="info">
+`url`/`key` default to the `SUPABASE_URL` / `SUPABASE_KEY` environment variables — the
+task wires `extension.url.orElse(environmentVariable("SUPABASE_URL"))` (and the same for
+`key`), so you only set them in the DSL to override the environment.
+</Callout>
+
+### Generated task
+
+The plugin registers one task:
+
+| Task | Group | Does |
+| --- | --- | --- |
+| `generateSupabaseModels` | `supabase` | Fetches the schema and writes the Kotlin `@Serializable` models into `outputDir`. |
+
+```bash
+export SUPABASE_URL="https://<ref>.supabase.co"
+export SUPABASE_KEY="<service_role key>"
+./gradlew generateSupabaseModels
+```
+
+The task always runs when invoked (it is never reported up-to-date, since the remote
+schema can change with no local input change) and is not cached.
+
+**`autoSync` behaviour.** With `autoSync = true`, the plugin makes every
+`compile*Kotlin*` task depend on `generateSupabaseModels`, so the models regenerate
+before each compile. If neither `url`/`key` nor the env vars are set, an auto-sync build
+**skips** codegen with a warning instead of failing — keeping offline/CI builds green —
+while a configured-but-unreachable fetch still fails the build. With `autoSync = false`
+(the default), the task is **not** wired into compilation; you run it on demand and
+commit the result. In either mode you must add `outputDir` as a source directory yourself:
+
+```kotlin
+kotlin.sourceSets.commonMain {
+    kotlin.srcDir(layout.buildDirectory.dir("generated/supabase"))
+}
+```
+
+The Gradle plugin generates Kotlin models only. To emit SQLDelight `.sq` files, use the
+CLI or the programmatic API with `--format sqldelight`.
+
+## 3. Output layout
+
+Kotlin output (`--format kotlin`) is split by kind into typed sub-packages, one file
+each, under the base package:
+
+```
+com/example/db/
+  tables/
+    ChatRooms.kt
+    ChatMessages.kt
+  enums/
+    OrderStatus.kt
+```
+
+`SupabaseModelGenerator.generatedSubpackages` is exactly `["tables", "enums"]`. These are
+the only directories the generator owns: before each run it deletes them and rewrites
+them, so a table or enum dropped from the database leaves no stale file, while
+hand-written code elsewhere in the package (such as extension functions) is untouched.
+
+<Callout type="warning">
+**Auto-sync output is build output, never editable.** When `autoSync = true`, the models
+land under `build/` (default `build/generated/supabase`) and are regenerated on every run.
+Gitignore them and never hand-edit them. To add behaviour, write extension functions in
+your own file (the cleanup is scoped to `tables/`/`enums/`, so your file survives). When
+committing models instead, point `outputDir` (or `--out`) at a real source set and turn
+`autoSync` off.
+</Callout>
+
+## 4. `--format sqldelight` output
+
+With `--format sqldelight`, the tool emits one `.sq` file per table (named in PascalCase)
+under the package directory, ready for SQLDelight's own Gradle plugin to compile into a
+type-safe Kotlin database. Each file contains a `CREATE TABLE IF NOT EXISTS` plus a small
+set of standard labelled queries:
+
+- `selectAll`, `countAll`, and `upsert` (an `INSERT OR REPLACE` over every column) for
+  every table.
+- When a primary key is detected (a column PostgREST flags with `<pk/>`, or a column
+  literally named `id`): `selectById`, `deleteById`, `page` (offset pagination ordered by
+  the primary key), and `pageAfter` (keyset pagination after a given key).
+
+Postgres types are collapsed to SQLite storage classes (integer/bigint/boolean →
+`INTEGER`, numeric/real/double → `REAL`, arrays stored as JSON `TEXT`, everything else
+including `text`/`uuid`/`timestamp`/`json`/`money` → `TEXT`). Two tables whose names
+normalise to the same `.sq` file name fail fast rather than overwriting each other.
+
+```bash
+supabase-codegen --spec schema.json --package com.example.db \
+  --out src/commonMain/sqldelight --format sqldelight
+```
+
+Add `--adapters true` to also emit a single `SupabaseAdapters.kt` alongside the `.sq`
+files. It exposes `public fun supabaseAdapters(driver: SqlDriver): Map<String, TableAdapter>`,
+wiring each generated table into a local-store adapter map. This file imports the
+offline-sync runtime types, so that runtime must be on the classpath for the generated
+code to compile.
+
+```toml
+# gradle/libs.versions.toml — the generated .sq files are compiled by SQLDelight's plugin
+[plugins]
+sqldelight = { id = "app.cash.sqldelight", version = "<version>" }
+```

--- a/website/pages/reference/core.mdx
+++ b/website/pages/reference/core.mdx
@@ -1,0 +1,676 @@
+---
+title: Core — API Reference
+description: Complete public API of the supabase-core module — the SupabaseResult sealed type and its combinators, the SupabaseError model and error categories, the Column value class, and the typed filter DSL that every other Supabase KMP module is built on.
+---
+
+import { Callout } from 'nextra/components'
+
+# Core — API Reference
+
+`supabase-core` is the foundation layer of Supabase KMP. It defines the `SupabaseResult<T>` sealed type that every call returns instead of throwing, a normalized `SupabaseError` model with coarse error categories, the `Column<T>` value class, and the typed filter DSL (`where { }` / `query { }`). It has no dependency on a transport or a specific Supabase service, so every other module (`supabase-database`, `supabase-auth`, `supabase-storage`, `supabase-realtime`, …) depends on it.
+
+- **Artifact:** `io.github.androidpoet:supabase-core`
+- **Version:** `1.0.0`
+- **Packages:** `io.github.androidpoet.supabase.core.result`, `…core.models`, `…core.paging`, `…core.util`
+
+<Callout type="info">
+  You rarely add this dependency directly — pulling in any feature module brings `supabase-core` transitively. Import it explicitly only when you write shared helpers that pass `SupabaseResult` or `Column` around without touching a specific service.
+</Callout>
+
+---
+
+## SupabaseResult
+
+```kotlin
+public sealed interface SupabaseResult<out T> {
+    public data class Success<out T>(public val value: T) : SupabaseResult<T>
+    public data class Failure(public val error: SupabaseError) : SupabaseResult<Nothing>
+
+    public val isSuccess: Boolean
+    public val isFailure: Boolean
+
+    public fun getOrNull(): T?
+    public fun getOrThrow(): T
+    public fun errorOrNull(): SupabaseError?
+
+    public companion object {
+        public inline fun <T> catching(block: () -> T): SupabaseResult<T>
+        public suspend inline fun <T> suspendCatching(block: suspend () -> T): SupabaseResult<T>
+    }
+}
+```
+
+The return type of every fallible SDK call. It is a **closed two-case** type — either a `Success` holding a value of type `T`, or a `Failure` holding a [`SupabaseError`](#supabaseerror). It is deliberately **not** `kotlin.Result`: the failure side carries a structured `SupabaseError` (not an arbitrary `Throwable`), and it does not box.
+
+### Variants
+
+- **`Success<T>(value: T)`** — a successful outcome. `value` is the payload (a row, a list, a session, `Unit`, …). A `data class`, so `component1()`/`copy()`/`equals`/`hashCode` are available.
+- **`Failure(error: SupabaseError)`** — a failed outcome. `error` is the normalized failure. Declared as `SupabaseResult<Nothing>`, so a `Failure` is assignable to any `SupabaseResult<T>` (this is why combinators can return `this` on the failure branch).
+
+### Members
+
+- **`isSuccess` / `isFailure`** — convenience predicates; `isSuccess` is `this is Success`.
+- **`getOrNull(): T?`** — the value on success, or `null` on failure.
+- **`getOrThrow(): T`** — the value on success, or **throws** [`SupabaseException`](#supabaseexception) (via `error.toException()`) on failure. The bridge into exception-based code.
+- **`errorOrNull(): SupabaseError?`** — the error on failure, or `null` on success.
+
+### Companion factories
+
+- **`catching(block)`** — runs `block`, wrapping its return in `Success`. A thrown `SupabaseException` is unwrapped to its `error`; any other `Throwable` becomes a generic `SupabaseError`. `CancellationException` is always re-thrown so coroutine cancellation is honoured.
+- **`suspendCatching(block)`** — the `suspend` form of `catching` for suspending bodies.
+
+```kotlin
+val result: SupabaseResult<Int> = SupabaseResult.catching { "42".toInt() }
+
+when (result) {
+    is SupabaseResult.Success -> println("got ${result.value}")
+    is SupabaseResult.Failure -> println("failed: ${result.error.message}")
+}
+```
+
+---
+
+## Result combinators
+
+All combinators are extension functions on `SupabaseResult<T>` in the `…core.result` package. They let you transform, inspect and unwrap a result without ever writing a `when`. On a `Failure`, every transform short-circuits and passes the failure through unchanged.
+
+### Transforming the success value
+
+```kotlin
+public inline fun <T, R> SupabaseResult<T>.map(transform: (T) -> R): SupabaseResult<R>
+public inline fun <T, R> SupabaseResult<T>.flatMap(transform: (T) -> SupabaseResult<R>): SupabaseResult<R>
+```
+
+- **`map`** — applies `transform` to the success value; a `Failure` passes through.
+- **`flatMap`** — like `map`, but `transform` itself returns a `SupabaseResult`, so failures from chained calls compose. The success path of one call feeds the next.
+
+```kotlin
+val name: SupabaseResult<String> =
+    database.selectSingle<User>("users")     // SupabaseResult<User>
+        .map { it.name }                     // SupabaseResult<String>
+        .flatMap { validateNonEmpty(it) }    // SupabaseResult<String>
+```
+
+### Transforming or recovering from the error
+
+```kotlin
+public inline fun <T> SupabaseResult<T>.mapError(transform: (SupabaseError) -> SupabaseError): SupabaseResult<T>
+public inline fun <T> SupabaseResult<T>.recover(transform: (SupabaseError) -> T): SupabaseResult<T>
+public inline fun <T> SupabaseResult<T>.flatMapError(transform: (SupabaseError) -> SupabaseResult<T>): SupabaseResult<T>
+```
+
+- **`mapError`** — rewrites the `SupabaseError` on a `Failure`; a `Success` passes through. Useful to add context.
+- **`recover`** — turns a `Failure` into a `Success` by computing a fallback value from the error.
+- **`flatMapError`** — the failure-side mirror of `flatMap`: maps a failure to another `SupabaseResult` (e.g. retry after a token refresh). A `Success` passes through.
+
+```kotlin
+val profile = api.fetchProfile()
+    .flatMapError { err -> if (err.category == SupabaseErrorCategory.Unauthorized) refreshAndRetry() else SupabaseResult.Failure(err) }
+    .recover { Profile.GUEST }   // never fails after this
+```
+
+### Asserting invariants
+
+```kotlin
+public inline fun <T> SupabaseResult<T>.validate(predicate: (T) -> Boolean, lazyError: (T) -> SupabaseError): SupabaseResult<T>
+public inline fun <T> SupabaseResult<T>.filter(lazyError: (T) -> SupabaseError = …, predicate: (T) -> Boolean): SupabaseResult<T>
+public inline fun <T> SupabaseResult<T>.filterNot(lazyError: (T) -> SupabaseError = …, predicate: (T) -> Boolean): SupabaseResult<T>
+```
+
+- **`validate`** — turns a `Success` whose value fails `predicate` into a `Failure` built by `lazyError`. A passing value (and any existing `Failure`) passes through.
+- **`filter`** — lighter `validate`; keeps a `Success` only while its value satisfies `predicate`, otherwise fails with `lazyError` (default message: "Value did not match the predicate").
+- **`filterNot`** — the negation of `filter`: a `Success` survives only when `predicate` is **false** (default message: "Value matched the excluded predicate").
+
+```kotlin
+api.fetchCount()
+    .filter(lazyError = { SupabaseError("count must be positive, was $it") }) { it > 0 }
+```
+
+### Combining several results
+
+```kotlin
+public inline fun <A, B, R> SupabaseResult<A>.zip(other: SupabaseResult<B>, transform: (A, B) -> R): SupabaseResult<R>
+public inline fun <A, B, C, R> SupabaseResult<A>.zip(second: SupabaseResult<B>, third: SupabaseResult<C>, transform: (A, B, C) -> R): SupabaseResult<R>
+
+public fun <T> mergeAll(results: List<SupabaseResult<T>>): SupabaseResult<List<T>>
+public fun <T> mergeAll(vararg results: SupabaseResult<T>): SupabaseResult<List<T>>
+```
+
+- **`zip`** (two- and three-arg) — combines independent results: a `Success` of `transform` applied to all values when every result succeeds, otherwise the **first** `Failure` in receiver → `second` → `third` order.
+- **`mergeAll`** — collapses many homogeneous results into a single `SupabaseResult<List<T>>`, preserving order. Short-circuits on the first `Failure`, so the success path guarantees every input succeeded. Available as a `List` and a `vararg` overload.
+
+```kotlin
+val both = api.fetchUser().zip(api.fetchSettings()) { user, settings -> Screen(user, settings) }
+val all  = mergeAll(page1, page2, page3)   // SupabaseResult<List<Page>>
+```
+
+### Unwrapping (terminal operations)
+
+```kotlin
+public fun <T> SupabaseResult<T>.getOrDefault(defaultValue: T): T
+public inline fun <T> SupabaseResult<T>.getOrElse(defaultValue: (SupabaseError) -> T): T
+public inline fun <T, R> SupabaseResult<T>.fold(onSuccess: (T) -> R, onFailure: (SupabaseError) -> R): R
+```
+
+- **`getOrDefault`** — the success value, or an eagerly-supplied `defaultValue` on failure.
+- **`getOrElse`** — the success value, or a value computed from the error (the lazy sibling of `getOrDefault`).
+- **`fold`** — collapses both cases to a single `R` by supplying a handler for each branch. The most general terminal operator.
+
+```kotlin
+val label: String = api.fetchName().fold(
+    onSuccess = { it },
+    onFailure = { "anonymous (${it.category})" },
+)
+```
+
+### Side effects
+
+```kotlin
+public inline fun <T> SupabaseResult<T>.onSuccess(action: (T) -> Unit): SupabaseResult<T>
+public inline fun <T> SupabaseResult<T>.onFailure(action: (SupabaseError) -> Unit): SupabaseResult<T>
+public inline fun <T> SupabaseResult<T>.onFailureCategory(category: SupabaseErrorCategory, action: (SupabaseError) -> Unit): SupabaseResult<T>
+public inline fun <T, C> SupabaseResult<T>.onFailureCategory(category: C, classifier: (SupabaseError) -> C, action: (SupabaseError) -> Unit): SupabaseResult<T>
+
+public inline fun <T> SupabaseResult<T>.onConflict(action: (SupabaseError) -> Unit): SupabaseResult<T>
+public inline fun <T> SupabaseResult<T>.onNotFound(action: (SupabaseError) -> Unit): SupabaseResult<T>
+public inline fun <T> SupabaseResult<T>.onUnauthorized(action: (SupabaseError) -> Unit): SupabaseResult<T>
+public inline fun <T> SupabaseResult<T>.onRateLimited(action: (SupabaseError) -> Unit): SupabaseResult<T>
+public inline fun <T> SupabaseResult<T>.onNetworkError(action: (SupabaseError) -> Unit): SupabaseResult<T>
+```
+
+Each runs `action` for the matching case and returns the **same** result unchanged, so they chain. `onFailureCategory` fires only when `error.category` equals `category`; its second overload lets you supply a custom `classifier`. The five named helpers (`onConflict`, `onNotFound`, `onUnauthorized`, `onRateLimited`, `onNetworkError`) are shorthands for `onFailureCategory` with the corresponding [`SupabaseErrorCategory`](#supabaseerrorcategory).
+
+```kotlin
+api.deleteRow(id)
+    .onSuccess { toast("Deleted") }
+    .onNotFound { toast("Already gone") }
+    .onUnauthorized { signOut() }
+    .onFailure { log(it.message) }
+```
+
+### Suspending variants
+
+For when an `action`/`transform` must itself suspend. Behaviour matches the non-suspending sibling above.
+
+```kotlin
+public suspend inline fun <T> SupabaseResult<T>.onSuccessSuspend(action: suspend (T) -> Unit): SupabaseResult<T>
+public suspend inline fun <T> SupabaseResult<T>.onFailureSuspend(action: suspend (SupabaseError) -> Unit): SupabaseResult<T>
+public suspend inline fun <T> SupabaseResult<T>.onFailureCategorySuspend(category: SupabaseErrorCategory, action: suspend (SupabaseError) -> Unit): SupabaseResult<T>
+public suspend inline fun <T, C> SupabaseResult<T>.onFailureCategorySuspend(category: C, classifier: (SupabaseError) -> C, action: suspend (SupabaseError) -> Unit): SupabaseResult<T>
+public suspend inline fun <T, R> SupabaseResult<T>.foldSuspend(onSuccess: suspend (T) -> R, onFailure: suspend (SupabaseError) -> R): R
+public suspend inline fun <T, R> SupabaseResult<T>.mapSuspend(transform: suspend (T) -> R): SupabaseResult<R>
+public suspend inline fun <T> SupabaseResult<T>.recoverSuspend(transform: suspend (SupabaseError) -> T): SupabaseResult<T>
+public suspend inline fun <T> SupabaseResult<T>.flatMapErrorSuspend(transform: suspend (SupabaseError) -> SupabaseResult<T>): SupabaseResult<T>
+```
+
+### kotlin.Result interop
+
+```kotlin
+public fun <T> SupabaseResult<T>.toKotlinResult(): Result<T>
+public inline fun <T> Result<T>.toSupabaseResult(mapThrowable: (Throwable) -> SupabaseError = …): SupabaseResult<T>
+```
+
+- **`toKotlinResult`** — converts to a standard `kotlin.Result`; a `Failure` becomes a `Result.failure` carrying the `error.toException()`.
+- **`toSupabaseResult`** — converts a `kotlin.Result` back. By default a wrapped `SupabaseException` keeps its `error`; any other throwable becomes a generic `SupabaseError` (override via `mapThrowable`). `CancellationException` is re-thrown.
+
+### Flow bridges
+
+```kotlin
+public fun <T> SupabaseResult<T>.asFlow(): Flow<SupabaseResult<T>>
+public fun <T> supabaseFlow(block: suspend () -> SupabaseResult<T>): Flow<SupabaseResult<T>>
+public fun <T> dataFlow(block: suspend () -> SupabaseResult<T>): Flow<T>
+
+public fun <T> SupabaseResult<T>.toFlow(): Flow<T>
+public inline fun <T, R> SupabaseResult<T>.toFlow(transform: (T) -> R): Flow<R>
+public inline fun <T, R> SupabaseResult<T>.toSuspendFlow(transform: suspend (T) -> R): Flow<R>
+public fun <T> SupabaseResult<T>.toResultFlow(): Flow<SupabaseResult<T>>
+```
+
+- **`asFlow`** — emits an already-computed result as a single-value cold `Flow`, keeping the wrapper. Handy for seeding a stream with a cached result before live values arrive.
+- **`supabaseFlow`** — wraps a not-yet-run suspending call in a cold `Flow` that runs it on collection and emits the result once, **keeping** the `SupabaseResult` wrapper.
+- **`dataFlow`** — the no-`Result` escape hatch: emits the plain value on success and **throws** (`SupabaseException`) on failure, so the wrapper never enters your stream. Pairs with exception-based `Flow<T>.asResult()` UI helpers.
+- **`toFlow()`** — emits the success value, or an **empty** flow on failure (failures are dropped silently). A `transform` overload maps before emitting.
+- **`toSuspendFlow`** — `toFlow` with a `suspend` transform run in the collection context.
+- **`toResultFlow`** — emits the whole result as one element, so a failure (and its error) survives into the stream — the error-preserving counterpart of `toFlow`.
+
+```kotlin
+supabaseFlow { database.selectTyped<Todo>("todos") }
+    .collect { result -> result.onSuccess(::render).onFailure(::showError) }
+```
+
+### Concurrent fan-out
+
+```kotlin
+public fun <T> CoroutineScope.deferredResult(block: suspend () -> SupabaseResult<T>): Deferred<SupabaseResult<T>>
+public suspend fun <T> awaitMerged(deferreds: List<Deferred<SupabaseResult<T>>>): SupabaseResult<List<T>>
+public suspend fun <T> awaitMerged(vararg deferreds: Deferred<SupabaseResult<T>>): SupabaseResult<List<T>>
+```
+
+- **`deferredResult`** — launches `block` on the scope and returns a `Deferred` to its result, so independent calls run concurrently. Any throwable is captured as a `Failure`, so `await()` never throws and one failure can't cancel siblings; cooperative cancellation still propagates.
+- **`awaitMerged`** — awaits every deferred and `mergeAll`s them: an ordered success list when all succeed, or the first `Failure`. The collect step for a `deferredResult` fan-out (`List` and `vararg` overloads).
+
+```kotlin
+val pages = ids.map { id -> scope.deferredResult { api.fetchPage(id) } }
+val all: SupabaseResult<List<Page>> = awaitMerged(pages)
+```
+
+---
+
+## Error model
+
+### SupabaseError
+
+```kotlin
+@Serializable
+public data class SupabaseError(
+    public val message: String,
+    public val code: String? = null,
+    public val details: JsonElement? = null,
+    public val hint: String? = null,
+    public val httpStatus: Int? = null,
+    public val retryAfterSeconds: Long? = null,
+)
+```
+
+The normalized failure — the `error` half of a `Failure`, unifying PostgREST, GoTrue, Storage, Realtime and client-side faults.
+
+- **`message`** — human-readable description (required).
+- **`code`** — machine-readable service code (e.g. a PostgREST `PGRST…`/SQLSTATE, a GoTrue slug) or a synthetic [`SupabaseErrorCodes.Client`](#supabaseerrorcodes) code, when known. Default `null`.
+- **`details`** — additional structured context from the error body, as a raw `JsonElement`. Default `null`.
+- **`hint`** — a suggested remedy, when the server supplies one. Default `null`.
+- **`httpStatus`** — the HTTP status that produced this error, captured **independently** of `code` so [`category`](#supabaseerrorcategory) keeps working even when the body has no machine-readable code. Default `null`.
+- **`retryAfterSeconds`** — the server's `Retry-After` hint in seconds, typically on a `429`. Useful for "try again in N seconds" UI. Default `null`.
+
+```kotlin
+val err = SupabaseError(message = "Row not found", code = "PGRST116", httpStatus = 406)
+println(err.category)   // Validation
+```
+
+### SupabaseException
+
+```kotlin
+public class SupabaseException(public val error: SupabaseError, cause: Throwable? = null) : Exception(error.message, cause)
+public fun SupabaseError.toException(cause: Throwable? = null): SupabaseException
+```
+
+The throwable form of a `SupabaseError`, thrown by `getOrThrow()` / `dataFlow` and caught by `catching`. It keeps the original `error` so a `catch` block can still inspect `error.code`/`error.category`, and an optional `cause` so the underlying throwable stays in the stack trace. `toException()` is the convenience wrapper.
+
+### SupabaseErrorCategory
+
+```kotlin
+public enum class SupabaseErrorCategory {
+    Conflict, NotFound, Unauthorized, RateLimited, Validation, Internal, Network, Unknown
+}
+
+public val SupabaseError.category: SupabaseErrorCategory
+public val SupabaseErrorCategory.isRetryable: Boolean
+```
+
+A coarse classification of a failure so callers can branch on the **kind** of error without matching individual codes.
+
+- **`Conflict`** — uniqueness/foreign-key clash or already-existing resource (HTTP 409).
+- **`NotFound`** — the table, row, user or object does not exist (HTTP 404).
+- **`Unauthorized`** — missing/invalid/insufficient credentials or permissions (HTTP 401/403).
+- **`RateLimited`** — a rate limit was exceeded; back off and retry (HTTP 429).
+- **`Validation`** — the request was malformed or failed validation (HTTP 400/406/416/422).
+- **`Internal`** — a server-side failure unrelated to request content (HTTP 5xx, plus transient 408/425).
+- **`Network`** — the request never reached the server or never produced a usable response (offline, timeout, connection or decode failure). Distinct from `Unknown` so you can show offline/retry UI.
+- **`Unknown`** — the catch-all fallback when nothing more specific applied.
+
+**`category`** resolves from the textual `code` first (matched against the per-service code sets in [`SupabaseErrorCodes`](#supabaseerrorcodes)), then falls back to `httpStatus` (or a numeric `code` in the HTTP range), so structured bodies without a textual code are still classified.
+
+**`isRetryable`** is `true` for the transient categories — `RateLimited`, `Internal`, `Network` — and `false` for client-fault categories that would fail again unchanged.
+
+```kotlin
+result.onFailure { err ->
+    if (err.category.isRetryable) scheduleRetry(after = err.retryAfterSeconds)
+    else showPermanentError(err)
+}
+```
+
+### Code-specific predicates
+
+```kotlin
+public fun SupabaseError.isUniquenessViolation(): Boolean   // Postgres 23505 — duplicate row
+public fun SupabaseError.isForeignKeyViolation(): Boolean   // Postgres 23503 — missing referenced row
+public fun SupabaseError.isInvalidCredentials(): Boolean    // GoTrue invalid_credentials
+public fun SupabaseError.isUserAlreadyExists(): Boolean     // GoTrue user_already_exists
+public fun SupabaseError.isFileNotFound(): Boolean          // Storage NoSuchKey
+public fun SupabaseError.isNetworkError(): Boolean          // == (category == Network)
+```
+
+Convenience checks against the most common individual codes, for when a category is too coarse.
+
+### SupabaseErrorCodes
+
+```kotlin
+public object SupabaseErrorCodes {
+    public object Database { /* PGRST… + SQLSTATE constants */ }
+    public object Auth { /* GoTrue slug constants */ }
+    public object Storage { /* object/bucket + S3 constants */ }
+    public object Realtime { /* channel/auth/topic constants */ }
+    public object Functions { /* Edge Functions constants */ }
+    public object Client { /* synthetic client-side constants */ }
+    public object Management { /* project/org constants */ }
+}
+```
+
+A catalog of the string error codes Supabase services return, grouped by service, so matching against `SupabaseError.code` never needs magic strings. These drive the category sets behind `category` and the `is*` helpers. Every constant is a `public const val String`.
+
+- **`Database`** — PostgREST (`PGRST000`…`PGRST303`, `PGRSTX00`) and raw PostgreSQL `SQLSTATE` codes: `FOREIGN_KEY_VIOLATION` (`23503`), `UNIQUENESS_VIOLATION` (`23505`), `UNDEFINED_TABLE` (`42P01`), `INSUFFICIENT_PRIVILEGE` (`42501`), `STATEMENT_TIMEOUT` (`57014`), `TABLE_NOT_FOUND`, `COLUMN_NOT_FOUND`, `FUNCTION_NOT_FOUND`, `JWT_INVALID`, `SINGULAR_RESPONSE_VIOLATION`, and more.
+- **`Auth`** — GoTrue codes: `INVALID_CREDENTIALS`, `USER_NOT_FOUND`, `USER_ALREADY_EXISTS`, `EMAIL_NOT_CONFIRMED`, `WEAK_PASSWORD`, `OTP_EXPIRED`, `TOO_MANY_REQUESTS`, `MFA_VERIFICATION_FAILED`, `SIGNUP_DISABLED`, and others.
+- **`Storage`** — object/bucket and S3-compatibility codes: `NO_SUCH_BUCKET`, `NO_SUCH_KEY`, `KEY_ALREADY_EXISTS`, `ENTITY_TOO_LARGE`, `INVALID_MIME_TYPE`, `ACCESS_DENIED`, `THROTTLING`, `INTERNAL_ERROR`, and more.
+- **`Realtime`** — WebSocket codes: `CHANNEL_RATE_LIMIT_REACHED`, `CONNECTION_RATE_LIMIT_REACHED`, `ERROR_AUTHORIZING_WEBSOCKET`, `AUTH_EXPIRED`, `INVALID_TOPIC`, `PAYLOAD_TOO_LARGE`, and others.
+- **`Functions`** — Edge Functions codes: `BOOT_ERROR`, `WORKER_ERROR`, `WORKER_LIMIT`, `DEPLOYMENT_FAILED`, `UNSUPPORTED_NODE_VERSION`, `FUNCTION_NOT_RETURNING_RESPONSE`.
+- **`Client`** — the only group **not** emitted by a server; synthesized by the SDK when a request never produced a response: `NETWORK_ERROR`, `TIMEOUT`, `CONNECTION_FAILED`. These let `category` resolve to `Network` instead of `Unknown`.
+- **`Management`** — Management API codes: `PROJECT_NOT_FOUND`, `ORGANIZATION_NOT_FOUND`, `INVALID_PROJECT_REF`, `UNAUTHORIZED`, `FORBIDDEN`, `RATE_LIMIT_EXCEEDED`.
+
+```kotlin
+result.onFailure { err ->
+    when (err.code) {
+        SupabaseErrorCodes.Database.UNIQUENESS_VIOLATION -> toast("Already exists")
+        SupabaseErrorCodes.Auth.WEAK_PASSWORD -> showPasswordHint()
+    }
+}
+```
+
+---
+
+## Column and query enums
+
+### Column
+
+```kotlin
+@JvmInline
+public value class Column<T>(public val name: String)
+```
+
+A type-safe handle to a table column, carrying both its wire `name` and the Kotlin type `T` of the values it holds. Passing `Column<T>` into the [filter operators](#filter-dsl) makes the compiler reject type-mismatched comparisons like `age eq "oops"`. Being a `value class`, it costs nothing at runtime — it is just the `String` name. This is the **only** value class in `supabase-core`; typed IDs (user, bucket, session, channel, …) live in their respective feature modules.
+
+```kotlin
+public object Profiles {
+    public val age: Column<Int> = Column("age")
+    public val status: Column<String> = Column("status")
+}
+```
+
+### Order
+
+```kotlin
+public enum class Order { ASC, DESC }
+```
+
+Sort direction for [`QueryBuilder.orderBy`](#querybuilder). `ASC` renders to PostgREST `asc`, `DESC` to `desc`.
+
+### Nulls
+
+```kotlin
+public enum class Nulls { FIRST, LAST }
+```
+
+Placement of `NULL` values relative to non-null values for `orderBy`. `FIRST` → `nullsfirst`, `LAST` → `nullslast`.
+
+### TextSearchType
+
+```kotlin
+public enum class TextSearchType { Raw, Plain, Phrase, Websearch }
+```
+
+Full-text search mode for [`WhereBuilder.textSearch`](#full-text-search), selecting how the query is parsed into a `tsquery`. Maps to a PostgREST operator prefix: `Raw` → `fts`, `Plain` → `plfts`, `Phrase` → `phfts`, `Websearch` → `wfts`.
+
+### Filter
+
+```kotlin
+public sealed interface Filter
+```
+
+An immutable filter expression — the value the filter DSL builds internally. A `Filter` is either a single column predicate or a logical combination of others. It has no public implementations; you never construct one by hand, you build it through `where { }`. It is rendered to PostgREST query parameters when a request is issued.
+
+### FilterDsl
+
+```kotlin
+@DslMarker
+public annotation class FilterDsl
+```
+
+A [DSL marker](https://kotlinlang.org/docs/type-safe-builders.html#scope-control-dslmarker) that scopes the receiver of nested DSL blocks (`where`/`or`/`and`/`not`), so an inner block can't accidentally call methods on an outer builder.
+
+---
+
+## Filter DSL
+
+### WhereBuilder
+
+```kotlin
+@FilterDsl
+public class WhereBuilder
+```
+
+The receiver of a filter block. Each statement adds one predicate; multiple statements are **AND**-ed together. The operators are infix extensions on `Column<T>`, type-checked against `T`. String operands are escaped per PostgREST quoting rules when they contain a structural character (comma, parens, quote, backslash); numbers and booleans are emitted verbatim.
+
+**Comparison** (`eq`/`neq` for any `T`; the ordering operators require `T : Comparable<T>`):
+
+```kotlin
+public infix fun <T> Column<T>.eq(value: T)                       // column = value
+public infix fun <T> Column<T>.neq(value: T)                      // column <> value
+public infix fun <T> Column<T>.isDistinctFrom(value: T)           // IS DISTINCT FROM (null-aware)
+public infix fun <T : Comparable<T>> Column<T>.greater(value: T)    // >
+public infix fun <T : Comparable<T>> Column<T>.greaterEq(value: T)  // >=
+public infix fun <T : Comparable<T>> Column<T>.less(value: T)       // <
+public infix fun <T : Comparable<T>> Column<T>.lessEq(value: T)     // <=
+public infix fun <T : Comparable<T>> Column<T>.within(range: ClosedRange<T>)  // >= start AND <= end
+```
+
+**Null / boolean IS:**
+
+```kotlin
+public fun Column<*>.isNull()                          // IS NULL
+public fun Column<*>.isNotNull()                       // IS NOT NULL
+public infix fun Column<Boolean>.isExactly(value: Boolean)   // IS TRUE / IS FALSE
+```
+
+**Pattern matching** (on `Column<String>`):
+
+```kotlin
+public infix fun Column<String>.like(pattern: String)     // LIKE (case-sensitive, % = any run)
+public infix fun Column<String>.ilike(pattern: String)    // ILIKE (case-insensitive)
+public infix fun Column<String>.matches(pattern: String)  // ~  POSIX regex (case-sensitive)
+public infix fun Column<String>.imatches(pattern: String) // ~* POSIX regex (case-insensitive)
+public infix fun Column<String>.likeAllOf(patterns: List<String>)   // LIKE ALL
+public infix fun Column<String>.likeAnyOf(patterns: List<String>)   // LIKE ANY
+public infix fun Column<String>.ilikeAllOf(patterns: List<String>)  // ILIKE ALL
+public infix fun Column<String>.ilikeAnyOf(patterns: List<String>)  // ILIKE ANY
+```
+
+**Membership:**
+
+```kotlin
+public infix fun <T> Column<T>.inList(values: List<T>)      // IN (…)
+public infix fun <T> Column<T>.notInList(values: List<T>)   // NOT IN (…)
+```
+
+**Array** (on `Column<List<T>>`):
+
+```kotlin
+public infix fun <T> Column<List<T>>.contains(values: List<T>)     // @> contains every element
+public infix fun <T> Column<List<T>>.containedBy(values: List<T>)  // <@ contained by
+public infix fun <T> Column<List<T>>.overlaps(values: List<T>)     // && shares any element
+```
+
+**Range columns** (`int4range`, `tstzrange`, … — `range` is a Postgres range literal passed verbatim, e.g. `"[1,10)"`):
+
+```kotlin
+public infix fun Column<*>.rangeGt(range: String)        // >>  strictly right of
+public infix fun Column<*>.rangeGte(range: String)       // &>  does not extend left of
+public infix fun Column<*>.rangeLt(range: String)        // <<  strictly left of
+public infix fun Column<*>.rangeLte(range: String)       // &<  does not extend right of
+public infix fun Column<*>.rangeAdjacent(range: String)  // -|- adjacent to
+```
+
+**Full-text search:**
+
+```kotlin
+public fun Column<String>.textSearch(query: String, config: String? = null, type: TextSearchType = TextSearchType.Plain)
+```
+
+- `query` — the search string.
+- `config` — an optional text-search configuration (e.g. `"english"`), wrapped in parentheses on the wire. Default `null`.
+- `type` — the parse mode; default `TextSearchType.Plain`.
+
+**Logical grouping and escape hatch:**
+
+```kotlin
+public fun or(referencedTable: String? = null, block: WhereBuilder.() -> Unit)   // OR group
+public fun and(referencedTable: String? = null, block: WhereBuilder.() -> Unit)  // explicit AND group
+public fun not(block: WhereBuilder.() -> Unit)                                    // negates every predicate inside
+public fun raw(column: Column<*>, operator: String, value: String)               // column=<operator>.<value>, value escaped
+```
+
+- `or` / `and` — combine the predicates in `block` with that operator; the optional `referencedTable` scopes the group to an embedded resource.
+- `not` — negates every predicate declared in `block` (SQL `NOT`).
+- `raw` — an escape hatch for operators the DSL doesn't expose yet.
+
+```kotlin
+where {
+    Profiles.status eq "active"
+    Profiles.age within 18..30
+    or {
+        Profiles.status eq "pending"
+        Profiles.status eq "invited"
+    }
+}
+```
+
+### QueryBuilder
+
+```kotlin
+@FilterDsl
+public class QueryBuilder {
+    public fun where(block: WhereBuilder.() -> Unit)
+    public fun orderBy(column: Column<*>, order: Order = Order.ASC, nulls: Nulls? = null, referencedTable: String? = null)
+    public fun limit(count: Int, referencedTable: String? = null)
+    public fun offset(count: Int, referencedTable: String? = null)
+    public fun range(from: Int, to: Int, referencedTable: String? = null)
+}
+```
+
+The receiver of a full read query: a `where { }` predicate plus result modifiers. Modifiers are kept distinct from filters, so a `not { limit(1) }` is not expressible.
+
+- **`where`** — the filter predicate; multiple statements inside are AND-ed.
+- **`orderBy`** — sort by `column`. `order` defaults to `Order.ASC`; `nulls` is optional null placement; `referencedTable` scopes the sort to an embedded resource. Successive calls add **secondary** sort keys (merged into one `order` param).
+- **`limit`** — cap the result at `count` rows; last call wins.
+- **`offset`** — skip the first `count` rows; last call wins.
+- **`range`** — an inclusive, zero-based row window `[from, to]`, emitted as an `offset` plus a derived `limit` (`to - from + 1`). Requires `to >= from`.
+
+### where / query
+
+```kotlin
+public inline fun where(block: WhereBuilder.() -> Unit): List<Pair<String, String>>
+public inline fun query(block: QueryBuilder.() -> Unit): List<Pair<String, String>>
+```
+
+The two entry points that materialize a DSL block into PostgREST query parameters. `where { }` builds a filter-only predicate (used by `update`/`delete`); `query { }` builds a full read query (filter + modifiers, used by `select`). You normally pass the block straight to a feature-module method rather than calling these directly.
+
+```kotlin
+val params = query {
+    where { Profiles.status eq "active" }
+    orderBy(Profiles.age, Order.DESC)
+    limit(20)
+}
+// → [(status, eq.active), (order, age.desc), (limit, 20)]
+```
+
+---
+
+## Response model
+
+### PostgrestResponse
+
+```kotlin
+@Serializable
+public data class PostgrestResponse<T>(
+    public val data: T,
+    public val count: Long? = null,
+)
+```
+
+A successful PostgREST response: the decoded `data` plus an optional row `count`.
+
+- **`data`** — the decoded body (a row, a list of rows, or a scalar).
+- **`count`** — the total row count, populated **only** when the request asked for it (a `Prefer: count=…` header), e.g. to drive pagination; `null` otherwise.
+
+---
+
+## Paging
+
+### Paginator
+
+```kotlin
+public class Paginator<T>(
+    pageSize: Int = 20,
+    fetch: suspend (offset: Int, limit: Int) -> List<T>,
+) {
+    public val items: StateFlow<List<T>>
+    public val isLoading: StateFlow<Boolean>
+    public val endReached: StateFlow<Boolean>
+    public val error: StateFlow<Throwable?>
+
+    public suspend fun loadNext()
+    public suspend fun refresh()
+}
+```
+
+A small, dependency-free, **demand-driven** paginator for infinite-scroll UIs. It loads the next page only when asked, exposing its state as observable `StateFlow`s. It depends on nothing but coroutines, so it works on every target with or without Compose.
+
+- **`pageSize`** — rows requested per page; must be `> 0`. Default `20`.
+- **`fetch`** — returns one page given an `offset` and `limit`. Expected to **throw** on failure (e.g. via `getOrThrow()`); the throwable is captured into `error` rather than propagated, except `CancellationException`, which is always re-thrown.
+
+State:
+
+- **`items`** — the rows loaded so far, growing with each successful `loadNext`.
+- **`isLoading`** — `true` while a page is being fetched.
+- **`endReached`** — `true` once a page came back shorter than `pageSize`.
+- **`error`** — the last `fetch` failure, or `null`; cleared when a new load starts.
+
+Operations:
+
+- **`loadNext()`** — loads and appends the next page. A no-op if a load is running or `endReached` is set.
+- **`refresh()`** — resets to the first page and reloads it (pull-to-refresh); any in-flight page is discarded so it cannot append onto the cleared list.
+
+```kotlin
+val pager = Paginator(pageSize = 20) { offset, limit ->
+    database.selectTyped<Todo>("todos") { range(offset, offset + limit - 1) }.getOrThrow()
+}
+// observe pager.items; near the end of the list:
+LaunchedEffect(lastVisibleIndex) { pager.loadNext() }
+```
+
+---
+
+## Utilities
+
+### urlEncode
+
+```kotlin
+public fun urlEncode(value: String): String
+```
+
+Percent-encodes `value` for use as a single URL component (RFC 3986). The unreserved set (`A-Z a-z 0-9 - . _ ~`) passes through unchanged; everything else is encoded from its UTF-8 bytes. Shared so each module needn't carry its own copy.
+
+```kotlin
+urlEncode("a b/c")   // "a%20b%2Fc"
+```
+
+---
+
+## Design notes
+
+**Result-first, no exceptions.** Every fallible operation returns a `SupabaseResult<T>` rather than throwing. Failure is a value (`Failure(SupabaseError)`), not a stack-unwinding event, so the compiler forces you to acknowledge both branches and the happy path composes with `map`/`flatMap`/`zip`. Exceptions remain available as an opt-in (`getOrThrow`, `dataFlow`, `toKotlinResult`) for code that prefers `try`/`catch`, but they are never the default.
+
+**Not `kotlin.Result`.** The failure side is a structured, serializable `SupabaseError` — with a `code`, an `httpStatus`, a `category` and a `Retry-After` hint — not an opaque `Throwable`. That lets you branch on the *kind* of failure (`onUnauthorized`, `category.isRetryable`) without string-matching messages, and lets errors cross serialization boundaries.
+
+**Cancellation is sacred.** Every helper that catches throwables (`catching`, `deferredResult`, `Paginator`, `toSupabaseResult`) re-throws `CancellationException`, so structured concurrency and coroutine cancellation always work as expected.
+
+**Zero-cost types where it counts.** `Column<T>` is a `value class`, so type-safe filters carry no runtime overhead over a bare `String`. Filters are modelled as an immutable `Filter` tree and rendered in a single recursive walk, so logical combinators stay trivial and no already-serialized output is ever re-parsed.
+
+**Thin over the REST API.** The filter DSL maps directly onto PostgREST operators; nothing here hides or reinterprets the wire protocol, and the `raw` escape hatch is always available for operators the DSL doesn't yet name.

--- a/website/pages/reference/database.mdx
+++ b/website/pages/reference/database.mdx
@@ -1,0 +1,1579 @@
+---
+title: Database — API Reference
+description: Complete API reference for the supabase-database module — PostgREST reads, writes, and RPC, plus the typed Kotlin filter DSL. Every public symbol, signature, and return type.
+---
+
+import { Callout } from 'nextra/components'
+
+# Database — API Reference
+
+The `supabase-database` module is a thin, stateless Kotlin client over a Supabase
+project's PostgREST endpoint (`/rest/v1`). It gives you CRUD over your tables,
+calls to stored procedures (RPC), and a typed filter DSL for building `WHERE`
+clauses, ordering, and pagination — all mapped to a single HTTP request per call.
+
+- **Artifact:** `io.github.androidpoet:supabase-database`
+- **Entry point:** `createDatabaseClient(client)` or the `SupabaseClient.database` accessor.
+
+```kotlin
+val database = createDatabaseClient(client)
+// or
+val database = client.database
+```
+
+<Callout type="info">
+Every method returns a `SupabaseResult<T>` — a **sealed** type from
+`supabase-core` with two cases, `SupabaseResult.Success(value)` and
+`SupabaseResult.Failure(error)` where `error` is a typed `SupabaseError`. This is
+**not** `kotlin.Result`. Failures (HTTP errors, transport problems, malformed
+requests, decode failures) are returned, never thrown — except for the explicit
+`*OrThrow` helpers. Pattern-match on the result, or use `getOrNull()`,
+`getOrThrow()`, `errorOrNull()`, and `map`.
+</Callout>
+
+The interface methods return the raw response body as a `String` (the wire-level
+escape hatch). The ergonomic, type-safe access lives in `reified inline`
+extension functions named with a `Typed`/`Unit`/`Csv`/etc. suffix — these
+serialize and deserialize around the string core. See [Design notes](#design-notes)
+for why typed decoding is a separate name rather than an overload of `select`.
+
+---
+
+## Client construction
+
+### `createDatabaseClient`
+
+```kotlin
+public fun createDatabaseClient(supabaseClient: SupabaseClient): DatabaseClient
+```
+
+Creates a `DatabaseClient` bound to `supabaseClient`. The result is a thin,
+stateless wrapper that forwards every call to the client's transport, so it is
+cheap to create and holds no state of its own.
+
+- `supabaseClient` — the configured Supabase client whose transport is used.
+
+**Returns:** a `DatabaseClient`.
+
+```kotlin
+val database = createDatabaseClient(client)
+```
+
+### `SupabaseClient.database`
+
+```kotlin
+public val SupabaseClient.database: DatabaseClient
+```
+
+Accessor property that simply calls `createDatabaseClient(this)`. Use it for
+one-off access without keeping a named reference.
+
+```kotlin
+val rows = client.database.selectTyped<Todo>("todos")
+```
+
+---
+
+## Reads
+
+### `select` (interface method)
+
+```kotlin
+public suspend fun select(
+    table: String,
+    schema: String? = null,
+    columns: String = "*",
+    format: ResponseFormat = ResponseFormat.ROWS,
+    count: CountOption? = null,
+    stripNulls: Boolean = false,
+    explain: ExplainOptions? = null,
+    retry: Boolean = true,
+    headers: Map<String, String> = emptyMap(),
+    block: QueryBuilder.() -> Unit = {},
+): SupabaseResult<String>
+```
+
+Reads rows from `table` via `GET /rest/v1/{table}`, returning the response body as
+a raw string (typically a JSON array). This is the wire-level read; prefer
+[`selectTyped`](#selecttyped) for decoded results.
+
+- `table` — table (or view) name.
+- `schema` — target Postgres schema; sent as `Accept-Profile` when non-null, otherwise the default schema. Default `null`.
+- `columns` — the PostgREST `select=` projection (supports embedded resources and renames). Default `"*"`.
+- `format` — body shape requested via `Accept` (see [`ResponseFormat`](#responseformat)). Default `ResponseFormat.ROWS`.
+- `count` — adds a `count=` preference so the total appears in `Content-Range` (see [`CountOption`](#countoption)). Default `null`.
+- `stripNulls` — omits null fields from the response. Default `false`.
+- `explain` — when set, returns the query plan instead of data (see [`ExplainOptions`](#explainoptions)). Default `null`.
+- `retry` — whether this read may be transparently retried by the transport. Default `true`.
+- `headers` — extra request headers, merged with the computed ones. Default `emptyMap()`.
+- `block` — the [query DSL](#query-and-filter-dsl): row predicates, ordering, and range.
+
+**Returns:** `SupabaseResult<String>` — `Success` with the raw body, or `Failure` with a `SupabaseError`.
+
+```kotlin
+val json = database.select("todos", columns = "id,title") {
+    where { Todo.done eq false }
+    orderBy(Todo.createdAt, order = Order.DESC)
+    limit(20)
+}
+```
+
+### `selectTyped`
+
+```kotlin
+public suspend inline fun <reified T> DatabaseClient.selectTyped(
+    table: String,
+    schema: String? = null,
+    columns: String = "*",
+    noinline block: QueryBuilder.() -> Unit = {},
+): SupabaseResult<List<T>>
+```
+
+The type-safe wrapper over `select`: decodes the JSON array body into `List<T>`.
+
+- `table` — table or view name.
+- `schema` — target schema, or default. Default `null`.
+- `columns` — `select=` projection. Default `"*"`.
+- `block` — the [query DSL](#query-and-filter-dsl).
+
+**Returns:** `SupabaseResult<List<T>>`. Decode failures and HTTP errors both come back as `Failure`.
+
+```kotlin
+val todos: SupabaseResult<List<Todo>> = database.selectTyped("todos") {
+    where { Todo.done eq false }
+}
+```
+
+### `selectTypedOrThrow`
+
+```kotlin
+public suspend inline fun <reified T> DatabaseClient.selectTypedOrThrow(
+    table: String,
+    schema: String? = null,
+    columns: String = "*",
+    noinline block: QueryBuilder.() -> Unit = {},
+): List<T>
+```
+
+The plain (no-`SupabaseResult`) form of `selectTyped`: returns the decoded
+`List<T>` directly and **throws** `SupabaseException` on failure. A natural fit
+for a paging `fetch` lambda that reports errors through its own channel.
+
+- Parameters as for [`selectTyped`](#selecttyped).
+
+**Returns:** `List<T>` (throws on failure).
+
+```kotlin
+val todos: List<Todo> = database.selectTypedOrThrow("todos")
+```
+
+### `selectSingleTyped`
+
+```kotlin
+public suspend inline fun <reified T> DatabaseClient.selectSingleTyped(
+    table: String,
+    schema: String? = null,
+    columns: String = "*",
+    noinline block: QueryBuilder.() -> Unit = {},
+): SupabaseResult<T>
+```
+
+Reads the single row matching the filters and decodes it into `T`. Requests
+`format = SINGLE`, so PostgREST returns HTTP 406 (a `Failure` with
+`SupabaseErrorCategory.NotFound`) when zero or more than one row matches.
+
+- Parameters as for [`selectTyped`](#selecttyped).
+
+**Returns:** `SupabaseResult<T>`.
+
+```kotlin
+val todo = database.selectSingleTyped<Todo>("todos") { where { Todo.id eq 7 } }
+```
+
+### `selectMaybeSingleTyped`
+
+```kotlin
+public suspend inline fun <reified T> DatabaseClient.selectMaybeSingleTyped(
+    table: String,
+    schema: String? = null,
+    columns: String = "*",
+    noinline block: QueryBuilder.() -> Unit = {},
+): SupabaseResult<T?>
+```
+
+The lenient variant of `selectSingleTyped`: reads at most one row, mapping a "no
+rows" response (HTTP 406 / `NotFound`) to `Success(null)` instead of a failure.
+Still fails if more than one row matches.
+
+- Parameters as for [`selectTyped`](#selecttyped).
+
+**Returns:** `SupabaseResult<T?>` — `Success(null)` when absent.
+
+```kotlin
+val maybe = database.selectMaybeSingleTyped<Todo>("todos") { where { Todo.id eq 7 } }
+```
+
+### `selectWithCount`
+
+```kotlin
+public suspend inline fun <reified T> DatabaseClient.selectWithCount(
+    table: String,
+    schema: String? = null,
+    columns: String = "*",
+    count: CountOption = CountOption.EXACT,
+    noinline block: QueryBuilder.() -> Unit = {},
+): SupabaseResult<PostgrestPage<T>>
+```
+
+Selects rows and decodes them into a [`PostgrestPage`](#postgrestpage) carrying the
+total `count` from PostgREST's `Content-Range` header. Combine with `limit`/`range`
+for count-aware pagination.
+
+- `count` — how the total is computed (see [`CountOption`](#countoption)). Default `CountOption.EXACT`.
+- Other parameters as for [`selectTyped`](#selecttyped).
+
+**Returns:** `SupabaseResult<PostgrestPage<T>>`.
+
+```kotlin
+val page = database.selectWithCount<Todo>("todos") { range(0, 19) }
+// page.value.rows, page.value.count
+```
+
+### `selectGeoJson`
+
+```kotlin
+public suspend fun DatabaseClient.selectGeoJson(
+    table: String,
+    schema: String? = null,
+    columns: String = "*",
+    headers: Map<String, String> = emptyMap(),
+    block: QueryBuilder.() -> Unit = {},
+): SupabaseResult<String>
+```
+
+Selects rows as a PostGIS GeoJSON `FeatureCollection`, returned as the raw JSON
+string (`Accept: application/geo+json`). Equivalent to calling `select` with
+`format = ResponseFormat.GEOJSON`.
+
+- `headers` — extra request headers. Default `emptyMap()`.
+- Other parameters as for [`selectTyped`](#selecttyped).
+
+**Returns:** `SupabaseResult<String>` — the GeoJSON document.
+
+```kotlin
+val geo = database.selectGeoJson("stores", columns = "id,name,location")
+// or: database.select("stores", format = ResponseFormat.GEOJSON)
+```
+
+### `selectCsv`
+
+```kotlin
+public suspend fun DatabaseClient.selectCsv(
+    table: String,
+    schema: String? = null,
+    columns: String = "*",
+    block: QueryBuilder.() -> Unit = {},
+): SupabaseResult<String>
+```
+
+Reads rows as CSV (`Accept: text/csv`), returned as the raw response string with a
+header row — convenient for export/download.
+
+- Parameters as for [`selectTyped`](#selecttyped).
+
+**Returns:** `SupabaseResult<String>` — the CSV text.
+
+```kotlin
+val csv = database.selectCsv("todos")
+```
+
+### `selectHead`
+
+```kotlin
+public suspend fun DatabaseClient.selectHead(
+    table: String,
+    schema: String? = null,
+    columns: String = "*",
+    count: CountOption? = null,
+    block: QueryBuilder.() -> Unit = {},
+): SupabaseResult<Unit>
+```
+
+Issues a `HEAD` request to test that a query runs or to fetch a count without
+transferring rows; the empty body is discarded. A success means the query ran — it
+does not indicate whether any row matched. For the parsed total use
+[`selectCount`](#selectcount).
+
+- `count` — when set (e.g. `CountOption.EXACT`), the total is reported in `Content-Range`. Default `null`.
+- Other parameters as for [`selectTyped`](#selecttyped).
+
+**Returns:** `SupabaseResult<Unit>`.
+
+```kotlin
+val ran = database.selectHead("todos") { where { Todo.done eq false } }
+```
+
+### `selectCount` (interface method)
+
+```kotlin
+public suspend fun selectCount(
+    table: String,
+    schema: String? = null,
+    columns: String = "*",
+    count: CountOption = CountOption.EXACT,
+    headers: Map<String, String> = emptyMap(),
+    block: QueryBuilder.() -> Unit = {},
+): SupabaseResult<PostgrestRange>
+```
+
+Issues a count-only `HEAD` request and returns the total parsed from the
+`Content-Range` header. No rows are fetched.
+
+- `count` — `EXACT` (accurate, slowest), `PLANNED`, or `ESTIMATED` (faster, approximate). Default `CountOption.EXACT`.
+- Other parameters as for [`select`](#select-interface-method).
+
+**Returns:** `SupabaseResult<PostgrestRange>` — its `count` holds the total.
+
+```kotlin
+val total = database.selectCount("todos") { where { Todo.done eq true } }
+// total.value.count
+```
+
+### `selectRange` (interface method)
+
+```kotlin
+public suspend fun selectRange(
+    table: String,
+    schema: String? = null,
+    columns: String = "*",
+    format: ResponseFormat = ResponseFormat.ROWS,
+    count: CountOption = CountOption.EXACT,
+    stripNulls: Boolean = false,
+    headers: Map<String, String> = emptyMap(),
+    block: QueryBuilder.() -> Unit = {},
+): SupabaseResult<PostgrestRawPage>
+```
+
+Like `select`, but also returns the total and the fetched range from
+`Content-Range` alongside the raw body, packaged as a
+[`PostgrestRawPage`](#postgrestrawpage) (a data class with `body`, `count`, and
+`range` — **not** a `Pair`). The typed [`selectWithCount`](#selectwithcount) sits
+on top of this and decodes `body` into a `PostgrestPage`.
+
+- `count` — total computation strategy. Default `CountOption.EXACT`.
+- Other parameters as for [`select`](#select-interface-method).
+
+**Returns:** `SupabaseResult<PostgrestRawPage>`.
+
+```kotlin
+val raw = database.selectRange("todos") { range(0, 9) }
+// raw.value.body (String), raw.value.count (Long?), raw.value.range (LongRange?)
+```
+
+### `paginator`
+
+```kotlin
+public inline fun <reified T> DatabaseClient.paginator(
+    table: String,
+    pageSize: Int = 20,
+    schema: String? = null,
+    columns: String = "*",
+    crossinline block: QueryBuilder.() -> Unit = {},
+): Paginator<T>
+```
+
+Builds a demand-driven `Paginator` over `table`, fetching one offset-based page per
+`Paginator.loadNext()` via `selectTypedOrThrow` and a `range` window. The paginator
+exposes accumulated rows and loading/end/error state as `StateFlow`s; nothing is
+fetched until you call `loadNext()`.
+
+- `table` — table or view name.
+- `pageSize` — rows per page; must be greater than 0. Default `20`.
+- `schema` — target schema. Default `null`.
+- `columns` — `select=` projection. Default `"*"`.
+- `block` — ordering and predicates; always `orderBy` a stable column. Do **not** add your own `range`/`limit`/`offset` — the paginator owns the window.
+
+**Returns:** `Paginator<T>` (from `supabase-core`).
+
+```kotlin
+val pager = database.paginator<Todo>("todos", pageSize = 20) {
+    orderBy(Todo.createdAt, order = Order.DESC)
+}
+pager.loadNext()
+```
+
+---
+
+## Writes
+
+### `insert` (interface method)
+
+```kotlin
+public suspend fun insert(
+    table: String,
+    schema: String? = null,
+    body: String,
+    columns: List<String>? = null,
+    upsert: Boolean = false,
+    upsertResolution: UpsertResolution = UpsertResolution.MERGE_DUPLICATES,
+    defaultToNull: Boolean = true,
+    onConflict: String? = null,
+    returning: ReturnOption = ReturnOption.REPRESENTATION,
+    count: CountOption? = null,
+    stripNulls: Boolean = false,
+    rollback: Boolean = false,
+    contentType: String = "application/json",
+    headers: Map<String, String> = emptyMap(),
+): SupabaseResult<String>
+```
+
+Inserts (or upserts) into `table` via `POST /rest/v1/{table}`, with `body` the JSON
+of a single object or an array (bulk insert).
+
+- `table` — target table.
+- `schema` — target schema. Default `null`.
+- `body` — the JSON object or array to write.
+- `columns` — explicit column list (`columns=`); when null it is derived for bulk inserts as the union of all rows' keys. Default `null`.
+- `upsert` — when true, turns this into an upsert (`on_conflict=` + `resolution=`). Default `false`.
+- `upsertResolution` — conflict resolution when upserting (see [`UpsertResolution`](#upsertresolution)). Default `MERGE_DUPLICATES`.
+- `defaultToNull` — when `false`, sends `missing=default` so omitted fields take their column DEFAULT instead of NULL. Default `true`.
+- `onConflict` — the unique column(s) to match on for upsert. Default `null`.
+- `returning` — whether affected rows are echoed back or the body is empty (see [`ReturnOption`](#returnoption)). Default `REPRESENTATION`.
+- `count` — adds a `count=` preference, surfacing the affected total in `Content-Range`. Default `null`.
+- `stripNulls` — omit null fields from the response. Default `false`.
+- `rollback` — when true, sends `tx=rollback` so the write is validated but not committed. Default `false`.
+- `contentType` — the request body's `Content-Type`; lets callers send e.g. a `text/csv` bulk insert. Only the header changes — `body` is sent verbatim. Default `"application/json"`.
+- `headers` — extra request headers. Default `emptyMap()`.
+
+**Returns:** `SupabaseResult<String>` — representation rows, or empty for `MINIMAL`.
+
+```kotlin
+database.insert("todos", body = """{"title":"Buy milk"}""")
+```
+
+### `insertTyped`
+
+```kotlin
+public suspend inline fun <reified T> DatabaseClient.insertTyped(
+    table: String,
+    schema: String? = null,
+    value: T,
+    columns: List<String>? = null,
+    upsert: Boolean = false,
+    upsertResolution: UpsertResolution = UpsertResolution.MERGE_DUPLICATES,
+    defaultToNull: Boolean = true,
+    onConflict: String? = null,
+): SupabaseResult<List<T>>
+```
+
+Inserts a single `value` (serialized to JSON) and returns the inserted row(s)
+decoded as `List<T>` — `insert` with `REPRESENTATION`. DB defaults/triggers are
+reflected in the decoded result.
+
+- `value` — the object to insert.
+- Other parameters as on [`insert`](#insert-interface-method).
+
+**Returns:** `SupabaseResult<List<T>>`.
+
+```kotlin
+val inserted = database.insertTyped("todos", value = Todo(title = "Buy milk"))
+```
+
+### `insertTypedMany`
+
+```kotlin
+public suspend inline fun <reified T> DatabaseClient.insertTypedMany(
+    table: String,
+    schema: String? = null,
+    values: List<T>,
+    columns: List<String>? = null,
+    upsert: Boolean = false,
+    upsertResolution: UpsertResolution = UpsertResolution.MERGE_DUPLICATES,
+    defaultToNull: Boolean = true,
+    onConflict: String? = null,
+): SupabaseResult<List<T>>
+```
+
+Bulk-inserts `values` in one request and returns the inserted rows. The union of
+all elements' keys is sent as `columns=`, so a field present on only some rows is
+still inserted rather than dropped from first-row inference.
+
+- `values` — the objects to insert.
+- Other parameters as on [`insert`](#insert-interface-method).
+
+**Returns:** `SupabaseResult<List<T>>`.
+
+```kotlin
+database.insertTypedMany("todos", values = listOf(Todo("a"), Todo("b")))
+```
+
+### `insertUnit`
+
+```kotlin
+public suspend fun DatabaseClient.insertUnit(
+    table: String,
+    schema: String? = null,
+    body: String,
+    columns: List<String>? = null,
+    upsert: Boolean = false,
+    upsertResolution: UpsertResolution = UpsertResolution.MERGE_DUPLICATES,
+    defaultToNull: Boolean = true,
+    onConflict: String? = null,
+    count: CountOption? = null,
+): SupabaseResult<Unit>
+```
+
+Inserts the raw JSON `body` without fetching the result back (`ReturnOption.MINIMAL`),
+saving the round-trip payload. `body` may be a single object or an array.
+
+- `count` — when set, learn how many rows were written via `Content-Range`. Default `null`.
+- Other parameters as on [`insert`](#insert-interface-method).
+
+**Returns:** `SupabaseResult<Unit>`.
+
+```kotlin
+database.insertUnit("todos", body = """{"title":"Buy milk"}""")
+```
+
+### `insertUnitTyped`
+
+```kotlin
+public suspend inline fun <reified T> DatabaseClient.insertUnitTyped(
+    table: String,
+    schema: String? = null,
+    value: T,
+    columns: List<String>? = null,
+    upsert: Boolean = false,
+    upsertResolution: UpsertResolution = UpsertResolution.MERGE_DUPLICATES,
+    defaultToNull: Boolean = true,
+    onConflict: String? = null,
+    count: CountOption? = null,
+): SupabaseResult<Unit>
+```
+
+The typed counterpart to `insertUnit`: serializes `value` to JSON and inserts it
+without fetching it back.
+
+- `value` — the object to insert.
+- Other parameters as on [`insertUnit`](#insertunit).
+
+**Returns:** `SupabaseResult<Unit>`.
+
+```kotlin
+database.insertUnitTyped("todos", value = Todo(title = "Buy milk"))
+```
+
+### `upsertTyped`
+
+```kotlin
+public suspend inline fun <reified T> DatabaseClient.upsertTyped(
+    table: String,
+    schema: String? = null,
+    value: T,
+    columns: List<String>? = null,
+    upsertResolution: UpsertResolution = UpsertResolution.MERGE_DUPLICATES,
+    defaultToNull: Boolean = true,
+    onConflict: String? = null,
+): SupabaseResult<List<T>>
+```
+
+Upserts a single `value` (insert-or-update on conflict) and returns the resulting
+row(s) — `insertTyped` with `upsert = true` under a clearer name.
+
+- `onConflict` — the unique column(s) PostgREST matches on. Default `null`.
+- `upsertResolution` — merge or ignore existing rows. Default `MERGE_DUPLICATES`.
+- Other parameters as on [`insertTyped`](#inserttyped).
+
+**Returns:** `SupabaseResult<List<T>>`.
+
+```kotlin
+database.upsertTyped("todos", value = todo, onConflict = "id")
+```
+
+### `upsertTypedMany`
+
+```kotlin
+public suspend inline fun <reified T> DatabaseClient.upsertTypedMany(
+    table: String,
+    schema: String? = null,
+    values: List<T>,
+    columns: List<String>? = null,
+    upsertResolution: UpsertResolution = UpsertResolution.MERGE_DUPLICATES,
+    defaultToNull: Boolean = true,
+    onConflict: String? = null,
+): SupabaseResult<List<T>>
+```
+
+Bulk upserts `values` in one request and returns the resulting rows — the
+multi-row form of `upsertTyped`.
+
+- Parameters as on [`upsertTyped`](#upserttyped), with `values` in place of `value`.
+
+**Returns:** `SupabaseResult<List<T>>`.
+
+```kotlin
+database.upsertTypedMany("todos", values = todos, onConflict = "id")
+```
+
+### `update` (interface method)
+
+```kotlin
+public suspend fun update(
+    table: String,
+    schema: String? = null,
+    body: String,
+    returning: ReturnOption = ReturnOption.REPRESENTATION,
+    count: CountOption? = null,
+    stripNulls: Boolean = false,
+    rollback: Boolean = false,
+    maxAffected: Int? = null,
+    explain: ExplainOptions? = null,
+    headers: Map<String, String> = emptyMap(),
+    block: WhereBuilder.() -> Unit = {},
+): SupabaseResult<String>
+```
+
+Updates rows matching the filters via `PATCH /rest/v1/{table}`, applying the
+partial JSON object in `body` to every matched row. The mutation `block` is a
+**filter-only** `WhereBuilder` — there is no order/limit. An empty filter set
+updates the whole table.
+
+- `table` — target table.
+- `schema` — target schema. Default `null`.
+- `body` — the partial JSON object to apply.
+- `returning` — shape the echoed body (see [`ReturnOption`](#returnoption)). Default `REPRESENTATION`.
+- `count` — adds a `count=` preference, surfacing the affected total. Default `null`.
+- `stripNulls` — omit null fields from the response. Default `false`.
+- `rollback` — validate without committing (`tx=rollback`). Default `false`.
+- `maxAffected` — when set (must be > 0), caps the rows modified (`handling=strict` + `max-affected=`), failing rather than touching more. Default `null`.
+- `explain` — returns the query plan instead of mutating. Default `null`.
+- `headers` — extra request headers. Default `emptyMap()`.
+- `block` — the [filter DSL](#wherebuilder) (filter only).
+
+**Returns:** `SupabaseResult<String>`.
+
+```kotlin
+database.update("todos", body = """{"done":true}""") { Todo.id eq 7 }
+```
+
+### `updateTyped`
+
+```kotlin
+public suspend inline fun <reified T> DatabaseClient.updateTyped(
+    table: String,
+    schema: String? = null,
+    value: T,
+    noinline block: WhereBuilder.() -> Unit = {},
+): SupabaseResult<List<T>>
+```
+
+Updates rows matching the filters with the fields of `value` and returns the
+updated rows. `value` is applied as a partial update.
+
+<Callout type="warning">
+`null` fields of `value` are **omitted** from the request (the serializer uses
+`explicitNulls = false`), so they leave the existing column untouched rather than
+overwriting it with `NULL`. To clear a column to `NULL`, use [`update`](#update-interface-method)
+with a raw JSON body (e.g. `{"avatar_url": null}`).
+</Callout>
+
+- `value` — the object whose non-null fields are written.
+- `block` — the [filter DSL](#wherebuilder).
+
+**Returns:** `SupabaseResult<List<T>>`.
+
+```kotlin
+database.updateTyped("todos", value = Todo(done = true)) { Todo.id eq 7 }
+```
+
+### `updateUnit`
+
+```kotlin
+public suspend fun DatabaseClient.updateUnit(
+    table: String,
+    schema: String? = null,
+    body: String,
+    count: CountOption? = null,
+    block: WhereBuilder.() -> Unit = {},
+): SupabaseResult<Unit>
+```
+
+Updates rows matching the filters with the raw JSON `body` without fetching the
+result back (`ReturnOption.MINIMAL`). An empty filter block updates every row.
+
+- `count` — learn how many rows changed via `Content-Range`. Default `null`.
+- Other parameters as on [`update`](#update-interface-method).
+
+**Returns:** `SupabaseResult<Unit>`.
+
+```kotlin
+database.updateUnit("todos", body = """{"done":true}""") { Todo.id eq 7 }
+```
+
+### `updateUnitTyped`
+
+```kotlin
+public suspend inline fun <reified T> DatabaseClient.updateUnitTyped(
+    table: String,
+    schema: String? = null,
+    value: T,
+    count: CountOption? = null,
+    noinline block: WhereBuilder.() -> Unit = {},
+): SupabaseResult<Unit>
+```
+
+The typed counterpart to `updateUnit`: serializes `value` and updates without
+fetching rows back. As with `updateTyped`, `null` fields of `value` are omitted
+(not written as `NULL`).
+
+- `value` — the object whose non-null fields are written.
+- `count` — affected total via `Content-Range`. Default `null`.
+- `block` — the [filter DSL](#wherebuilder).
+
+**Returns:** `SupabaseResult<Unit>`.
+
+```kotlin
+database.updateUnitTyped("todos", value = Todo(done = true)) { Todo.id eq 7 }
+```
+
+### `replace` (interface method)
+
+```kotlin
+public suspend fun replace(
+    table: String,
+    body: String,
+    returning: ReturnOption = ReturnOption.REPRESENTATION,
+    columns: String = "*",
+    block: WhereBuilder.() -> Unit = {},
+): SupabaseResult<String>
+```
+
+Replaces (or inserts) a single row via `PUT /rest/v1/{table}` — the
+replace-by-primary-key write. Unlike `update`'s partial `PATCH`, this is a full-row
+replace: `body` must carry **every** column (including the primary key), and the
+filter must select **exactly** that primary key. PostgREST replaces the matching
+row, or inserts the row when none matches.
+
+- `table` — target table.
+- `body` — the complete JSON object (every column).
+- `returning` — whether the affected row is echoed back or the body is empty. Default `REPRESENTATION`.
+- `columns` — the `select=` projection applied to the returned representation. Default `"*"`.
+- `block` — the [filter DSL](#wherebuilder), selecting exactly the primary key.
+
+**Returns:** `SupabaseResult<String>` — the replaced row, or empty for non-representation returns.
+
+```kotlin
+database.replace("todos", body = """{"id":7,"title":"Buy milk","done":true}""") {
+    Todo.id eq 7
+}
+```
+
+### `delete` (interface method)
+
+```kotlin
+public suspend fun delete(
+    table: String,
+    schema: String? = null,
+    returning: ReturnOption = ReturnOption.REPRESENTATION,
+    count: CountOption? = null,
+    stripNulls: Boolean = false,
+    rollback: Boolean = false,
+    maxAffected: Int? = null,
+    explain: ExplainOptions? = null,
+    headers: Map<String, String> = emptyMap(),
+    block: WhereBuilder.() -> Unit = {},
+): SupabaseResult<String>
+```
+
+Deletes rows matching the filters via `DELETE /rest/v1/{table}`. As with `update`,
+the rows removed are exactly those the filter selects, so an empty filter set
+deletes the whole table — guard large or accidental deletes with `maxAffected`.
+
+- `table` — target table.
+- `schema` — target schema. Default `null`.
+- `returning` — whether deleted rows are echoed back or the body is empty. Default `REPRESENTATION`.
+- `count` — affected total via `Content-Range`. Default `null`.
+- `stripNulls` — omit null fields from the response. Default `false`.
+- `rollback` — validate without committing. Default `false`.
+- `maxAffected` — when set (> 0), caps the rows deleted, failing rather than removing more. Default `null`.
+- `explain` — returns the query plan instead of deleting. Default `null`.
+- `headers` — extra request headers. Default `emptyMap()`.
+- `block` — the [filter DSL](#wherebuilder).
+
+**Returns:** `SupabaseResult<String>`.
+
+```kotlin
+database.delete("todos") { Todo.id eq 7 }
+```
+
+### `deleteTyped`
+
+```kotlin
+public suspend inline fun <reified T> DatabaseClient.deleteTyped(
+    table: String,
+    schema: String? = null,
+    returning: ReturnOption = ReturnOption.REPRESENTATION,
+    count: CountOption? = null,
+    noinline block: WhereBuilder.() -> Unit = {},
+): SupabaseResult<List<T>>
+```
+
+Deletes rows matching the filters and returns the deleted rows as `List<T>` —
+useful when you need the removed data (e.g. to undo or audit).
+
+- Parameters as on [`delete`](#delete-interface-method).
+
+**Returns:** `SupabaseResult<List<T>>`.
+
+```kotlin
+val removed = database.deleteTyped<Todo>("todos") { Todo.done eq true }
+```
+
+### `deleteUnit`
+
+```kotlin
+public suspend fun DatabaseClient.deleteUnit(
+    table: String,
+    schema: String? = null,
+    count: CountOption? = null,
+    block: WhereBuilder.() -> Unit = {},
+): SupabaseResult<Unit>
+```
+
+Deletes rows matching the filters without fetching them back
+(`ReturnOption.MINIMAL`). An empty filter block deletes every row.
+
+- `count` — learn how many rows were removed via `Content-Range`. Default `null`.
+- Other parameters as on [`delete`](#delete-interface-method).
+
+**Returns:** `SupabaseResult<Unit>`.
+
+```kotlin
+database.deleteUnit("todos") { Todo.id eq 7 }
+```
+
+---
+
+## RPC (stored procedures)
+
+PostgREST exposes stored procedures both as `POST /rest/v1/rpc/{function}` (the
+mutating form, in [`rpc`](#rpc-interface-method)) and `GET /rest/v1/rpc/{function}`
+(the cacheable, read-only form, in [`rpcGet`](#rpcget-interface-method)). Each has a
+family of typed wrappers; most come in two overloads — one taking a raw JSON
+`params` string (or a `Map` for GET), and one taking a serializable `params`
+object that is encoded for you.
+
+### `rpc` (interface method)
+
+```kotlin
+public suspend fun rpc(
+    function: String,
+    schema: String? = null,
+    params: String? = null,
+    format: ResponseFormat = ResponseFormat.ROWS,
+    count: CountOption? = null,
+    stripNulls: Boolean = false,
+    rollback: Boolean = false,
+    maxAffected: Int? = null,
+    explain: ExplainOptions? = null,
+    contentType: String = "application/json",
+    headers: Map<String, String> = emptyMap(),
+    block: QueryBuilder.() -> Unit = {},
+): SupabaseResult<String>
+```
+
+Calls a stored procedure (`POST`) with `params` as the JSON request body. Suitable
+for functions with side effects or large argument payloads; for a read-only
+function prefer [`rpcGet`](#rpcget-interface-method).
+
+- `function` — the function name.
+- `schema` — target schema. Default `null`.
+- `params` — JSON object of named arguments, or null for a no-argument call. Default `null`.
+- `format` — body shape (see [`ResponseFormat`](#responseformat)). Default `ROWS`.
+- `count` — adds a `count=` preference. Default `null`.
+- `stripNulls` — omit null fields from the response. Default `false`.
+- `rollback` — roll back any writes (`tx=rollback`). Default `false`.
+- `maxAffected` — when set (> 0), caps rows the function may modify. Default `null`.
+- `explain` — returns the plan. Default `null`.
+- `contentType` — request body `Content-Type`; lets you send a scalar body (e.g. `text/plain`) to a single-parameter function. `params` is sent verbatim. Default `"application/json"`.
+- `headers` — extra request headers. Default `emptyMap()`.
+- `block` — PostgREST filters/ordering/pagination applied to a set-returning function's rows (the [query DSL](#query-and-filter-dsl)).
+
+**Returns:** `SupabaseResult<String>`.
+
+```kotlin
+database.rpc("increment", params = """{"row_id":7}""")
+```
+
+### `rpcTyped`
+
+```kotlin
+public suspend inline fun <reified T> DatabaseClient.rpcTyped(
+    function: String, schema: String? = null, params: String? = null,
+): SupabaseResult<T>
+
+public suspend inline fun <reified Request : Any, reified Response> DatabaseClient.rpcTyped(
+    function: String, schema: String? = null, params: Request,
+): SupabaseResult<Response>
+```
+
+Calls a stored procedure (POST) and decodes its result into `T`/`Response`. The
+second overload serializes a `params` object to a JSON object for you.
+
+- `function` — the function name.
+- `schema` — target schema. Default `null`.
+- `params` — raw JSON string (or null), or a serializable arguments object.
+
+**Returns:** `SupabaseResult<T>` (or `SupabaseResult<Response>`).
+
+```kotlin
+val total: SupabaseResult<Int> = database.rpcTyped("count_open_todos")
+```
+
+### `rpcListTyped`
+
+```kotlin
+public suspend inline fun <reified T> DatabaseClient.rpcListTyped(
+    function: String, schema: String? = null, params: String? = null,
+): SupabaseResult<List<T>>
+
+public suspend inline fun <reified Request : Any, reified Response> DatabaseClient.rpcListTyped(
+    function: String, schema: String? = null, params: Request,
+): SupabaseResult<List<Response>>
+```
+
+The list-result form of `rpcTyped` for set-returning functions: decodes into
+`List<T>`/`List<Response>`.
+
+- Parameters as on [`rpcTyped`](#rpctyped).
+
+**Returns:** `SupabaseResult<List<T>>`.
+
+```kotlin
+val rows = database.rpcListTyped<Todo>("search_todos", params = """{"q":"milk"}""")
+```
+
+### `rpcSingleTyped`
+
+```kotlin
+public suspend inline fun <reified T> DatabaseClient.rpcSingleTyped(
+    function: String, schema: String? = null, params: String? = null,
+): SupabaseResult<T>
+
+public suspend inline fun <reified Request : Any, reified Response> DatabaseClient.rpcSingleTyped(
+    function: String, schema: String? = null, params: Request,
+): SupabaseResult<Response>
+```
+
+Calls a procedure expecting exactly one row/scalar, decoded into `T`. Requests
+`format = SINGLE`, so zero or more than one row fails with HTTP 406 / `NotFound`.
+
+- Parameters as on [`rpcTyped`](#rpctyped).
+
+**Returns:** `SupabaseResult<T>`.
+
+```kotlin
+val one = database.rpcSingleTyped<Todo>("latest_todo")
+```
+
+### `rpcMaybeSingleTyped`
+
+```kotlin
+public suspend inline fun <reified T> DatabaseClient.rpcMaybeSingleTyped(
+    function: String, schema: String? = null, params: String? = null,
+): SupabaseResult<T?>
+
+public suspend inline fun <reified Request : Any, reified Response> DatabaseClient.rpcMaybeSingleTyped(
+    function: String, schema: String? = null, params: Request,
+): SupabaseResult<Response?>
+```
+
+The lenient variant of `rpcSingleTyped`: a "no rows" response (HTTP 406 /
+`NotFound`) maps to `Success(null)`; other failures propagate.
+
+- Parameters as on [`rpcTyped`](#rpctyped).
+
+**Returns:** `SupabaseResult<T?>`.
+
+```kotlin
+val maybe = database.rpcMaybeSingleTyped<Todo>("latest_todo")
+```
+
+### `rpcUnit`
+
+```kotlin
+public suspend fun DatabaseClient.rpcUnit(
+    function: String, schema: String? = null, params: String? = null,
+): SupabaseResult<Unit>
+
+public suspend inline fun <reified Request : Any> DatabaseClient.rpcUnit(
+    function: String, schema: String? = null, params: Request,
+): SupabaseResult<Unit>
+```
+
+Calls a procedure (POST) for its side effects, discarding the result.
+
+- Parameters as on [`rpcTyped`](#rpctyped).
+
+**Returns:** `SupabaseResult<Unit>`.
+
+```kotlin
+database.rpcUnit("reset_counters")
+```
+
+### `rpcCsv`
+
+```kotlin
+public suspend fun DatabaseClient.rpcCsv(
+    function: String, schema: String? = null, params: String? = null,
+): SupabaseResult<String>
+
+public suspend inline fun <reified Request : Any> DatabaseClient.rpcCsv(
+    function: String, schema: String? = null, params: Request,
+): SupabaseResult<String>
+```
+
+Calls a procedure (POST) requesting `text/csv`, returning the raw CSV string.
+
+- Parameters as on [`rpcTyped`](#rpctyped).
+
+**Returns:** `SupabaseResult<String>`.
+
+```kotlin
+val csv = database.rpcCsv("export_todos")
+```
+
+### `rpcHead`
+
+```kotlin
+public suspend fun DatabaseClient.rpcHead(
+    function: String, schema: String? = null, params: String? = null,
+    count: CountOption? = null,
+): SupabaseResult<Unit>
+
+public suspend inline fun <reified Request : Any> DatabaseClient.rpcHead(
+    function: String, schema: String? = null, params: Request,
+    count: CountOption? = null,
+): SupabaseResult<Unit>
+```
+
+Issues a procedure (POST) as a `HEAD` request for its headers/`count` only,
+discarding the empty body.
+
+- `count` — when set, the total is reported via `Content-Range`. Default `null`.
+- Other parameters as on [`rpcTyped`](#rpctyped).
+
+**Returns:** `SupabaseResult<Unit>`.
+
+```kotlin
+database.rpcHead("count_open_todos", count = CountOption.EXACT)
+```
+
+### `rpcGet` (interface method)
+
+```kotlin
+public suspend fun rpcGet(
+    function: String,
+    schema: String? = null,
+    queryParams: List<Pair<String, String>> = emptyList(),
+    format: ResponseFormat = ResponseFormat.ROWS,
+    count: CountOption? = null,
+    stripNulls: Boolean = false,
+    explain: ExplainOptions? = null,
+    retry: Boolean = true,
+    headers: Map<String, String> = emptyMap(),
+): SupabaseResult<String>
+```
+
+Calls a stored procedure over `GET`, passing arguments as `queryParams` rather than
+a body — the cacheable, side-effect-free counterpart to `rpc` for functions marked
+`STABLE`/`IMMUTABLE`.
+
+- `function` — the function name.
+- `schema` — target schema. Default `null`.
+- `queryParams` — ordered list of name/value argument pairs. Default `emptyList()`.
+- `format` — body shape. Default `ROWS`.
+- `count` — adds a `count=` preference. Default `null`.
+- `stripNulls` — omit null fields. Default `false`.
+- `explain` — returns the plan. Default `null`.
+- `retry` — whether this read may be transparently retried. Default `true`.
+- `headers` — extra request headers. Default `emptyMap()`.
+
+**Returns:** `SupabaseResult<String>`.
+
+```kotlin
+database.rpcGet("hello", queryParams = listOf("name" to "Ada"))
+```
+
+### `rpcGet` (Map and object overloads)
+
+```kotlin
+public suspend fun DatabaseClient.rpcGet(
+    function: String, schema: String? = null,
+    queryParams: Map<String, String>,
+): SupabaseResult<String>
+
+public suspend fun DatabaseClient.rpcGet(
+    function: String, schema: String? = null,
+    queryParams: Map<String, String>,
+    format: ResponseFormat = ResponseFormat.ROWS,
+    count: CountOption? = null,
+): SupabaseResult<String>
+
+public suspend inline fun <reified Request : Any> DatabaseClient.rpcGet(
+    function: String, schema: String? = null, params: Request,
+): SupabaseResult<String>
+```
+
+`Map`-based and serializable-object conveniences over the pair-list interface
+method. The object overload flattens the request's top-level fields into query
+arguments (object/array values re-encoded as JSON strings); a `null` argument is
+omitted so the function receives its SQL default.
+
+- `queryParams` — named arguments as a `Map` (RPC arguments are named).
+- `params` — a serializable arguments object.
+- `format` / `count` — as on [`rpcGet`](#rpcget-interface-method).
+
+**Returns:** `SupabaseResult<String>`.
+
+```kotlin
+database.rpcGet("hello", queryParams = mapOf("name" to "Ada"))
+```
+
+### `rpcGetTyped`
+
+```kotlin
+public suspend inline fun <reified T> DatabaseClient.rpcGetTyped(
+    function: String, schema: String? = null,
+    queryParams: Map<String, String> = emptyMap(),
+): SupabaseResult<T>
+
+public suspend inline fun <reified Request : Any, reified Response> DatabaseClient.rpcGetTyped(
+    function: String, schema: String? = null, params: Request,
+): SupabaseResult<Response>
+```
+
+The GET counterpart of `rpcTyped`: calls a read-only procedure and decodes the
+result into `T`/`Response`.
+
+- `queryParams` — named arguments. Default `emptyMap()`.
+- `params` — a serializable arguments object.
+
+**Returns:** `SupabaseResult<T>`.
+
+```kotlin
+val greeting = database.rpcGetTyped<String>("hello", mapOf("name" to "Ada"))
+```
+
+### `rpcGetListTyped`
+
+```kotlin
+public suspend inline fun <reified T> DatabaseClient.rpcGetListTyped(
+    function: String, schema: String? = null,
+    queryParams: Map<String, String> = emptyMap(),
+): SupabaseResult<List<T>>
+
+public suspend inline fun <reified Request : Any, reified Response> DatabaseClient.rpcGetListTyped(
+    function: String, schema: String? = null, params: Request,
+): SupabaseResult<List<Response>>
+```
+
+The GET counterpart of `rpcListTyped` for set-returning read-only functions.
+
+- Parameters as on [`rpcGetTyped`](#rpcgettyped).
+
+**Returns:** `SupabaseResult<List<T>>`.
+
+```kotlin
+val rows = database.rpcGetListTyped<Todo>("search_todos", mapOf("q" to "milk"))
+```
+
+### `rpcGetSingleTyped`
+
+```kotlin
+public suspend inline fun <reified T> DatabaseClient.rpcGetSingleTyped(
+    function: String, schema: String? = null,
+    queryParams: Map<String, String> = emptyMap(),
+): SupabaseResult<T>
+
+public suspend inline fun <reified Request : Any, reified Response> DatabaseClient.rpcGetSingleTyped(
+    function: String, schema: String? = null, params: Request,
+): SupabaseResult<Response>
+```
+
+The GET counterpart of `rpcSingleTyped`. Fails with HTTP 406 / `NotFound` when not
+exactly one row is returned.
+
+- Parameters as on [`rpcGetTyped`](#rpcgettyped).
+
+**Returns:** `SupabaseResult<T>`.
+
+```kotlin
+val one = database.rpcGetSingleTyped<Todo>("latest_todo")
+```
+
+### `rpcGetMaybeSingleTyped`
+
+```kotlin
+public suspend inline fun <reified T> DatabaseClient.rpcGetMaybeSingleTyped(
+    function: String, schema: String? = null,
+    queryParams: Map<String, String> = emptyMap(),
+): SupabaseResult<T?>
+
+public suspend inline fun <reified Request : Any, reified Response> DatabaseClient.rpcGetMaybeSingleTyped(
+    function: String, schema: String? = null, params: Request,
+): SupabaseResult<Response?>
+```
+
+The GET, lenient counterpart of `rpcSingleTyped`: "no rows" (HTTP 406 / `NotFound`)
+maps to `Success(null)`.
+
+- Parameters as on [`rpcGetTyped`](#rpcgettyped).
+
+**Returns:** `SupabaseResult<T?>`.
+
+```kotlin
+val maybe = database.rpcGetMaybeSingleTyped<Todo>("latest_todo")
+```
+
+### `rpcGetUnit`
+
+```kotlin
+public suspend fun DatabaseClient.rpcGetUnit(
+    function: String, schema: String? = null,
+    queryParams: Map<String, String> = emptyMap(),
+): SupabaseResult<Unit>
+
+public suspend inline fun <reified Request : Any> DatabaseClient.rpcGetUnit(
+    function: String, schema: String? = null, params: Request,
+): SupabaseResult<Unit>
+```
+
+Calls a read-only procedure (GET) for its effect alone, discarding the body.
+
+- Parameters as on [`rpcGetTyped`](#rpcgettyped).
+
+**Returns:** `SupabaseResult<Unit>`.
+
+```kotlin
+database.rpcGetUnit("ping")
+```
+
+### `rpcGetCsv`
+
+```kotlin
+public suspend fun DatabaseClient.rpcGetCsv(
+    function: String, schema: String? = null,
+    queryParams: Map<String, String> = emptyMap(),
+): SupabaseResult<String>
+
+public suspend inline fun <reified Request : Any> DatabaseClient.rpcGetCsv(
+    function: String, schema: String? = null, params: Request,
+): SupabaseResult<String>
+```
+
+The GET counterpart of `rpcCsv`: requests `text/csv` and returns the raw CSV string.
+
+- Parameters as on [`rpcGetTyped`](#rpcgettyped).
+
+**Returns:** `SupabaseResult<String>`.
+
+```kotlin
+val csv = database.rpcGetCsv("export_todos")
+```
+
+### `rpcGetHead`
+
+```kotlin
+public suspend fun DatabaseClient.rpcGetHead(
+    function: String, schema: String? = null,
+    queryParams: Map<String, String> = emptyMap(),
+    count: CountOption? = null,
+): SupabaseResult<Unit>
+
+public suspend inline fun <reified Request : Any> DatabaseClient.rpcGetHead(
+    function: String, schema: String? = null, params: Request,
+    count: CountOption? = null,
+): SupabaseResult<Unit>
+```
+
+The GET counterpart of `rpcHead`: issues a `HEAD` for headers/`count` only,
+discarding the empty body.
+
+- `count` — when set, total via `Content-Range`. Default `null`.
+- Other parameters as on [`rpcGetTyped`](#rpcgettyped).
+
+**Returns:** `SupabaseResult<Unit>`.
+
+```kotlin
+database.rpcGetHead("count_open_todos", count = CountOption.EXACT)
+```
+
+---
+
+## Query and filter DSL
+
+Reads take a `QueryBuilder` block (filters **plus** result modifiers); mutations
+(`update`/`delete`/`replace`) take a filter-only `WhereBuilder` block. These DSL
+types are provided by `supabase-core` (`io.github.androidpoet.supabase.core.models`)
+and re-used here.
+
+### `QueryBuilder`
+
+The receiver of the read-query block. Combines a `where { }` predicate with result
+modifiers; modifiers are kept distinct from filters.
+
+| Member | Signature | Effect |
+| --- | --- | --- |
+| `where` | `where(block: WhereBuilder.() -> Unit)` | Filter predicate; multiple statements are AND-ed. |
+| `orderBy` | `orderBy(column: Column<*>, order: Order = Order.ASC, nulls: Nulls? = null, referencedTable: String? = null)` | Sort key; successive calls add secondary keys into one `order=` param. |
+| `limit` | `limit(count: Int, referencedTable: String? = null)` | Cap rows; last call wins. |
+| `offset` | `offset(count: Int, referencedTable: String? = null)` | Skip rows; last call wins. |
+| `range` | `range(from: Int, to: Int, referencedTable: String? = null)` | Inclusive zero-based window `[from, to]`, emitted as `offset` + derived `limit`. Requires `to >= from`. |
+
+```kotlin
+database.selectTyped<Todo>("todos") {
+    where { Todo.done eq false }
+    orderBy(Todo.createdAt, order = Order.DESC, nulls = Nulls.LAST)
+    range(0, 19)
+}
+```
+
+### `WhereBuilder`
+
+Builds a `Filter` from column predicates combined with infix operators. Each
+statement adds one predicate; multiple statements are AND-ed. String operands are
+escaped per PostgREST's quoting rules; numbers and booleans are emitted verbatim.
+
+**Comparison:** `eq`, `neq`, `greater`, `greaterEq`, `less`, `lessEq`,
+`within` (a `ClosedRange`, inclusive), `isDistinctFrom` (null-aware `IS DISTINCT FROM`).
+
+**Null / boolean IS:** `isNull()`, `isNotNull()`, `isExactly` (`IS TRUE/FALSE`).
+
+**Pattern matching:** `like`, `ilike`, `matches` (POSIX `~`), `imatches` (`~*`),
+`likeAllOf`, `likeAnyOf`, `ilikeAllOf`, `ilikeAnyOf` (each taking a `List<String>`).
+
+**Membership:** `inList`, `notInList` (each taking a `List<T>`).
+
+**Array:** `contains` (`@>`), `containedBy` (`<@`), `overlaps` (`&&`) — on `Column<List<T>>`.
+
+**Range columns:** `rangeGt` (`sr`), `rangeGte` (`nxl`), `rangeLt` (`sl`),
+`rangeLte` (`nxr`), `rangeAdjacent` (`adj`) — each takes a range literal `String`.
+
+**Full-text search:** `textSearch(query: String, config: String? = null, type: TextSearchType = TextSearchType.Plain)`.
+
+**Escape hatch:** `raw(column: Column<*>, operator: String, value: String)` — emits `column=<operator>.<value>` for operators the DSL doesn't expose yet.
+
+**Logical groups:** `or(referencedTable: String? = null, block)`, `and(referencedTable: String? = null, block)`, `not(block)`.
+
+```kotlin
+database.deleteTyped<Todo>("todos") {
+    Todo.done eq true
+    or {
+        Todo.priority greater 5
+        Todo.title ilike "%urgent%"
+    }
+}
+```
+
+### `Column`
+
+```kotlin
+@JvmInline
+public value class Column<T>(public val name: String)
+```
+
+A type-safe handle to a column, carrying its wire `name` and Kotlin type `T` so the
+compiler rejects type-mismatched comparisons. Declare columns by hand, or let
+codegen emit a typed schema object.
+
+```kotlin
+object Todo {
+    val id = Column<Int>("id")
+    val title = Column<String>("title")
+    val done = Column<Boolean>("done")
+}
+```
+
+---
+
+## Models and enums
+
+### `ResponseFormat`
+
+```kotlin
+public enum class ResponseFormat { ROWS, SINGLE, CSV, GEOJSON, HEAD }
+```
+
+The mutually-exclusive body shape a read requests via its `Accept` header (one enum
+rather than parallel `single`/`csv`/`geojson`/`head` booleans, so illegal
+combinations are unrepresentable).
+
+- `ROWS` — the default JSON array.
+- `SINGLE` — expects exactly one row (`application/vnd.pgrst.object+json`; 406 otherwise).
+- `CSV` — returns `text/csv`.
+- `GEOJSON` — returns a PostGIS `FeatureCollection`.
+- `HEAD` — requests headers only and yields an empty body; pair with a `count` to fetch just a total.
+
+```kotlin
+database.select("stores", format = ResponseFormat.GEOJSON)
+```
+
+### `CountOption`
+
+```kotlin
+public enum class CountOption { EXACT, PLANNED, ESTIMATED }
+```
+
+How PostgREST should compute the total row count (the `count=` directive of the
+`Prefer` header); the result is surfaced in `Content-Range`.
+
+- `EXACT` — full count, accurate but slowest.
+- `PLANNED` — the query planner's estimate (fast).
+- `ESTIMATED` — the planner estimate, possibly falling back to an exact count for small results.
+
+### `ReturnOption`
+
+```kotlin
+public enum class ReturnOption { MINIMAL, REPRESENTATION, HEADERS_ONLY }
+```
+
+What a write should return (the `return=` directive of the `Prefer` header).
+
+- `MINIMAL` — empty body (used by the `*Unit` helpers).
+- `REPRESENTATION` — echoes the affected rows back (so typed helpers can decode them).
+- `HEADERS_ONLY` — empty body but keeps headers such as `Location` populated.
+
+### `UpsertResolution`
+
+```kotlin
+public enum class UpsertResolution { MERGE_DUPLICATES, IGNORE_DUPLICATES }
+```
+
+How an upsert resolves a conflict on the target key (the `resolution=` directive),
+used when `upsert` is enabled.
+
+- `MERGE_DUPLICATES` — update the existing row with the incoming values.
+- `IGNORE_DUPLICATES` — leave the existing row untouched.
+
+### `ExplainFormat`
+
+```kotlin
+public enum class ExplainFormat { TEXT, JSON, XML, YAML }
+```
+
+Output format for an `EXPLAIN` plan, selecting the
+`application/vnd.pgrst.plan+<format>` media type via [`ExplainOptions`](#explainoptions).
+
+### `ExplainOptions`
+
+```kotlin
+public data class ExplainOptions(
+    public val analyze: Boolean = false,
+    public val verbose: Boolean = false,
+    public val settings: Boolean = false,
+    public val buffers: Boolean = false,
+    public val wal: Boolean = false,
+    public val format: ExplainFormat = ExplainFormat.TEXT,
+)
+```
+
+Requests a PostgREST query plan (`EXPLAIN`) instead of executing the request for its
+result. Pass an instance to `select`, `update`, `delete`, or the `rpc` calls to have
+them return the plan text in the body rather than rows.
+
+- `analyze` — actually run the query and report real timings, not just the estimate. Default `false`.
+- `verbose` — include additional per-node detail. Default `false`.
+- `settings` — include configuration parameters that affect planning. Default `false`.
+- `buffers` — include buffer usage (requires `analyze`). Default `false`.
+- `wal` — include write-ahead-log usage (requires `analyze`). Default `false`.
+- `format` — the rendering format (see [`ExplainFormat`](#explainformat)). Default `ExplainFormat.TEXT`.
+
+```kotlin
+val plan = database.select("todos", explain = ExplainOptions(analyze = true))
+```
+
+### `PostgrestRange`
+
+```kotlin
+public data class PostgrestRange(
+    public val count: Long? = null,
+    public val range: LongRange? = null,
+)
+```
+
+The count and row range parsed from a `Content-Range` response header. For
+`Content-Range: 0-9/27`, `range` is `0..9` and `count` is `27`. Either part may be
+absent — `*` maps to `null` rather than failing. Returned by
+[`selectCount`](#selectcount-interface-method).
+
+### `PostgrestRawPage`
+
+```kotlin
+public data class PostgrestRawPage(
+    public val body: String,
+    public val count: Long? = null,
+    public val range: LongRange? = null,
+)
+```
+
+The raw response `body` of a [`selectRange`](#selectrange-interface-method) together
+with the total `count` and fetched `range` from `Content-Range`. The string analogue
+of `PostgrestPage` — **not** a `Pair`. The typed `selectWithCount` helper decodes
+`body` into a `PostgrestPage`.
+
+### `PostgrestPage`
+
+```kotlin
+public data class PostgrestPage<T>(
+    public val rows: List<T>,
+    public val count: Long? = null,
+    public val range: LongRange? = null,
+)
+```
+
+A page of decoded `rows` together with the total `count` reported by PostgREST.
+Produced by [`selectWithCount`](#selectwithcount).
+
+---
+
+## Design notes
+
+### `select` returns `String`; `selectTyped` is a separate name
+
+The interface method `select(...)` returns `SupabaseResult<String>` — the raw JSON
+escape hatch — while decoding into a `List<T>` is done by the **separate** `reified
+inline` extension `selectTyped<T>` (and `selectSingleTyped<T>` → `T`,
+`selectMaybeSingleTyped<T>` → `T?`). This split is deliberate and forced by the
+language:
+
+- Decoding the body into `T` needs the concrete type at runtime, which on Kotlin
+  Multiplatform means a `reified` type parameter.
+- A `reified` type parameter requires an `inline` function, and **an interface
+  method cannot be `inline`** (there is no body to inline at the call site, and a
+  virtual call can't carry a reified type). So the typed variant cannot live on the
+  `DatabaseClient` interface — it has to be a top-level extension.
+- A single function can't return both `String` and `List<T>`, and adding a typed
+  *overload* of `select` would create resolution ambiguity (the compiler couldn't
+  always tell the raw call from the typed one). Giving the typed variant its own
+  name — `selectTyped` — removes the ambiguity and makes the choice explicit at the
+  call site.
+
+The same reasoning produces the `*Typed`/`*Unit`/`*Csv` naming across the whole
+module: the interface holds the small set of raw, string-returning primitives
+(`select`, `insert`, `update`, `replace`, `delete`, `rpc`, `rpcGet`,
+`selectCount`, `selectRange`), and the ergonomic typed layer is a set of reified
+extensions on top.
+
+### Raw primitives vs. the decoding layer
+
+Keeping the wire-level methods on the interface and the serialization in extensions
+separates two concerns cleanly. The interface is a thin, mockable contract that owns
+exactly one thing — turning a call into one HTTP request and handing back the body
+and headers. Serialization policy (which `kotlinx.serialization` settings, how
+`null` fields are treated, how a "no rows" 406 becomes `Success(null)`) lives
+entirely in the extension layer, where it can evolve without changing the interface
+and where every helper is a pure, testable transformation over the same primitive.
+It also leaves the raw `String` methods available as an escape hatch for responses
+the typed helpers don't model (custom media types, hand-built queries, streaming the
+body elsewhere).

--- a/website/pages/reference/e2ee.mdx
+++ b/website/pages/reference/e2ee.mdx
@@ -1,0 +1,343 @@
+---
+title: End-to-End Encryption — API Reference
+description: Complete public API for supabase-e2ee — ECDH P-256 key pairs, HKDF-SHA256 key agreement, and AES-256-GCM encrypt/decrypt so Supabase only ever stores ciphertext.
+---
+
+import { Callout } from 'nextra/components'
+
+# End-to-End Encryption — API Reference
+
+`supabase-e2ee` is an optional, client-side end-to-end encryption module. It lets
+two devices derive the **same** symmetric key on-device — never sending it to the
+server — so anything you store in Supabase is opaque ciphertext the backend cannot
+read. The flow follows the cryptography-kotlin secure-messaging recipe:
+
+```
+ECDH (P-256) → HKDF-SHA256 → AES-256-GCM
+```
+
+Each side generates an ECDH P-256 key pair, publishes only its **public** key, and
+runs an ECDH agreement against the peer's public key. The raw shared secret is never
+used directly as a key; it is run through HKDF-SHA256 to produce a 256-bit AES key.
+That key encrypts and decrypts data with AES-GCM, an authenticated cipher whose
+nonce is embedded in the ciphertext.
+
+**Maven artifact**
+
+```kotlin
+implementation("io.github.androidpoet:supabase-e2ee:<version>")
+```
+
+This module is opt-in and fully independent of the other feature clients (auth,
+database, storage, realtime). It depends only on the core result types and a
+multiplatform cryptography provider; you can use it without a `SupabaseClient`.
+
+Every fallible call returns a [`SupabaseResult<T>`](/results-and-errors) — a
+success-or-failure box — rather than throwing. Crypto exceptions (including a
+failed AES-GCM authentication tag on tampered or wrong-key ciphertext) come back as
+`SupabaseResult.Failure`, not thrown exceptions. `kotlinx.coroutines`
+`CancellationException` is the one thing that still propagates.
+
+<Callout type="warning">
+  **Key management is your responsibility.** This module *derives and uses* keys; it
+  does not store them or establish trust. Public keys are exchanged as raw bytes,
+  and `deriveSession` runs **raw ECDH** — it does not verify that a peer's public key
+  truly belongs to the intended peer. An attacker who can substitute the published
+  key (for example by tampering with the table you fetch it from) can mount a
+  man-in-the-middle attack. Distribute public keys over a trusted channel or verify
+  their fingerprints out-of-band. Private keys (from `exportPrivateKey`) are secret:
+  persist them in platform secure storage (Keychain / Keystore / etc.), and never
+  log or upload them.
+</Callout>
+
+All symbols live in the package `io.github.androidpoet.supabase.e2ee`.
+
+## Key pairs and generation
+
+### `E2eeKeyPair`
+
+```kotlin
+public class E2eeKeyPair {
+    public val publicKey: ByteArray
+}
+```
+
+An ECDH (P-256) key pair. There is no public constructor — obtain one from
+[`generateE2eeKeyPair`](#generatee2eekeypair) or
+[`importE2eeKeyPair`](#importe2eekeypair).
+
+- `publicKey` — the raw-encoded public key bytes (`EC.PublicKey.Format.RAW`). Safe to
+  publish: store it in a Supabase table so peers can fetch it.
+
+The private key is held internally and is never exposed as a property. To persist a
+pair, export the private half explicitly with [`exportPrivateKey`](#exportprivatekey).
+
+P-256 (rather than X25519) is used because it is supported by every provider,
+including WebCrypto on `wasmJs`.
+
+### `generateE2eeKeyPair`
+
+```kotlin
+public suspend fun generateE2eeKeyPair(): SupabaseResult<E2eeKeyPair>
+```
+
+Generates a fresh ECDH P-256 key pair. The public key is raw-encoded for publishing.
+
+- Returns `SupabaseResult<E2eeKeyPair>` — `Success` with the new pair, or `Failure`
+  (error code `"keygen"`).
+
+```kotlin
+val keyPair = when (val r = generateE2eeKeyPair()) {
+    is SupabaseResult.Success -> r.value
+    is SupabaseResult.Failure -> return // handle r.error
+}
+// keyPair.publicKey is safe to upload; the private key stays on-device.
+```
+
+### `exportPrivateKey`
+
+```kotlin
+public suspend fun E2eeKeyPair.exportPrivateKey(): SupabaseResult<ByteArray>
+```
+
+Exports this pair's **private** key as PKCS#8 DER bytes so a device can persist its
+identity across launches. DER (PKCS#8) round-trips across JDK / Apple / OpenSSL /
+WebCrypto, so it works on every target including `wasmJs`.
+
+- Returns `SupabaseResult<ByteArray>` — `Success` with the PKCS#8 DER-encoded private
+  key bytes, or `Failure` (error code `"export"`).
+
+These bytes are secret. Store them in your platform's secure storage and never log or
+upload them; only `publicKey` is safe to publish. Restore later with
+[`importE2eeKeyPair`](#importe2eekeypair).
+
+```kotlin
+val privateDer = keyPair.exportPrivateKey().getOrNull() ?: return
+secureStorage.put("e2ee_priv", privateDer)        // PKCS#8 DER, keep secret
+secureStorage.put("e2ee_pub", keyPair.publicKey)  // raw public, may be published
+```
+
+### `importE2eeKeyPair`
+
+```kotlin
+public suspend fun importE2eeKeyPair(
+    privateKeyDer: ByteArray,
+    publicKey: ByteArray,
+): SupabaseResult<E2eeKeyPair>
+```
+
+Restores an `E2eeKeyPair` from a previously exported private key and its matching
+public key. This is the other half of at-rest, single-user encryption: a device
+generates a pair once, persists it, and re-imports it on the next launch to
+re-derive the same session and decrypt its own history.
+
+- `privateKeyDer` — PKCS#8 DER bytes produced by [`exportPrivateKey`](#exportprivatekey).
+- `publicKey` — the matching raw public key bytes (as published / from
+  [`E2eeKeyPair.publicKey`](#e2eekeypair)).
+- Returns `SupabaseResult<E2eeKeyPair>` — `Success` with the reconstructed pair, or
+  `Failure` (error code `"import"`).
+
+```kotlin
+val priv = secureStorage.get("e2ee_priv")
+val pub = secureStorage.get("e2ee_pub")
+val restored = importE2eeKeyPair(priv, pub).getOrNull() ?: return
+```
+
+## Key agreement (ECDH) and derivation (HKDF)
+
+Both derivation functions perform the full pipeline — ECDH key agreement, then
+HKDF-SHA256 to a 256-bit AES key — and return a ready-to-use [`E2eeSession`](#e2eesession).
+The raw shared secret is never used as a key directly. Both sides that agree on the
+same pair of public keys derive the **identical** key locally; the server never sees it.
+
+### `deriveSession`
+
+```kotlin
+public suspend fun E2eeKeyPair.deriveSession(
+    peerPublicKey: ByteArray,
+): SupabaseResult<E2eeSession>
+```
+
+Derives a shared session from this key pair and a peer's raw public key. To pair two
+devices, each calls this with the other's published public key.
+
+- `peerPublicKey` — the peer's raw-encoded public key bytes (their
+  [`E2eeKeyPair.publicKey`](#e2eekeypair)).
+- Returns `SupabaseResult<E2eeSession>` — `Success` with the shared session, or
+  `Failure` (error code `"derive"`).
+
+<Callout type="warning">
+  This is raw ECDH: it does **not** verify that `peerPublicKey` belongs to the
+  intended peer. Authenticate or fingerprint-verify peer keys out-of-band to prevent
+  a man-in-the-middle attack.
+</Callout>
+
+### `deriveSelfSession`
+
+```kotlin
+public suspend fun E2eeKeyPair.deriveSelfSession(): SupabaseResult<E2eeSession>
+```
+
+Derives a session keyed to **this device's own pair** — an ECDH agreement against its
+own public key, producing a stable deterministic self-key for single-user at-rest
+encryption (encrypt your own notes/files; the server only ever sees ciphertext).
+Equivalent to `deriveSession(publicKey)`. Persist the pair with
+[`exportPrivateKey`](#exportprivatekey) / [`importE2eeKeyPair`](#importe2eekeypair)
+so the same key returns on the next launch. Has no peer, so it is unaffected by the
+man-in-the-middle caveat above.
+
+- Returns `SupabaseResult<E2eeSession>` — `Success` with the self session, or `Failure`
+  (error code `"derive"`).
+
+```kotlin
+// Single-user, at-rest: same key every launch after import.
+val session = restored.deriveSelfSession().getOrNull() ?: return
+```
+
+## Encrypt / decrypt
+
+### `E2eeSession`
+
+```kotlin
+public class E2eeSession {
+    public suspend fun encrypt(plaintext: ByteArray): SupabaseResult<ByteArray>
+    public suspend fun encrypt(text: String): SupabaseResult<ByteArray>
+    public suspend fun decrypt(ciphertext: ByteArray): SupabaseResult<ByteArray>
+    public suspend fun decryptToString(ciphertext: ByteArray): SupabaseResult<String>
+}
+```
+
+A symmetric AES-256-GCM session derived from an ECDH key agreement. It encrypts and
+decrypts any data; the relay/server only ever sees the returned ciphertext, in which
+the GCM nonce is embedded. There is no public constructor — obtain one from
+[`deriveSession`](#derivesession) or [`deriveSelfSession`](#deriveselfsession).
+
+Because AES-GCM is authenticated, decrypting tampered ciphertext or ciphertext from a
+mismatched key fails the authentication tag and returns a `SupabaseResult.Failure`
+(it does not throw and does not return garbage).
+
+#### `encrypt(plaintext: ByteArray)`
+
+Encrypts arbitrary bytes; the nonce is embedded in the returned ciphertext.
+
+- `plaintext` — the raw bytes to encrypt.
+- Returns `SupabaseResult<ByteArray>` — `Success` with ciphertext (nonce embedded), or
+  `Failure` (error code `"encrypt"`).
+
+#### `encrypt(text: String)`
+
+Encrypts a UTF-8 string. Equivalent to encrypting `text.encodeToByteArray()`.
+
+- `text` — the string to encrypt; encoded as UTF-8.
+- Returns `SupabaseResult<ByteArray>` — `Success` with ciphertext, or `Failure`
+  (error code `"encrypt"`).
+
+#### `decrypt(ciphertext: ByteArray)`
+
+Decrypts bytes produced by `encrypt`.
+
+- `ciphertext` — bytes returned by an `encrypt` call (nonce embedded).
+- Returns `SupabaseResult<ByteArray>` — `Success` with the original plaintext bytes,
+  or `Failure` (error code `"decrypt"`) on a bad/tampered/wrong-key input.
+
+#### `decryptToString(ciphertext: ByteArray)`
+
+Decrypts ciphertext back into a UTF-8 string.
+
+- `ciphertext` — bytes returned by an `encrypt` call.
+- Returns `SupabaseResult<String>` — `Success` with the decoded UTF-8 string, or
+  `Failure` (error code `"decrypt"`).
+
+#### Two-party round-trip
+
+```kotlin
+// Alice and Bob each generate a pair and publish their public key.
+val alice = generateE2eeKeyPair().getOrThrow()
+val bob = generateE2eeKeyPair().getOrThrow()
+
+// Each derives a session from the OTHER's public key — the key never leaves the device.
+val aliceSession = alice.deriveSession(bob.publicKey).getOrThrow()
+val bobSession = bob.deriveSession(alice.publicKey).getOrThrow()
+
+// Alice encrypts; only the ciphertext is stored in / relayed by Supabase.
+val cipher = aliceSession.encrypt("hello bob 🔐").getOrThrow()
+
+// Bob derived the same key, so he can decrypt.
+val plain = bobSession.decryptToString(cipher).getOrThrow() // "hello bob 🔐"
+```
+
+## Typed value helpers
+
+These inline extensions encrypt and decrypt any `@Serializable` value by encoding it
+to JSON first, then applying the session cipher. They are `reified` over `T`.
+
+### `encryptValue`
+
+```kotlin
+public suspend inline fun <reified T> E2eeSession.encryptValue(
+    value: T,
+    json: Json = Json,
+): SupabaseResult<ByteArray>
+```
+
+Encrypts any `@Serializable` value: it is encoded to a JSON string, then to ciphertext.
+
+- `value` — the value to encrypt; its type `T` must be `@Serializable`.
+- `json` — the serializer to use. Default: the standard `kotlinx.serialization.json.Json`
+  instance.
+- Returns `SupabaseResult<ByteArray>` — `Success` with ciphertext, or `Failure`
+  (error code `"encrypt"`).
+
+### `decryptValue`
+
+```kotlin
+public suspend inline fun <reified T> E2eeSession.decryptValue(
+    ciphertext: ByteArray,
+    json: Json = Json,
+): SupabaseResult<T>
+```
+
+Decrypts and decodes ciphertext produced by `encryptValue` back into `T`. It first
+decrypts to a UTF-8 string, then JSON-decodes it.
+
+- `ciphertext` — bytes produced by [`encryptValue`](#encryptvalue).
+- `json` — the serializer to use; must match the one used to encrypt. Default: the
+  standard `Json` instance.
+- Returns `SupabaseResult<T>` — `Success` with the decoded value, `Failure` with the
+  decryption error code (e.g. `"decrypt"`) if the cipher step fails, or `Failure`
+  with error code `"decode"` if the JSON cannot be parsed into `T`.
+
+```kotlin
+@Serializable
+data class Message(val from: String, val body: String, val ts: Long)
+
+val msg = Message(from = "alice", body = "hello bob", ts = 1_700_000_000)
+
+val cipher = aliceSession.encryptValue(msg).getOrThrow()
+val back = bobSession.decryptValue<Message>(cipher).getOrThrow()
+// back == msg
+```
+
+## At-rest, single-user round-trip
+
+The export/import + self-session path lets one device encrypt its own data, persist
+its identity, and decrypt that data again after a restart.
+
+```kotlin
+// First launch: generate once and persist.
+val pair = generateE2eeKeyPair().getOrThrow()
+secureStorage.put("e2ee_priv", pair.exportPrivateKey().getOrThrow()) // PKCS#8 DER, secret
+secureStorage.put("e2ee_pub", pair.publicKey)                        // raw, may be published
+
+val cipher = pair.deriveSelfSession().getOrThrow()
+    .encryptValue(Message("me", "secret note", 1)).getOrThrow()
+// store `cipher` in Supabase — the server sees only ciphertext.
+
+// Next launch: restore and decrypt the same data.
+val restored = importE2eeKeyPair(
+    secureStorage.get("e2ee_priv"),
+    secureStorage.get("e2ee_pub"),
+).getOrThrow()
+val note = restored.deriveSelfSession().getOrThrow()
+    .decryptValue<Message>(cipher).getOrThrow()
+```

--- a/website/pages/reference/functions.mdx
+++ b/website/pages/reference/functions.mdx
@@ -1,0 +1,451 @@
+---
+title: Edge Functions — API Reference
+description: Complete API reference for the supabase-functions module — invoke Supabase Edge Functions with raw, typed, binary, and streaming responses, all returned as SupabaseResult.
+---
+
+# Edge Functions — API Reference
+
+The `supabase-functions` module calls Supabase Edge Functions deployed under
+`/functions/v1/` and returns each result as a `SupabaseResult<T>` instead of
+throwing. Raw calls hand back the response body as a `String`; the typed
+extensions decode that body — and optionally encode the request — through the
+Functions JSON serializer; and a streaming variant surfaces a
+`text/event-stream` response as a `Flow`.
+
+Add the dependency:
+
+```kotlin
+implementation("io.github.androidpoet:supabase-functions")
+```
+
+Reach the API from an existing `SupabaseClient` through the `functions`
+accessor, or build a client explicitly with `createFunctionsClient(client)`:
+
+```kotlin
+val functions = client.functions
+// or
+val functions = createFunctionsClient(client)
+```
+
+Every call is authenticated with the wrapped client's current session token
+unless a token is pinned with `setAuth`.
+
+---
+
+## `SupabaseClient.functions`
+
+```kotlin
+public val SupabaseClient.functions: FunctionsClient
+```
+
+Extension property that returns the `FunctionsClient` for this Supabase project —
+a discoverable shortcut for `createFunctionsClient` so you can reach Edge
+Functions as `client.functions` instead of holding a separate factory reference.
+
+The returned client is a thin, stateless wrapper around the receiver client, so
+reading this property repeatedly is cheap and always talks to the same
+underlying transport.
+
+```kotlin
+val result = client.functions.invoke("hello-world")
+```
+
+---
+
+## `createFunctionsClient`
+
+```kotlin
+public fun createFunctionsClient(supabaseClient: SupabaseClient): FunctionsClient
+```
+
+Creates a `FunctionsClient` backed by `supabaseClient`, reusing its base URL,
+HTTP engine, and session token. This is the standard entry point to the
+Functions API.
+
+- `supabaseClient` — the project client whose base URL, transport, and session
+  token the Functions client reuses.
+
+The returned client holds no state of its own beyond an optionally pinned
+`setAuth` token, so one instance per `SupabaseClient` is enough.
+
+```kotlin
+val functions = createFunctionsClient(client)
+```
+
+---
+
+## `FunctionsClient`
+
+```kotlin
+public interface FunctionsClient
+```
+
+Calls Supabase Edge Functions deployed under `/functions/v1/`, returning each
+result as a `SupabaseResult` rather than throwing. One client wraps a
+`SupabaseClient` and reuses its base URL and session token, so calls are
+authenticated with the current session unless a token is pinned via `setAuth`.
+Obtain an instance with `createFunctionsClient` or the `functions` accessor.
+
+### `setAuth`
+
+```kotlin
+public fun setAuth(token: String)
+```
+
+Pins `token` as the bearer token for every subsequent call, overriding the
+wrapped client's current session token.
+
+- `token` — the bearer token to send on all following calls.
+
+Pass a new token to rotate it; there is no unset — to fall back to the session
+token, construct a fresh client.
+
+### `invoke`
+
+```kotlin
+public suspend fun invoke(
+    functionName: String,
+    body: String? = null,
+    method: FunctionMethod = FunctionMethod.POST,
+    headers: Map<String, String> = emptyMap(),
+    region: FunctionRegion? = null,
+): SupabaseResult<String>
+```
+
+Invokes the Edge Function named `functionName` with an optional text `body` and
+returns its full response body.
+
+- `functionName` — the deployed function name, appended to `/functions/v1/`.
+- `body` — optional text request body. Default `null`. When non-null and the
+  caller has not set one, a `Content-Type: application/json` header is added
+  (Edge Functions commonly branch on it). Ignored under `FunctionMethod.GET`,
+  which sends no body.
+- `method` — the HTTP method to issue. Default `FunctionMethod.POST`.
+- `headers` — extra request headers, merged last so they win over the
+  auth/region defaults. Default empty.
+- `region` — optional region to pin the call to via the `x-region` header.
+  Default `null` (Supabase routes to the nearest region).
+
+**Returns** `SupabaseResult<String>` — `Success` carries the full response body
+as a string; a non-2xx response is a `Failure`.
+
+```kotlin
+when (val result = client.functions.invoke("hello-world", body = """{"name":"Ada"}""")) {
+    is SupabaseResult.Success -> println(result.value)
+    is SupabaseResult.Failure -> println(result.error)
+}
+```
+
+### `invokeWithBody`
+
+```kotlin
+public suspend fun invokeWithBody(
+    functionName: String,
+    body: ByteArray,
+    contentType: String = "application/octet-stream",
+    method: FunctionMethod = FunctionMethod.POST,
+    headers: Map<String, String> = emptyMap(),
+    region: FunctionRegion? = null,
+): SupabaseResult<String>
+```
+
+Invokes `functionName` with a raw binary `body` (e.g. an image or protobuf),
+returning the full response. The byte-oriented counterpart to `invoke`, with the
+same routing and `x-region`/`headers` behavior.
+
+- `functionName` — the deployed function name, appended to `/functions/v1/`.
+- `body` — the raw bytes to upload.
+- `contentType` — the `Content-Type` for the uploaded bytes. Default
+  `"application/octet-stream"`.
+- `method` — the HTTP method to issue. Default `FunctionMethod.POST`.
+  `FunctionMethod.GET` is not meaningful here since it carries no body — pass a
+  body-bearing verb.
+- `headers` — extra request headers, merged over the auth/region defaults.
+  Default empty.
+- `region` — optional region to pin the call to via `x-region`. Default `null`.
+
+**Returns** `SupabaseResult<String>` — `Success` carries the full response body
+as a string; a non-2xx response is a `Failure`.
+
+```kotlin
+val png: ByteArray = readImageBytes()
+val result = client.functions.invokeWithBody(
+    functionName = "resize-image",
+    body = png,
+    contentType = "image/png",
+)
+```
+
+### `invokeSSE`
+
+```kotlin
+public fun invokeSSE(
+    functionName: String,
+    body: String? = null,
+    contentType: String = "application/json",
+    headers: Map<String, String> = emptyMap(),
+    region: FunctionRegion? = null,
+): Flow<FunctionServerSentEvent>
+```
+
+Invokes a streaming Edge Function and returns its response as a cold `Flow` of
+`FunctionServerSentEvent`s, parsed from the `text/event-stream` body as they
+arrive (nothing is buffered to completion).
+
+- `functionName` — the deployed function name, appended to `/functions/v1/`.
+- `body` — optional text request body. Default `null`.
+- `contentType` — the `Content-Type` for the request body. Default
+  `"application/json"`.
+- `headers` — extra request headers, merged over the auth/region defaults.
+  Default empty.
+- `region` — optional region to pin the call to via `x-region`. Default `null`.
+
+**Returns** `Flow<FunctionServerSentEvent>`. The request is a POST issued when
+the flow is collected; collecting twice invokes twice. Unlike the buffered
+`invoke`, a streamed call cannot return a `SupabaseResult` up front — a non-2xx
+response surfaces as a terminal exception in the flow rather than an empty
+stream, so collect within `try`/`catch` (or Flow `.catch`).
+
+```kotlin
+client.functions.invokeSSE("stream-tokens")
+    .catch { e -> println("stream failed: $e") }
+    .collect { event -> println(event.data) }
+```
+
+---
+
+## Typed invoke extensions
+
+These reified extensions decode the response body — and, in one overload, encode
+the request — through the Functions JSON serializer, staying Result-first end to
+end: a decode failure becomes a `SupabaseResult.Failure` rather than an
+exception.
+
+### `invokeTyped` (text body)
+
+```kotlin
+public suspend inline fun <reified T> FunctionsClient.invokeTyped(
+    functionName: String,
+    body: String? = null,
+    method: FunctionMethod = FunctionMethod.POST,
+    headers: Map<String, String> = emptyMap(),
+    region: FunctionRegion? = null,
+): SupabaseResult<T>
+```
+
+Invokes `functionName` and decodes its response JSON into `T`. Wraps `invoke`;
+pass a serialized `body` string (use the request-object overload to encode the
+request too).
+
+- `functionName` — the deployed function name.
+- `body` — optional serialized text request body. Default `null`.
+- `method` — the HTTP method to issue. Default `FunctionMethod.POST`.
+- `headers` — extra request headers, merged over the auth/region defaults.
+  Default empty.
+- `region` — optional region to pin the call to via `x-region`. Default `null`.
+
+**Returns** `SupabaseResult<T>` — `Success` carries the decoded value; a non-2xx
+response or a decode failure is a `Failure`.
+
+```kotlin
+@Serializable
+data class Greeting(val message: String)
+
+val result: SupabaseResult<Greeting> =
+    client.functions.invokeTyped("hello-world", body = """{"name":"Ada"}""")
+```
+
+### `invokeTyped` (typed request and response)
+
+```kotlin
+public suspend inline fun <reified Request : Any, reified Response> FunctionsClient.invokeTyped(
+    functionName: String,
+    request: Request,
+    method: FunctionMethod = FunctionMethod.POST,
+    headers: Map<String, String> = emptyMap(),
+    region: FunctionRegion? = null,
+): SupabaseResult<Response>
+```
+
+Encodes `request` to JSON, invokes `functionName` with it, and decodes the
+response into `Response` — both sides typed in one call. The fully typed
+counterpart to the text-body `invokeTyped`; both serialization steps use the
+Functions serializer and a failure at either end surfaces as
+`SupabaseResult.Failure`.
+
+- `functionName` — the deployed function name.
+- `request` — the request body, serialized to JSON via `Request`'s serializer.
+- `method` — the HTTP method to issue. Default `FunctionMethod.POST`.
+- `headers` — extra request headers, merged over the auth/region defaults.
+  Default empty.
+- `region` — optional region to pin the call to via `x-region`. Default `null`.
+
+**Returns** `SupabaseResult<Response>` — `Success` carries the decoded response;
+a non-2xx response or a decode failure at either end is a `Failure`.
+
+```kotlin
+@Serializable
+data class HelloRequest(val name: String)
+
+@Serializable
+data class Greeting(val message: String)
+
+val result: SupabaseResult<Greeting> =
+    client.functions.invokeTyped("hello-world", HelloRequest(name = "Ada"))
+```
+
+### `invokeWithBodyTyped`
+
+```kotlin
+public suspend inline fun <reified T> FunctionsClient.invokeWithBodyTyped(
+    functionName: String,
+    body: ByteArray,
+    contentType: String = "application/octet-stream",
+    method: FunctionMethod = FunctionMethod.POST,
+    headers: Map<String, String> = emptyMap(),
+    region: FunctionRegion? = null,
+): SupabaseResult<T>
+```
+
+Posts a raw binary `body` to `functionName` and decodes the JSON response into
+`T`. The byte-body analogue of `invokeTyped`, wrapping `invokeWithBody`.
+
+- `functionName` — the deployed function name.
+- `body` — the raw bytes to upload.
+- `contentType` — the `Content-Type` for the uploaded bytes. Default
+  `"application/octet-stream"`.
+- `method` — the HTTP method to issue. Default `FunctionMethod.POST`.
+- `headers` — extra request headers, merged over the auth/region defaults.
+  Default empty.
+- `region` — optional region to pin the call to via `x-region`. Default `null`.
+
+**Returns** `SupabaseResult<T>` — `Success` carries the decoded value; a non-2xx
+response or a decode failure is a `Failure`.
+
+```kotlin
+@Serializable
+data class ResizeResult(val width: Int, val height: Int)
+
+val result: SupabaseResult<ResizeResult> =
+    client.functions.invokeWithBodyTyped(
+        functionName = "resize-image",
+        body = readImageBytes(),
+        contentType = "image/png",
+    )
+```
+
+---
+
+## `FunctionServerSentEvent`
+
+```kotlin
+public data class FunctionServerSentEvent(
+    public val id: String? = null,
+    public val event: String? = null,
+    public val data: String? = null,
+)
+```
+
+One Server-Sent Event emitted by a streaming Edge Function, as produced by
+`invokeSSE`. Fields mirror the SSE wire format:
+
+- `id` — the last-event-id (`id:` line). It persists across events, so an event
+  that omits `id:` reports the most recently seen id (matching the browser
+  `EventSource.lastEventId`), and is `null` only until the server first sends
+  one. Default `null`.
+- `event` — the event type (`event:` line), defaulting to `"message"` on the
+  wire when omitted. Default `null`.
+- `data` — the payload (`data:` line); multiple `data:` lines in one event are
+  joined with `\n`. Default `null`.
+
+Keep-alive comment lines (`:`) are dropped by the parser and never surface as
+events.
+
+### `decodeAs`
+
+```kotlin
+public inline fun <reified T> decodeAs(): T?
+```
+
+Deserializes `data` into `T` using the Functions serializer.
+
+**Returns** the decoded value, or `null` when this event carries no `data` (e.g.
+an event with only an `id:`/`event:` line). Throws if `data` is present but not
+valid JSON for `T` — wrap the call site if you need that as a value.
+
+```kotlin
+@Serializable
+data class Token(val text: String)
+
+client.functions.invokeSSE("stream-tokens")
+    .collect { event ->
+        val token = event.decodeAs<Token>()
+        if (token != null) print(token.text)
+    }
+```
+
+---
+
+## `FunctionMethod`
+
+```kotlin
+public enum class FunctionMethod
+```
+
+The HTTP method an Edge Function call is issued with, used by `invoke` and
+`invokeWithBody`. Functions default to `POST`; pass another verb when a function
+routes on the request method. `GET` carries no request body (a GET with a body
+is invalid) — any body supplied alongside it is ignored.
+
+| Entry | Meaning |
+| --- | --- |
+| `POST` | HTTP `POST` — the default; carries the request body. |
+| `GET` | HTTP `GET` — no request body is sent. |
+| `PUT` | HTTP `PUT` — carries the request body. |
+| `PATCH` | HTTP `PATCH` — carries the request body. |
+| `DELETE` | HTTP `DELETE` — carries the request body. |
+
+---
+
+## `FunctionRegion`
+
+```kotlin
+public enum class FunctionRegion(
+    public val value: String,
+)
+```
+
+The Edge Functions region to pin a call to, sent as the `x-region` request
+header by `invoke` and friends. Edge Functions are normally routed to the region
+nearest the caller; pin one when a function must run close to a regional
+resource (e.g. a co-located database) to avoid the cross-region round trip.
+
+- `value` — the wire string placed in the `x-region` header.
+
+`ANY` (the default behavior when no region is passed) leaves routing to
+Supabase.
+
+| Entry | `value` |
+| --- | --- |
+| `ANY` | `any` |
+| `US_EAST_1` | `us-east-1` |
+| `US_WEST_1` | `us-west-1` |
+| `US_WEST_2` | `us-west-2` |
+| `CA_CENTRAL_1` | `ca-central-1` |
+| `SA_EAST_1` | `sa-east-1` |
+| `EU_WEST_1` | `eu-west-1` |
+| `EU_WEST_2` | `eu-west-2` |
+| `EU_WEST_3` | `eu-west-3` |
+| `EU_CENTRAL_1` | `eu-central-1` |
+| `AP_SOUTH_1` | `ap-south-1` |
+| `AP_SOUTHEAST_1` | `ap-southeast-1` |
+| `AP_SOUTHEAST_2` | `ap-southeast-2` |
+| `AP_NORTHEAST_1` | `ap-northeast-1` |
+| `AP_NORTHEAST_2` | `ap-northeast-2` |
+
+`FunctionRegion` is `@Serializable`; each entry serializes to its `value`
+string.
+
+```kotlin
+client.functions.invoke("nearby", region = FunctionRegion.EU_WEST_2)
+```

--- a/website/pages/reference/index.mdx
+++ b/website/pages/reference/index.mdx
@@ -1,0 +1,49 @@
+---
+title: API Reference
+description: Complete, symbol-by-symbol reference for every Supabase KMP module — signatures, parameters, return types, and examples, generated from the real 1.0.0 public API.
+---
+
+import { Callout } from 'nextra/components'
+
+# API Reference
+
+This section documents the **complete public API** of Supabase KMP — every client
+interface, extension function, data type, enum, and value class that ships in the
+1.0.0 artifacts. Each page is organized by module and lists real signatures,
+every parameter, the return type, and a short example.
+
+<Callout type="info">
+  Looking to *learn* a feature rather than look up a symbol? Start with the
+  task-oriented guides — [Getting Started](/getting-started),
+  [Database](/database), [Authentication](/auth), [Storage](/storage),
+  [Realtime](/realtime). This reference is the exhaustive companion to those.
+</Callout>
+
+## How to read these pages
+
+Every fallible call returns a **`SupabaseResult<T>`** — a sealed `Success<T>` /
+`Failure` type (it is *not* `kotlin.Result`). You branch with
+`onSuccess` / `onFailure` and transform with `map` / `flatMap` / `recover`; no
+exceptions leak onto the happy path. See [Results & Errors](/results-and-errors)
+for the full contract, and the [Core](/reference/core) reference for the type
+itself.
+
+Each module is published independently under the group
+`io.github.androidpoet` — depend only on what you use.
+
+## Modules
+
+| Reference | Artifact | What it covers |
+| --- | --- | --- |
+| [Core](/reference/core) | `supabase-core` | `SupabaseResult`, error model, value-class IDs, typed filter DSL |
+| [Client](/reference/client) | `supabase-client` | `Supabase.create`, configuration, HTTP transport |
+| [Authentication](/reference/auth) | `supabase-auth` | Email/phone/OTP, OAuth, MFA, PKCE, sessions, passkeys |
+| [Auth Admin](/reference/auth-admin) | `supabase-auth-admin` | Service-role user management (server-side only) |
+| [Native Sign-In](/reference/auth-native) | `supabase-auth-google` · `-apple` · `-passkey` | Native Google / Apple / WebAuthn ceremonies |
+| [Database](/reference/database) | `supabase-database` | PostgREST CRUD, RPC, typed read/write helpers |
+| [Storage](/reference/storage) | `supabase-storage` | Buckets, objects, signed & public URLs |
+| [Realtime](/reference/realtime) | `supabase-realtime` | WebSocket channels, postgres changes, broadcast, presence |
+| [Edge Functions](/reference/functions) | `supabase-functions` | Typed edge-function invocation |
+| [End-to-End Encryption](/reference/e2ee) | `supabase-e2ee` | ECDH → HKDF → AES-256-GCM client-side crypto |
+| [Offline Sync](/reference/sync) | `supabase-sync-core` · `-sqldelight` · `-sync` · `-paging` | Offline-first pull/merge/push engine |
+| [Codegen](/reference/codegen) | `supabase-codegen` · Gradle plugin | Generate typed models from your schema |

--- a/website/pages/reference/realtime.mdx
+++ b/website/pages/reference/realtime.mdx
@@ -1,0 +1,1317 @@
+---
+title: Realtime — API Reference
+description: Complete public API reference for the supabase-realtime module — RealtimeClient, channels and subscriptions, postgres changes, broadcast (text and binary), presence, connection state, auto-reconnect config, and every model, data, enum and sealed type.
+---
+
+import { Callout } from 'nextra/components'
+
+# Realtime — API Reference
+
+`supabase-realtime` opens a single WebSocket connection to a Supabase project's
+Realtime service and multiplexes many Phoenix channels over it. Each channel can
+carry three kinds of traffic: **postgres changes** (rows inserted, updated or
+deleted in your database), **broadcast** (client-to-client messages, including
+raw binary frames), and **presence** (who is currently on the channel). The
+socket speaks the Phoenix protocol at version `2.0.0`, in which every frame is an
+array `[join_ref, ref, topic, event, payload]` — the array encoding is what lets
+binary broadcasts travel as real binary frames rather than base64 text.
+
+The connection auto-reconnects with exponential backoff (and jitter) when it
+drops, replaying its channel joins, and exposes its lifecycle as a `StateFlow`.
+
+- **Maven artifact:** `io.github.androidpoet:supabase-realtime`
+- **Entry point:** `createRealtimeClient(client)`
+
+<Callout type="info">
+Methods that touch the network are either Result-first (`SupabaseResult<T>`) or
+suspend until the operation settles. Query methods (`getSubscription`,
+`getActiveChannelNames`, …) are synchronous snapshots, and event streams are
+exposed as `Flow`/`StateFlow`. Each symbol below notes which it is.
+</Callout>
+
+## Creating a client
+
+### `createRealtimeClient`
+
+```kotlin
+fun createRealtimeClient(
+    supabaseClient: SupabaseClient,
+    config: RealtimeConfig = RealtimeConfig(),
+    engineFactory: HttpClientEngineFactory<*> = platformEngine(),
+): RealtimeClient
+```
+
+The module entry point. Builds a [`RealtimeClient`](#realtimeclient) bound to a
+`SupabaseClient`.
+
+- `supabaseClient` — the core client; supplies the project URL, API key and the
+  current session token used for channel authorization.
+- `config` — reconnect and heartbeat tuning; see [`RealtimeConfig`](#realtimeconfig).
+- `engineFactory` — the Ktor engine used for the WebSocket. Defaults to the
+  platform's WebSocket-capable engine; pass your own (e.g. a mock engine) in
+  tests.
+
+Returns a `RealtimeClient`. The socket is not opened here — it connects lazily on
+the first subscription, or eagerly when you call `connect()`.
+
+```kotlin
+val realtime = createRealtimeClient(client)
+```
+
+### `RealtimeConfig`
+
+```kotlin
+data class RealtimeConfig(
+    val autoReconnect: Boolean = true,
+    val initialReconnectDelayMs: Long = 1_000L,
+    val maxReconnectDelayMs: Long = 30_000L,
+    val backoffMultiplier: Double = 2.0,
+    val reconnectJitter: Boolean = true,
+    val maxReconnectAttempts: Int = 0,
+    val heartbeatIntervalMs: Long = 25_000L,
+    val connectionTimeoutMs: Long = 10_000L,
+    val logLevel: String? = null,
+)
+```
+
+Tuning for reconnect and heartbeat behavior. Defaults are production-sane
+(exponential backoff with jitter, 25s heartbeat); override only what you need.
+
+- `autoReconnect` — reconnect automatically when the socket drops.
+- `initialReconnectDelayMs` — delay before the first reconnect attempt.
+- `maxReconnectDelayMs` — upper bound the backoff is clamped to.
+- `backoffMultiplier` — factor the delay grows by after each failed attempt.
+- `reconnectJitter` — when `true`, the computed backoff is randomized between
+  half and the full exponential delay ("equal jitter"), so a fleet of clients
+  that all dropped at once don't reconnect in lockstep and stampede the server.
+- `maxReconnectAttempts` — give up after this many tries (`0` = retry forever),
+  transitioning to [`ConnectionState.Failed`](#connectionstate).
+- `heartbeatIntervalMs` — how often to send a Phoenix heartbeat to keep the
+  socket alive.
+- `connectionTimeoutMs` — how long to wait for a connection or channel join to
+  settle before failing it.
+- `logLevel` — server-side log verbosity, passed as the `log_level` query param
+  when opening the socket (e.g. `info`, `warn`, `error`); `null` omits the param
+  and leaves the server default in effect.
+
+```kotlin
+val realtime = createRealtimeClient(
+    client,
+    RealtimeConfig(heartbeatIntervalMs = 15_000L, maxReconnectAttempts = 10),
+)
+```
+
+## Connection lifecycle
+
+### `RealtimeClient`
+
+```kotlin
+interface RealtimeClient
+```
+
+One WebSocket connection to `/realtime/v1/` multiplexing many Phoenix channels.
+Build channels with [`channel`](#channel), and the socket connects lazily on the
+first subscription. Subscriptions are deduplicated by topic — subscribing to the
+same channel name twice returns the existing one. The members below cover the
+connection; channel and subscription members are documented in later sections.
+
+#### `connectionState`
+
+```kotlin
+val connectionState: StateFlow<ConnectionState>
+```
+
+Cold-start-safe `StateFlow` of the socket lifecycle; emits the current
+[`ConnectionState`](#connectionstate) on collection and on every transition.
+Drive reconnect indicators off this.
+
+```kotlin
+realtime.connectionState.collect { state ->
+    println("realtime: $state")
+}
+```
+
+#### `isConnected` / `isConnecting` / `isDisconnecting`
+
+```kotlin
+val isConnected: Boolean
+val isConnecting: Boolean
+val isDisconnecting: Boolean
+```
+
+Synchronous snapshots of the socket state: `isConnected` is `true` in
+`ConnectionState.Connected`; `isConnecting` is `true` while establishing or
+re-establishing a connection; `isDisconnecting` is `true` while tearing the
+connection down.
+
+#### `connect`
+
+```kotlin
+suspend fun connect()
+```
+
+Opens the WebSocket eagerly. Optional — the socket connects on the first
+[`subscribe`](#subscribe-1); call this to pre-warm it or to reconnect after
+`disconnect()`. Suspends until the attempt settles.
+
+```kotlin
+realtime.connect()
+```
+
+#### `disconnect`
+
+```kotlin
+suspend fun disconnect()
+```
+
+Closes the WebSocket but keeps the client (and its engine) reusable: active
+subscriptions are retained and rejoined on the next `connect()` or subscription.
+For a permanent teardown that frees the engine, use [`close`](#close).
+
+#### `close`
+
+```kotlin
+suspend fun close()
+```
+
+Disconnects and releases the underlying HTTP/WebSocket engine. The client cannot
+be reused afterwards. Call this when you are done with the client to avoid
+leaking the engine's connection pool and threads. Prefer `disconnect()` if you
+intend to `connect()` again later.
+
+#### `setAuth`
+
+```kotlin
+suspend fun setAuth(token: String? = null)
+```
+
+Updates the auth token used for channel authorization and rejoins active channels
+with it (Phoenix `access_token`), so RLS-gated `postgres_changes` and private
+channels stay authorized after a session refresh. Pass `null` to fall back to the
+wrapped client's current session token.
+
+```kotlin
+realtime.setAuth(newAccessToken)
+```
+
+#### `sendHeartbeat`
+
+```kotlin
+suspend fun sendHeartbeat()
+```
+
+Sends one Phoenix heartbeat immediately, outside the periodic schedule. Rarely
+needed — heartbeats are sent automatically per [`RealtimeConfig`](#realtimeconfig).
+
+### `awaitConnected`
+
+```kotlin
+suspend fun RealtimeClient.awaitConnected(): ConnectionState.Connected
+```
+
+Suspends until `connectionState` reaches `ConnectionState.Connected` and returns
+it — useful right after `connect()` to gate setup work.
+
+```kotlin
+realtime.connect()
+realtime.awaitConnected()
+```
+
+### `awaitDisconnected`
+
+```kotlin
+suspend fun RealtimeClient.awaitDisconnected(): ConnectionState.Disconnected
+```
+
+Suspends until `connectionState` reaches `ConnectionState.Disconnected` and
+returns it — useful to confirm teardown after `disconnect()`.
+
+### `ConnectionState`
+
+```kotlin
+sealed interface ConnectionState {
+    data object Disconnected : ConnectionState
+    data object Connecting : ConnectionState
+    data object Connected : ConnectionState
+    data object Disconnecting : ConnectionState
+    data class Reconnecting(val attempt: Int, val nextRetryMs: Long) : ConnectionState
+    data class Failed(val reason: String, val attempts: Int) : ConnectionState
+}
+```
+
+The lifecycle state of the Realtime WebSocket, exposed as
+[`connectionState`](#connectionstate). `Reconnecting` and `Failed` carry the
+attempt count from the backoff loop.
+
+- `Disconnected` — no socket open and no reconnect in progress (the initial state,
+  and the resting state after `disconnect()`).
+- `Connecting` — the first connection attempt is in flight.
+- `Connected` — the socket is open and joins can proceed.
+- `Disconnecting` — a graceful shutdown is in progress.
+- `Reconnecting` — the socket dropped and an automatic reconnect is scheduled;
+  `attempt` is the 1-based retry number and `nextRetryMs` the backoff delay before
+  it.
+- `Failed` — reconnection gave up after `attempts` tries (when
+  `maxReconnectAttempts` is exceeded), with `reason` describing the last failure.
+  A terminal state until a manual `connect()`.
+
+```kotlin
+when (val s = realtime.connectionState.value) {
+    is ConnectionState.Reconnecting -> showRetry(s.attempt, s.nextRetryMs)
+    is ConnectionState.Failed -> showError(s.reason)
+    else -> Unit
+}
+```
+
+## Channels and subscriptions
+
+A **channel** is built and configured before joining; a **subscription** is the
+live handle you get back after joining.
+
+### `channel`
+
+```kotlin
+fun RealtimeClient.channel(name: String): RealtimeChannelBuilder
+```
+
+Begins configuring a channel topic `name` (the part after `realtime:`), returning
+a [`RealtimeChannelBuilder`](#realtimechannelbuilder) on which to register
+`postgres_changes`/`broadcast`/`presence` callbacks before `subscribe()`. Building
+a channel does not join it.
+
+```kotlin
+val sub = realtime.channel("room1")
+    .onBroadcast("cursor") { payload -> /* … */ }
+    .subscribe()
+```
+
+### `subscribe` (extension)
+
+```kotlin
+suspend fun RealtimeClient.subscribe(
+    channel: String,
+    configure: RealtimeChannelBuilder.() -> Unit = {},
+): RealtimeSubscription
+```
+
+One-call channel subscribe: builds the channel, applies `configure` (where you
+register `onPostgresChange`/`onBroadcast`/`onPresence` and channel options), and
+joins it. The lambda form of `channel(name)` + `subscribe()`; returns as soon as
+the join is sent.
+
+```kotlin
+val sub = realtime.subscribe("room1") {
+    onBroadcast("cursor") { payload -> render(payload) }
+}
+```
+
+### Querying active subscriptions
+
+These are synchronous snapshots — no network, no suspension.
+
+#### `getSubscription`
+
+```kotlin
+fun getSubscription(name: String): RealtimeSubscription?
+```
+
+Returns the active subscription for channel `name`, or `null` if not subscribed.
+
+#### `getSubscriptionByTopic`
+
+```kotlin
+fun getSubscriptionByTopic(topic: String): RealtimeSubscription?
+```
+
+Returns the active subscription for the fully-qualified Phoenix `topic` (e.g.
+`realtime:room1`), or `null`.
+
+#### `getSubscriptions`
+
+```kotlin
+fun getSubscriptions(): Set<RealtimeSubscription>
+```
+
+Returns a snapshot of all currently active subscriptions.
+
+#### `getActiveChannelNames`
+
+```kotlin
+fun getActiveChannelNames(): Set<String>
+```
+
+Returns the names of all currently subscribed channels.
+
+#### `getActiveChannels`
+
+```kotlin
+fun getActiveChannels(): Set<RealtimeChannel>
+```
+
+Returns name+topic details for all active channels. See
+[`RealtimeChannel`](#realtimechannel).
+
+```kotlin
+realtime.getActiveChannelNames() // e.g. setOf("room1", "room2")
+```
+
+### Removing subscriptions
+
+Each `remove*` call unsubscribes (leaves the Phoenix channel, status
+`UNSUBSCRIBED`) and drops the subscription from the client. All suspend until the
+leave is sent; the socket stays open.
+
+#### `removeSubscription`
+
+```kotlin
+suspend fun removeSubscription(subscription: RealtimeSubscription)
+suspend fun removeSubscription(name: String)
+```
+
+Removes a single subscription, either by its handle or by channel `name`.
+
+```kotlin
+realtime.removeSubscription("room1")
+```
+
+#### `removeSubscriptions`
+
+```kotlin
+suspend fun removeSubscriptions(subscriptions: List<RealtimeSubscription>)
+```
+
+Removes each subscription in the list.
+
+#### `removeSubscriptionByTopic`
+
+```kotlin
+suspend fun removeSubscriptionByTopic(topic: String)
+```
+
+Removes the subscription on the fully-qualified Phoenix `topic` (e.g.
+`realtime:room1`), if any.
+
+#### `removeSubscriptionsByTopic`
+
+```kotlin
+suspend fun removeSubscriptionsByTopic(topics: List<String>)
+```
+
+Removes the subscriptions on each of `topics`.
+
+#### `removeAllSubscriptions`
+
+```kotlin
+suspend fun removeAllSubscriptions()
+```
+
+Unsubscribes and removes every active subscription, leaving the socket open.
+
+### `RealtimeChannelBuilder`
+
+```kotlin
+class RealtimeChannelBuilder
+```
+
+Configures one Realtime channel — its `postgres_changes`, `broadcast` and
+`presence` callbacks plus channel options — before joining it. Obtained from
+`channel(name)`; the `onXxx`/`configureXxx` methods return `this` so they chain,
+and nothing is sent until `subscribe()` (or `subscribeWithResult()`).
+
+#### `onPostgresChange`
+
+```kotlin
+fun onPostgresChange(
+    schema: String = "public",
+    table: String? = null,
+    filter: String? = null,
+    event: PostgresChangeEvent = PostgresChangeEvent.ALL,
+    callback: suspend (JsonObject) -> Unit,
+): RealtimeChannelBuilder
+
+fun onPostgresChange(
+    schema: String = "public",
+    table: String? = null,
+    filter: String? = null,
+    event: PostgresChangeEvent = PostgresChangeEvent.ALL,
+    callback: suspend (PostgresChangeEvent, JsonObject) -> Unit,
+): RealtimeChannelBuilder
+```
+
+Subscribes to database `postgres_changes` and delivers each affected row as a raw
+`JsonObject` (the new row for INSERT/UPDATE, the old row for DELETE).
+
+- `schema` — database schema, default `public`.
+- `table` — table to scope to; `null` watches the whole schema.
+- `filter` — a single `column=op.value` string; build it with
+  [`realtimeFilter`](#realtimefilter) rather than by hand. Realtime allows only
+  **one** filter per subscription.
+- `event` — narrow to one change type, default `ALL`.
+- `callback` — receives the row; the second overload also passes the resolved
+  `PostgresChangeEvent` so one handler can branch on the change type.
+
+For typed rows, see the reified [`onPostgresChange`](#onpostgreschange-typed)
+extension. Returns the builder for chaining.
+
+```kotlin
+realtime.channel("rooms")
+    .onPostgresChange(table = "messages", event = PostgresChangeEvent.INSERT) { row ->
+        println("new message: $row")
+    }
+    .subscribe()
+```
+
+#### `onPostgresChange` (typed)
+
+```kotlin
+inline fun <reified T> RealtimeChannelBuilder.onPostgresChange(
+    schema: String = "public",
+    table: String? = null,
+    filter: String? = null,
+    event: PostgresChangeEvent = PostgresChangeEvent.ALL,
+    crossinline onRow: suspend (T) -> Unit,
+): RealtimeChannelBuilder
+```
+
+Like the raw `onPostgresChange`, but decodes each changed row into your model `T`
+before calling `onRow`. Rows that don't deserialize into `T` (e.g. a partial
+DELETE payload missing non-replica-identity columns) are skipped rather than
+throwing, so one bad event can't tear down the subscription. Returns the builder.
+
+```kotlin
+@Serializable data class Message(val id: Long, val body: String)
+
+realtime.channel("rooms")
+    .onPostgresChange<Message>(table = "messages") { msg -> store(msg) }
+    .subscribe()
+```
+
+#### `onBroadcast`
+
+```kotlin
+fun onBroadcast(
+    event: String,
+    callback: suspend (JsonObject) -> Unit,
+): RealtimeChannelBuilder
+```
+
+Registers `callback` for `broadcast` messages whose event name equals `event`,
+delivering the payload as a `JsonObject`. Send broadcasts with
+[`RealtimeSubscription.broadcast`](#broadcast-1) or
+[`RealtimeClient.broadcast`](#broadcast-over-http). Returns the builder.
+
+#### `onPresence`
+
+```kotlin
+fun onPresence(
+    callback: suspend (PresenceState) -> Unit,
+): RealtimeChannelBuilder
+```
+
+Registers `callback` for `presence` sync, invoked with the full cumulative
+[`PresenceState`](#presencestate) (every tracked member, keyed by presence key) on
+each `presence_state`/`presence_diff`. Publish your own state with
+[`track`](#track). Returns the builder.
+
+#### `configureBroadcast`
+
+```kotlin
+fun configureBroadcast(
+    receiveOwnBroadcasts: Boolean = false,
+    acknowledgeBroadcasts: Boolean = false,
+): RealtimeChannelBuilder
+```
+
+Tunes broadcast behavior for this channel: `receiveOwnBroadcasts` echoes the
+sender's own messages back to it (off by default), and `acknowledgeBroadcasts`
+asks the server to ack each broadcast (required for
+[`broadcastWithAck`](#broadcastwithack)). Returns the builder.
+
+#### `configureBroadcastReplay`
+
+```kotlin
+fun configureBroadcastReplay(
+    sinceMs: Long,
+    limit: Int? = null,
+): RealtimeChannelBuilder
+```
+
+Requests replay of recent broadcasts on join: messages from the last `sinceMs`
+milliseconds, capped at `limit` if given. Lets a late joiner catch up on missed
+broadcasts the server still retains (replayed events arrive with `replayed = true`).
+Returns the builder.
+
+#### `configurePresence`
+
+```kotlin
+fun configurePresence(key: String = ""): RealtimeChannelBuilder
+```
+
+Sets the presence `key` identifying this client among channel members (defaults
+to a server-assigned key). Use a stable per-user key to dedupe a user across
+reconnects or devices. Returns the builder.
+
+#### `setPrivate`
+
+```kotlin
+fun setPrivate(enabled: Boolean = true): RealtimeChannelBuilder
+```
+
+Marks the channel as private, so the server applies Realtime authorization (RLS)
+using the client's session JWT. Required for RLS-protected `postgres_changes` and
+private broadcast/presence channels. Returns the builder.
+
+#### `subscribe`
+
+```kotlin
+suspend fun subscribe(): RealtimeSubscription
+```
+
+Joins the Phoenix channel with the configured callbacks and returns its
+[`RealtimeSubscription`](#realtimesubscription), connecting the socket first if
+needed. Returns as soon as the join is sent — the subscription may still be
+`SUBSCRIBING`; use `subscribeWithResult()` or [`awaitSubscribed`](#awaitsubscribed)
+to wait for the server's reply.
+
+#### `subscribeWithResult`
+
+```kotlin
+suspend fun subscribeWithResult(): SupabaseResult<RealtimeSubscription>
+```
+
+Like `subscribe()`, but suspends until the channel join resolves and reports the
+outcome as a `SupabaseResult` instead of handing back a subscription that may
+still be joining. Returns `SupabaseResult.Failure` if the join is rejected by the
+server or times out (after `connectionTimeoutMs`).
+
+```kotlin
+when (val result = realtime.channel("room1").subscribeWithResult()) {
+    is SupabaseResult.Success -> use(result.data)
+    is SupabaseResult.Failure -> handle(result.error)
+}
+```
+
+### `RealtimeSubscription`
+
+```kotlin
+interface RealtimeSubscription
+```
+
+A live subscription to one joined channel: the handle returned by `subscribe()`
+for observing events and sending on the channel. It stays valid across reconnects
+— the client rejoins automatically.
+
+#### `channel`
+
+```kotlin
+val channel: String
+```
+
+The channel name (the part after `realtime:`).
+
+#### `status`
+
+```kotlin
+val status: StateFlow<Status>
+```
+
+The channel's join lifecycle as a `StateFlow`. Await `SUBSCRIBED` or use
+[`awaitSubscribed`](#awaitsubscribed).
+
+#### `asFlow`
+
+```kotlin
+fun asFlow(): Flow<RealtimeEvent>
+```
+
+A **hot** `Flow` of every decoded inbound [`RealtimeEvent`](#realtimeevent) for
+this channel — postgres changes, broadcasts and presence events interleaved. This
+is a shared, best-effort multicast, **not** a cold flow: collecting it does not
+start or stop the subscription, and events delivered before a collector attaches
+are not replayed (`replay = 0`). Under backpressure a slow collector loses oldest
+events (signaled by [`RealtimeDebugEvent.InboundEventDropped`](#realtimedebugevent))
+rather than stalling the socket. For one event kind, prefer the typed flows
+below.
+
+```kotlin
+sub.asFlow().collect { event ->
+    when (event) {
+        is RealtimeEvent.Broadcast -> render(event.payload)
+        else -> Unit
+    }
+}
+```
+
+#### `presenceState`
+
+```kotlin
+fun presenceState(): PresenceState
+```
+
+The current cumulative presence state — every member currently tracked on this
+channel, keyed by presence key — as of the last `presence_state`/`presence_diff`.
+Returns an empty map before the first sync.
+
+#### `send`
+
+```kotlin
+suspend fun send(type: SendType, event: String, payload: JsonObject? = null)
+```
+
+Low-level send of a Phoenix message of `type` with the given `event` name and
+optional `payload` on this channel. Prefer `broadcast`/`track` for the common
+cases; reach for this only for events they don't cover.
+
+#### `broadcast`
+
+```kotlin
+suspend fun broadcast(event: String, payload: JsonObject)
+```
+
+Broadcasts `payload` under the `event` name to other subscribers of this channel
+(and to this client too if `receiveOwnBroadcasts` was set). Fire-and-forget;
+received by `onBroadcast` handlers / [`broadcastFlow`](#broadcastflow).
+
+```kotlin
+sub.broadcast("cursor", buildJsonObject { put("x", 12); put("y", 40) })
+```
+
+#### `broadcastBinary`
+
+```kotlin
+suspend fun broadcastBinary(event: String, payload: ByteArray)
+```
+
+Broadcasts a raw binary `payload` under the `event` name, sent over the WebSocket
+as a binary frame instead of JSON (enabled by the Phoenix `2.0.0` array frames).
+Received as [`RealtimeEvent.BinaryBroadcast`](#realtimeevent) /
+[`binaryBroadcastFlow`](#binarybroadcastflow). Prefer this over base64-in-`broadcast`
+for compact, high-frequency or non-textual data (sensor streams, image frames,
+encrypted bytes). Fire-and-forget: if the socket is momentarily disconnected the
+frame is dropped rather than buffered. Requires the channel to be subscribed to
+reach other clients.
+
+```kotlin
+sub.broadcastBinary("frame", imageBytes)
+```
+
+#### `broadcastWithAck`
+
+```kotlin
+suspend fun broadcastWithAck(
+    event: String,
+    payload: JsonObject,
+    timeoutMillis: Long = 5_000,
+): SupabaseResult<Unit>
+```
+
+Broadcasts `payload` like `broadcast`, but awaits the server's acknowledgement
+instead of returning fire-and-forget. Requires the channel to have been configured
+with `acknowledgeBroadcasts` (see [`configureBroadcast`](#configurebroadcast)).
+Returns `SupabaseResult.Success` once the server acknowledges, or
+`SupabaseResult.Failure` if the channel is not subscribed, the server rejects the
+push, the connection drops before the ack arrives, or no ack is received within
+`timeoutMillis`. Never throws for these expected failures; genuine caller
+cancellation still propagates.
+
+#### `track`
+
+```kotlin
+suspend fun track(state: JsonObject)
+```
+
+Publishes this client's presence `state` on the channel, making it visible to
+other members' presence handlers under this subscription's presence key. Call
+again to replace the tracked state.
+
+```kotlin
+sub.track(buildJsonObject { put("user", "ada"); put("online_at", now) })
+```
+
+#### `untrack`
+
+```kotlin
+suspend fun untrack()
+```
+
+Removes this client's presence from the channel (the inverse of `track`),
+emitting a leave to other members.
+
+#### `unsubscribe`
+
+```kotlin
+suspend fun unsubscribe()
+```
+
+Leaves the channel (`UNSUBSCRIBED`) and stops delivery; ends `asFlow` collectors.
+Equivalent to [`RealtimeClient.removeSubscription`](#removesubscription) for this
+one.
+
+#### `RealtimeSubscription.Status`
+
+```kotlin
+enum class Status { SUBSCRIBING, SUBSCRIBED, UNSUBSCRIBING, UNSUBSCRIBED, ERROR }
+```
+
+The lifecycle of the channel join, observed via `status`.
+
+#### `RealtimeSubscription.SendType`
+
+```kotlin
+enum class SendType(val wireValue: String) {
+    BROADCAST("broadcast"),
+    PRESENCE("presence"),
+    POSTGRES_CHANGES("postgres_changes"),
+}
+```
+
+The kind of message [`send`](#send) dispatches, with its Phoenix `wireValue`.
+
+### `statusFlow`
+
+```kotlin
+fun RealtimeSubscription.statusFlow(): StateFlow<RealtimeSubscription.Status>
+```
+
+The subscription's `status` as a `StateFlow`, for observing the join lifecycle
+(e.g. to drive a connecting indicator).
+
+### `awaitSubscribed`
+
+```kotlin
+suspend fun RealtimeSubscription.awaitSubscribed(
+    timeoutMs: Long = 10_000,
+): RealtimeSubscription.Status
+```
+
+Suspends until this subscription reaches `SUBSCRIBED` (or `ERROR`) and returns
+that status, throwing `TimeoutCancellationException` after `timeoutMs`. Turns the
+fire-and-forget `subscribe()` into an await.
+
+```kotlin
+val sub = realtime.channel("room1").subscribe()
+sub.awaitSubscribed()
+```
+
+### `awaitUnsubscribed`
+
+```kotlin
+suspend fun RealtimeSubscription.awaitUnsubscribed(
+    timeoutMs: Long = 10_000,
+): RealtimeSubscription.Status
+```
+
+Suspends until this subscription reaches `UNSUBSCRIBED` (or `ERROR`) and returns
+that status, throwing `TimeoutCancellationException` after `timeoutMs`. Use to
+confirm a leave completed after `unsubscribe()`.
+
+## Postgres changes
+
+Beyond the builder callbacks above, these one-call helpers and filter DSL cover
+the common "watch this table" cases.
+
+### `subscribeToPostgresChanges`
+
+```kotlin
+suspend fun RealtimeClient.subscribeToPostgresChanges(
+    channel: String,
+    schema: String = "public",
+    table: String? = null,
+    filter: String? = null,
+    event: PostgresChangeEvent = PostgresChangeEvent.ALL,
+    callback: suspend (JsonObject) -> Unit,
+): RealtimeSubscription
+
+suspend fun RealtimeClient.subscribeToPostgresChanges(
+    channel: String,
+    schema: String = "public",
+    table: String? = null,
+    filter: String? = null,
+    event: PostgresChangeEvent = PostgresChangeEvent.ALL,
+    callback: suspend (PostgresChangeEvent, JsonObject) -> Unit,
+): RealtimeSubscription
+
+suspend inline fun <reified T> RealtimeClient.subscribeToPostgresChanges(
+    channel: String,
+    schema: String = "public",
+    table: String? = null,
+    filter: String? = null,
+    event: PostgresChangeEvent = PostgresChangeEvent.ALL,
+    crossinline onRow: suspend (T) -> Unit,
+): RealtimeSubscription
+```
+
+Subscribes to `channel` and registers a single `postgres_changes` callback in one
+call. The three overloads deliver, respectively: the raw row (`JsonObject`); the
+resolved change type plus the row; and the row decoded into your model `T` (with
+the same skip-on-mismatch semantics as the reified `onPostgresChange`). See
+[`onPostgresChange`](#onpostgreschange) for the parameters and `realtimeFilter`
+for building `filter`.
+
+```kotlin
+val sub = realtime.subscribeToPostgresChanges<Message>(
+    channel = "rooms",
+    table = "messages",
+    filter = realtimeFilter { eq("room_id", roomId) },
+) { msg -> store(msg) }
+```
+
+### `postgresInsertsFlow`
+
+```kotlin
+fun RealtimeSubscription.postgresInsertsFlow(): Flow<JsonObject>
+```
+
+Narrows `asFlow` to `postgres_changes` INSERTs, yielding each inserted row
+(`PostgresInsert.record`).
+
+### `postgresUpdatesFlow`
+
+```kotlin
+fun RealtimeSubscription.postgresUpdatesFlow(): Flow<RealtimeEvent.PostgresUpdate>
+```
+
+Narrows `asFlow` to `postgres_changes` UPDATEs as
+[`RealtimeEvent.PostgresUpdate`](#realtimeevent), carrying both new and old row
+(when replica identity provides the old one).
+
+### `postgresDeletesFlow`
+
+```kotlin
+fun RealtimeSubscription.postgresDeletesFlow(): Flow<JsonObject>
+```
+
+Narrows `asFlow` to `postgres_changes` DELETEs, yielding the deleted row
+(`PostgresDelete.oldRecord`).
+
+```kotlin
+sub.postgresInsertsFlow().collect { row -> append(row) }
+```
+
+### `realtimeFilter`
+
+```kotlin
+inline fun realtimeFilter(block: RealtimeFilter.() -> Unit): String?
+```
+
+Builds the single `column=op.value` filter string for a `postgres_changes`
+subscription. Returns the built string, or `null` if no operator was set.
+
+```kotlin
+val f = realtimeFilter { gte("age", 18) } // "age=gte.18"
+```
+
+### `RealtimeFilter`
+
+```kotlin
+class RealtimeFilter {
+    fun eq(column: String, value: String)
+    fun eq(column: String, value: Number)
+    fun eq(column: String, value: Boolean)
+    fun neq(column: String, value: String)
+    fun neq(column: String, value: Number)
+    fun neq(column: String, value: Boolean)
+    fun gt(column: String, value: Number)
+    fun gte(column: String, value: Number)
+    fun lt(column: String, value: Number)
+    fun lte(column: String, value: Number)
+    fun isIn(column: String, values: List<String>)
+    fun build(): String?
+}
+```
+
+Builds the single server-side filter for a `postgres_changes` subscription
+without hand-writing the wire string. Realtime supports exactly **one** filter per
+subscription and a fixed operator set (`eq`, `neq`, `gt`, `gte`, `lt`, `lte`,
+`in`) — setting more than one throws, as does a blank column.
+
+- `eq` / `neq` — equality and inequality, for strings, numbers or booleans.
+- `gt` / `gte` / `lt` / `lte` — numeric comparisons.
+- `isIn` — `column IN (…)`, e.g. `isIn("status", listOf("open", "pending"))`.
+- `build()` — returns the `column=op.value` string, or `null` if no operator was
+  set.
+
+<Callout type="warning">
+Values are passed through verbatim — the DSL does not quote or escape them. Avoid
+values containing characters the `column=op.value` grammar is sensitive to,
+notably a `,` inside an `in (...)` list and the `=`/`.` separators.
+</Callout>
+
+### `RealtimeFilterDsl`
+
+```kotlin
+annotation class RealtimeFilterDsl
+```
+
+`@DslMarker` for `RealtimeFilter`, so its member operators don't leak into nested
+scopes.
+
+### `PostgresChange`
+
+```kotlin
+@Serializable
+data class PostgresChange(
+    val schema: String = "public",
+    val table: String? = null,
+    val filter: String? = null,
+    val event: PostgresChangeEvent = PostgresChangeEvent.ALL,
+)
+```
+
+A `postgres_changes` subscription descriptor: which `schema`/`table` to watch, for
+which `event` type, optionally narrowed by a single `filter` (`column=op.value`,
+built with `realtimeFilter`). Serializable.
+
+### `PostgresChangeEvent`
+
+```kotlin
+@Serializable
+enum class PostgresChangeEvent { INSERT, UPDATE, DELETE, ALL }
+```
+
+The database change type a `postgres_changes` subscription listens for. `ALL`
+(the wire `*`) matches every type. Serializable, with each entry mapped to its
+wire name (`INSERT`/`UPDATE`/`DELETE`/`*`).
+
+## Broadcast
+
+Broadcast sends messages between clients on a channel, bypassing the database.
+Sending over a subscription is covered above ([`broadcast`](#broadcast-1),
+[`broadcastBinary`](#broadcastbinary), [`broadcastWithAck`](#broadcastwithack));
+the helpers here cover HTTP send, one-call subscribe, and consuming flows.
+
+### `broadcast` (over HTTP)
+
+```kotlin
+suspend fun RealtimeClient.broadcast(
+    channel: String,
+    event: String,
+    payload: JsonObject,
+    private: Boolean = false,
+): SupabaseResult<Unit>
+```
+
+Sends a broadcast over HTTP to the realtime broadcast endpoint
+(`/realtime/v1/api/broadcast`) without joining a channel or opening a WebSocket.
+Useful for fire-and-forget server-to-client fan-out where the sender doesn't need
+to subscribe.
+
+- `channel` — the channel name (without the `realtime:` prefix).
+- `event` — the broadcast event name.
+- `payload` — the message body.
+- `private` — when `true`, targets a private channel; the caller's session JWT
+  (or apikey) is attached automatically.
+
+Returns `SupabaseResult<Unit>`.
+
+```kotlin
+realtime.broadcast("room1", "notice", buildJsonObject { put("text", "hi") })
+```
+
+### `subscribeToBroadcast`
+
+```kotlin
+suspend fun RealtimeClient.subscribeToBroadcast(
+    channel: String,
+    event: String,
+    callback: suspend (JsonObject) -> Unit,
+): RealtimeSubscription
+```
+
+Subscribes to `channel` and registers a single broadcast `callback` for the named
+`event` in one call.
+
+### `broadcastFlow`
+
+```kotlin
+fun RealtimeSubscription.broadcastFlow(event: String? = null): Flow<JsonObject>
+```
+
+Narrows `asFlow` to broadcast payloads, optionally only those whose event name
+equals `event` (all broadcasts when `null`). Yields each message's `JsonObject`
+payload — the typed view over [`RealtimeEvent.Broadcast`](#realtimeevent).
+
+```kotlin
+sub.broadcastFlow("cursor").collect { payload -> moveCursor(payload) }
+```
+
+### `binaryBroadcastFlow`
+
+```kotlin
+fun RealtimeSubscription.binaryBroadcastFlow(event: String? = null): Flow<ByteArray>
+```
+
+Narrows `asFlow` to binary broadcasts, optionally only those whose event name
+equals `event` (all when `null`). Yields each message's raw `ByteArray` payload —
+the typed view over [`RealtimeEvent.BinaryBroadcast`](#realtimeevent). Pair with
+`broadcastBinary` for sending.
+
+### `BroadcastPayload`
+
+```kotlin
+@Serializable
+data class BroadcastPayload(
+    val event: String,
+    val payload: JsonObject,
+)
+```
+
+A broadcast envelope pairing an `event` name with its `payload`; the shape of a
+`broadcast` message body on the wire. Serializable.
+
+## Presence
+
+Presence tracks which clients are currently on a channel. Publishing is covered
+above ([`track`](#track) / [`untrack`](#untrack)); the helpers here cover one-call
+subscribe and consuming flows.
+
+### `subscribeToPresence`
+
+```kotlin
+suspend fun RealtimeClient.subscribeToPresence(
+    channel: String,
+    callback: suspend (PresenceState) -> Unit,
+): RealtimeSubscription
+```
+
+Subscribes to `channel` and registers a single presence sync `callback`, invoked
+with the full [`PresenceState`](#presencestate).
+
+### `presenceSyncFlow`
+
+```kotlin
+fun RealtimeSubscription.presenceSyncFlow(): Flow<PresenceState>
+```
+
+Narrows `asFlow` to presence syncs, yielding the full cumulative `PresenceState`
+on each `presence_state`/`presence_diff`.
+
+### `presenceJoinFlow`
+
+```kotlin
+fun RealtimeSubscription.presenceJoinFlow(): Flow<RealtimeEvent.PresenceJoin>
+```
+
+Narrows `asFlow` to presence join events, one per member that joins the channel.
+
+### `presenceLeaveFlow`
+
+```kotlin
+fun RealtimeSubscription.presenceLeaveFlow(): Flow<RealtimeEvent.PresenceLeave>
+```
+
+Narrows `asFlow` to presence leave events, one per member that leaves the channel.
+
+### `presenceDataFlow`
+
+```kotlin
+inline fun <reified T> RealtimeSubscription.presenceDataFlow(
+    json: Json = Json { ignoreUnknownKeys = true },
+    ignoreDecodeErrors: Boolean = true,
+): Flow<List<T>>
+```
+
+Like `presenceSyncFlow`, but decodes each member's presence payload into `T`,
+emitting the list of decoded members on every sync.
+
+- `json` — the serializer used to decode each member payload.
+- `ignoreDecodeErrors` — when `true` (default), members whose payload doesn't fit
+  `T` are skipped so one malformed member can't break the flow; set `false` to
+  fail fast with `IllegalArgumentException`. `CancellationException` is always
+  rethrown so collection stays cancellable.
+
+```kotlin
+@Serializable data class Member(val user: String)
+
+sub.presenceDataFlow<Member>().collect { members -> showOnline(members) }
+```
+
+### `PresenceState`
+
+```kotlin
+typealias PresenceState = Map<String, JsonObject>
+```
+
+Cumulative presence membership: each presence key mapped to that member's last
+tracked payload. Delivered by `RealtimeEvent.PresenceSync` and
+`RealtimeSubscription.presenceState()`; published with `track`.
+
+## Events
+
+### `RealtimeEvent`
+
+```kotlin
+sealed interface RealtimeEvent {
+    data class PostgresInsert(
+        val record: JsonObject,
+        val oldRecord: JsonObject? = null,
+        val commitTimestamp: String? = null,
+        val schema: String? = null,
+        val table: String? = null,
+    ) : RealtimeEvent
+
+    data class PostgresUpdate(
+        val record: JsonObject,
+        val oldRecord: JsonObject? = null,
+        val commitTimestamp: String? = null,
+        val schema: String? = null,
+        val table: String? = null,
+    ) : RealtimeEvent
+
+    data class PostgresDelete(
+        val oldRecord: JsonObject,
+        val commitTimestamp: String? = null,
+        val schema: String? = null,
+        val table: String? = null,
+    ) : RealtimeEvent
+
+    data class Broadcast(
+        val event: String,
+        val payload: JsonObject,
+        val replayed: Boolean = false,
+    ) : RealtimeEvent
+
+    class BinaryBroadcast(
+        val event: String,
+        val payload: ByteArray,
+        val replayed: Boolean = false,
+    ) : RealtimeEvent
+
+    data class PresenceSync(val state: PresenceState) : RealtimeEvent
+    data class PresenceJoin(val key: String, val newPresence: JsonObject) : RealtimeEvent
+    data class PresenceLeave(val key: String, val leftPresence: JsonObject) : RealtimeEvent
+    data class SystemEvent(val status: String, val message: String? = null) : RealtimeEvent
+}
+```
+
+A decoded inbound event on a Realtime channel, as delivered by `asFlow`. Spans the
+three channel features plus channel `SystemEvent`s. The typed flows above narrow
+this union to one case so you can avoid the `is`-checks.
+
+- `PostgresInsert` — a row was inserted; `record` is the new row. `commitTimestamp`
+  is the server commit time (ISO-8601), `schema`/`table` identify the relation;
+  all three are `null` if the server omits them.
+- `PostgresUpdate` — a row was updated; `record` is the new row and `oldRecord` the
+  previous one when the table's replica identity provides it.
+- `PostgresDelete` — a row was deleted; `oldRecord` is the removed row (may be
+  partial, depending on replica identity).
+- `Broadcast` — a broadcast message named `event` carrying `payload`. `replayed` is
+  `true` when the server is replaying a retained broadcast to a late joiner.
+- `BinaryBroadcast` — a broadcast named `event` carrying raw binary `payload`,
+  delivered as a binary frame. Implements structural `equals`/`hashCode` over the
+  byte content. `replayed` mirrors `Broadcast.replayed`.
+- `PresenceSync` — `state` is the full cumulative membership after a sync.
+- `PresenceJoin` / `PresenceLeave` — a member identified by `key` joined (carrying
+  `newPresence`) or left (carrying its last `leftPresence`).
+- `SystemEvent` — a channel-level system message (e.g. subscription status
+  changes), with an optional human-readable `message`.
+
+### `systemEventFlow`
+
+```kotlin
+fun RealtimeSubscription.systemEventFlow(status: String? = null): Flow<RealtimeEvent.SystemEvent>
+```
+
+Narrows `asFlow` to channel system events, optionally only those with the given
+`status` (all when `null`).
+
+## Models and diagnostics
+
+### `RealtimeChannel`
+
+```kotlin
+data class RealtimeChannel(val name: String, val topic: String)
+```
+
+Identifies an active channel by its `name` and fully-qualified Phoenix `topic`
+(e.g. `realtime:room1`); returned by [`getActiveChannels`](#getactivechannels).
+
+### `RealtimeMessage`
+
+```kotlin
+@Serializable(with = RealtimeMessageSerializer::class)
+data class RealtimeMessage(
+    val topic: String,
+    val event: String,
+    val payload: JsonObject,
+    val joinRef: String? = null,
+    val ref: String? = null,
+)
+```
+
+A raw Phoenix protocol frame. On the wire (Realtime Protocol `2.0.0`) this is the
+array `[join_ref, ref, topic, event, payload]`. Surfaced via
+[`RealtimeDebugEvent`](#realtimedebugevent) for diagnostics; application code
+normally works with decoded `RealtimeEvent`s instead.
+
+- `topic` — the channel topic (e.g. `realtime:room1`) or `phoenix` for socket
+  control frames.
+- `event` — the Phoenix event name (`phx_join`, `phx_reply`, `broadcast`, …).
+- `payload` — the message body.
+- `joinRef` — the ref of the join that scopes this message.
+- `ref` — the per-message correlation ref used to match replies.
+
+### `RealtimeClient.debugState`
+
+```kotlin
+val debugState: StateFlow<RealtimeDebugState>
+```
+
+Running counters (messages in/out, heartbeats, last refs) for diagnostics and
+tests. See [`RealtimeDebugState`](#realtimedebugstate).
+
+### `RealtimeClient.debugEvents`
+
+```kotlin
+val debugEvents: Flow<RealtimeDebugEvent>
+```
+
+A hot stream of low-level protocol events ([`RealtimeDebugEvent`](#realtimedebugevent))
+— including dropped-message signals — for diagnostics; not needed for normal use.
+
+### `RealtimeDebugState`
+
+```kotlin
+data class RealtimeDebugState(
+    val outboundMessageCount: Long = 0,
+    val inboundMessageCount: Long = 0,
+    val heartbeatSentCount: Long = 0,
+    val heartbeatReceivedCount: Long = 0,
+    val lastOutboundRef: String? = null,
+    val lastInboundRef: String? = null,
+)
+```
+
+A snapshot of cumulative socket counters, exposed via `debugState`. Counts every
+message and heartbeat sent and received since the client was created, plus the
+last Phoenix message `ref` in each direction.
+
+### `RealtimeDebugEvent`
+
+```kotlin
+sealed interface RealtimeDebugEvent {
+    data class OutboundMessage(val message: RealtimeMessage) : RealtimeDebugEvent
+    data class OutboundMessageDropped(val message: RealtimeMessage, val capacity: Int) : RealtimeDebugEvent
+    data class InboundMessage(val message: RealtimeMessage) : RealtimeDebugEvent
+    data class InboundEventDropped(val topic: String, val event: RealtimeEvent, val capacity: Int) : RealtimeDebugEvent
+    data class HeartbeatSent(val ref: String) : RealtimeDebugEvent
+    data class HeartbeatReceived(val ref: String?) : RealtimeDebugEvent
+}
+```
+
+A low-level protocol event observed on the socket, streamed by `debugEvents`.
+Covers every raw `RealtimeMessage` in and out, heartbeats, and the buffer-overflow
+drop signals — for diagnostics and tests, not normal application logic.
+
+- `OutboundMessage` / `InboundMessage` — a raw frame sent to / received from the
+  server.
+- `OutboundMessageDropped` — an outbound application message was dropped from the
+  full offline send buffer (`capacity` messages); the oldest buffered message is
+  discarded to make room for the newest.
+- `InboundEventDropped` — a decoded inbound event was dropped from a subscription's
+  event flow because a slow collector left the buffer full (`capacity` events);
+  Realtime delivery is best-effort under backpressure. The inbound mirror of
+  `OutboundMessageDropped`.
+- `HeartbeatSent` — a heartbeat was sent, tagged with its Phoenix `ref`.
+- `HeartbeatReceived` — a heartbeat reply was received, echoing the sent `ref`
+  (`null` if the server omitted it).

--- a/website/pages/reference/storage.mdx
+++ b/website/pages/reference/storage.mdx
@@ -1,0 +1,2538 @@
+---
+title: Storage — API Reference
+description: Typed, Result-first client for Supabase Storage. Manage buckets, upload and download objects, list with offset or cursor paging, build public/authenticated/signed/render URLs, run resumable (TUS) uploads, and drive the analytics (Apache Iceberg) and S3-Vectors surfaces. Complete 1.0.0 reference for io.github.androidpoet:supabase-storage.
+---
+
+import { Callout } from 'nextra/components'
+
+# Storage — API Reference
+
+The **supabase-storage** module is a typed, Result-first wrapper over the
+Supabase Storage REST API (`/storage/v1`). It manages buckets, uploads and
+downloads objects, lists them with offset or cursor paging, builds
+public/authenticated/signed/render URLs locally, runs resumable (TUS) uploads,
+and exposes the analytics (Apache Iceberg) catalog and S3-Vectors surfaces.
+
+Every suspending call returns a `SupabaseResult<T>` rather than throwing —
+network and HTTP errors (for example `404` for a missing object, `409` on an
+upsert conflict) arrive as `Failure`, so they are values you handle rather than
+exceptions you catch. The non-suspending URL builders compute a string locally
+and never touch the network.
+
+- **Maven artifact:** `io.github.androidpoet:supabase-storage`
+- **Entry point:** `createStorageClient(client)` (or the `client.storage` accessor)
+- **Package:** `io.github.androidpoet.supabase.storage` (models in `…storage.models`)
+
+Object paths are bucket-relative keys (for example `folder/file.png`) and are
+URL-encoded for you, with `/` preserved as a path separator.
+
+## Setup
+
+### createStorageClient
+
+Builds a [`StorageClient`](#storageclient) from an existing `SupabaseClient`.
+
+```kotlin
+fun createStorageClient(supabaseClient: SupabaseClient): StorageClient
+```
+
+- `supabaseClient` — the configured client whose project URL the storage calls target.
+
+**Returns** a `StorageClient`. This call does no I/O and does not fail.
+
+```kotlin
+val storage = createStorageClient(client)
+```
+
+### SupabaseClient.storage
+
+A discoverable extension property that calls `createStorageClient` for you, so
+you can reach storage as `client.storage`. The returned client is a thin,
+stateless wrapper, so reading the property repeatedly is cheap.
+
+```kotlin
+val SupabaseClient.storage: StorageClient
+```
+
+```kotlin
+val files = client.storage.list(bucket = "avatars")
+```
+
+---
+
+## StorageClient
+
+The interface exposing every storage operation. Suspending calls return
+`SupabaseResult<T>`; the URL builders return a `String` (or collection) computed
+locally. The sections below group the members by area.
+
+## Buckets
+
+### listBuckets
+
+Lists the buckets visible to the current credentials (`GET /bucket`).
+
+```kotlin
+suspend fun listBuckets(
+    limit: Int? = null,
+    offset: Int? = null,
+    sortColumn: String? = null,
+    sortOrder: SortOrder? = null,
+    search: String? = null,
+): SupabaseResult<List<Bucket>>
+```
+
+- `limit` — maximum number of buckets to return. Default `null`.
+- `offset` — number of buckets to skip, for paging. Default `null`.
+- `sortColumn` — column to sort by (server-defined, e.g. `name`/`created_at`). Default `null`.
+- `sortOrder` — ascending or descending order for `sortColumn`. Default `null`.
+- `search` — case-insensitive filter applied server-side to bucket names. Default `null`.
+
+**Returns** `SupabaseResult<List<Bucket>>` — `Success` with the buckets, `Failure` on error.
+
+```kotlin
+val buckets = storage.listBuckets(search = "avatars")
+```
+
+### getBucket
+
+Fetches a single bucket by `id`.
+
+```kotlin
+suspend fun getBucket(id: String): SupabaseResult<Bucket>
+```
+
+- `id` — the bucket id.
+
+**Returns** `SupabaseResult<Bucket>` — `Success` with the bucket, `Failure` (`404`) if no such bucket exists.
+
+```kotlin
+val bucket = storage.getBucket("avatars")
+```
+
+### createBucket
+
+Creates a bucket, returning the created [`Bucket`](#bucket).
+
+```kotlin
+suspend fun createBucket(
+    id: String,
+    name: String,
+    public: Boolean = false,
+    fileSizeLimit: Long? = null,
+    allowedMimeTypes: List<String>? = null,
+): SupabaseResult<Bucket>
+```
+
+- `id` — the bucket id (its stable identifier and URL segment).
+- `name` — human-readable bucket name.
+- `public` — when `true`, objects are readable via the public endpoint without a token. Default `false`.
+- `fileSizeLimit` — optional per-object size cap in bytes; `null` leaves it unset. Default `null`.
+- `allowedMimeTypes` — optional whitelist of accepted content types; `null` allows any. Default `null`.
+
+**Returns** `SupabaseResult<Bucket>` — `Success` with the created bucket, `Failure` (e.g. `409`) if `id` is already taken.
+
+```kotlin
+val bucket = storage.createBucket(
+    id = "avatars",
+    name = "avatars",
+    public = true,
+    fileSizeLimit = 5 * 1024 * 1024,
+    allowedMimeTypes = listOf("image/png", "image/jpeg"),
+)
+```
+
+### updateBucket
+
+Updates a bucket's mutable attributes. Only non-null arguments are sent, so
+omitted fields are left unchanged.
+
+```kotlin
+suspend fun updateBucket(
+    id: String,
+    name: String? = null,
+    public: Boolean? = null,
+    fileSizeLimit: Long? = null,
+    allowedMimeTypes: List<String>? = null,
+): SupabaseResult<Bucket>
+```
+
+- `id` — the bucket to update.
+- `name` — new bucket name, or `null` to keep it. Default `null`.
+- `public` — new public flag, or `null` to keep it. Default `null`.
+- `fileSizeLimit` — new per-object size cap in bytes, or `null` to keep it. Default `null`.
+- `allowedMimeTypes` — new MIME whitelist, or `null` to keep it. Default `null`.
+
+**Returns** `SupabaseResult<Bucket>` — `Success` with the updated bucket, `Failure` on error.
+
+```kotlin
+storage.updateBucket(id = "avatars", public = false)
+```
+
+### deleteBucket
+
+Deletes a bucket. The bucket must be empty first; see [`clearBucket`](#clearbucket).
+
+```kotlin
+suspend fun deleteBucket(id: String): SupabaseResult<Unit>
+```
+
+- `id` — the bucket to delete.
+
+**Returns** `SupabaseResult<Unit>` — `Success` on deletion, `Failure` (e.g. if the bucket is not empty) otherwise.
+
+```kotlin
+storage.deleteBucket("avatars")
+```
+
+### clearBucket
+
+Removes every object from a bucket without deleting the bucket itself.
+
+```kotlin
+suspend fun clearBucket(id: String): SupabaseResult<Unit>
+```
+
+- `id` — the bucket to empty.
+
+**Returns** `SupabaseResult<Unit>` — `Success` when cleared, `Failure` on error.
+
+```kotlin
+storage.clearBucket("avatars")        // then deleteBucket succeeds
+```
+
+---
+
+## Objects
+
+### upload
+
+Uploads `data` to `path` in `bucket`.
+
+```kotlin
+suspend fun upload(
+    bucket: String,
+    path: String,
+    data: ByteArray,
+    contentType: String = "application/octet-stream",
+    upsert: Boolean = false,
+    cacheControl: Int? = null,
+    metadata: JsonObject? = null,
+): SupabaseResult<String>
+```
+
+- `bucket` — target bucket.
+- `path` — bucket-relative key to write.
+- `data` — the bytes to upload.
+- `contentType` — MIME type stored for the object. Default `"application/octet-stream"`.
+- `upsert` — when `true`, overwrite an existing object at `path`. Default `false`.
+- `cacheControl` — cache-control max-age in seconds, when set. Default `null`.
+- `metadata` — optional user metadata; Base64-encoded into the `x-metadata` header. Default `null`.
+
+**Returns** `SupabaseResult<String>` — `Success` with the server-reported key, `Failure` (e.g. `409` without `upsert`) on error.
+
+```kotlin
+val key = storage.upload(
+    bucket = "avatars",
+    path = "jane/profile.png",
+    data = pngBytes,
+    contentType = "image/png",
+    upsert = true,
+)
+```
+
+### update
+
+Replaces the object at `path` in `bucket` with `data`. Same parameters and
+return as [`upload`](#upload).
+
+```kotlin
+suspend fun update(
+    bucket: String,
+    path: String,
+    data: ByteArray,
+    contentType: String = "application/octet-stream",
+    upsert: Boolean = false,
+    cacheControl: Int? = null,
+    metadata: JsonObject? = null,
+): SupabaseResult<String>
+```
+
+**Returns** `SupabaseResult<String>` — `Success` with the key, `Failure` on error.
+
+```kotlin
+storage.update(bucket = "avatars", path = "jane/profile.png", data = newBytes)
+```
+
+### createResumableUpload
+
+Creates a resumable (TUS) upload handle. The upload is not started until
+[`ResumableUpload.await`](#resumableupload) is called. Pass `uploadUrl` (a
+previously captured [`ResumableUpload.uploadUrl`](#resumableupload)) to resume an
+interrupted upload instead of starting a new one.
+
+```kotlin
+fun createResumableUpload(
+    bucket: String,
+    path: String,
+    data: ByteArray,
+    contentType: String = "application/octet-stream",
+    upsert: Boolean = false,
+    cacheControl: Int? = null,
+    chunkSize: Int = RESUMABLE_DEFAULT_CHUNK_SIZE,
+    uploadUrl: String? = null,
+    metadata: JsonObject? = null,
+): ResumableUpload
+```
+
+- `bucket` — target bucket.
+- `path` — bucket-relative key to write.
+- `data` — the full payload to upload in chunks.
+- `contentType` — MIME type stored for the object. Default `"application/octet-stream"`.
+- `upsert` — overwrite an existing object. Default `false`.
+- `cacheControl` — cache-control max-age in seconds, when set. Default `null`.
+- `chunkSize` — bytes per chunk; must be positive (a non-positive value throws `IllegalArgumentException` eagerly). Every chunk except the last must be a multiple of [`RESUMABLE_DEFAULT_CHUNK_SIZE`](#resumable_default_chunk_size) (6 MiB). Default `RESUMABLE_DEFAULT_CHUNK_SIZE`.
+- `uploadUrl` — a previously persisted upload URL to resume; `null` starts a new upload. Default `null`.
+- `metadata` — optional user metadata; Base64-encoded into the TUS `Upload-Metadata` header. Default `null`.
+
+**Returns** a [`ResumableUpload`](#resumableupload) handle (no I/O until `await`).
+
+```kotlin
+val handle = storage.createResumableUpload("videos", "clip.mp4", videoBytes)
+val result = handle.await()
+```
+
+### uploadResumable
+
+Extension that runs a resumable upload to completion in one call. Use
+[`createResumableUpload`](#createresumableupload) directly when you need progress
+or pause/resume.
+
+```kotlin
+suspend fun StorageClient.uploadResumable(
+    bucket: String,
+    path: String,
+    data: ByteArray,
+    contentType: String = "application/octet-stream",
+    upsert: Boolean = false,
+    cacheControl: Int? = null,
+    chunkSize: Int = RESUMABLE_DEFAULT_CHUNK_SIZE,
+    metadata: JsonObject? = null,
+): SupabaseResult<Unit>
+```
+
+- Parameters mirror [`createResumableUpload`](#createresumableupload) (without `uploadUrl`).
+
+**Returns** `SupabaseResult<Unit>` — `Success` when the upload completes, `Failure` on error.
+
+```kotlin
+storage.uploadResumable("videos", "clip.mp4", videoBytes)
+```
+
+### uploadToSignedUrl
+
+Uploads `data` to a pre-signed upload URL identified by `token` (see
+[`createUploadSignedUrl`](#createuploadsignedurl)).
+
+```kotlin
+suspend fun uploadToSignedUrl(
+    bucket: String,
+    path: String,
+    token: String,
+    data: ByteArray,
+    contentType: String = "application/octet-stream",
+    upsert: Boolean = false,
+    cacheControl: Int? = null,
+    metadata: JsonObject? = null,
+): SupabaseResult<String>
+```
+
+- `bucket` — bucket the token was issued for.
+- `path` — the object path bound to the token.
+- `token` — the signed upload token.
+- `data` — the bytes to upload.
+- `contentType` — MIME type stored for the object. Default `"application/octet-stream"`.
+- `upsert` — overwrite an existing object. Default `false`.
+- `cacheControl` — cache-control max-age in seconds, when set. Default `null`.
+- `metadata` — optional user metadata; Base64-encoded into the `x-metadata` header. Default `null`.
+
+**Returns** `SupabaseResult<String>` — `Success` with the key, `Failure` on error.
+
+```kotlin
+storage.uploadToSignedUrl("avatars", "jane/profile.png", token, pngBytes)
+```
+
+### download
+
+Downloads an object's body as a UTF-8 string from the authenticated endpoint.
+Text-only — for binary data use [`downloadBytes`](#downloadbytes). Two overloads:
+
+```kotlin
+suspend fun download(bucket: String, path: String): SupabaseResult<String>
+
+suspend fun download(
+    bucket: String,
+    path: String,
+    download: Boolean = true,
+    fileName: String? = null,
+): SupabaseResult<String>
+```
+
+- `bucket` / `path` — the object to read.
+- `download` — when `true`, send the `download` query so the server marks the response as an attachment. Default `true` (in the second overload).
+- `fileName` — optional file name suggested for the saved attachment. Default `null`.
+
+**Returns** `SupabaseResult<String>` — `Success` with the decoded text, `Failure` on error.
+
+```kotlin
+val text = storage.download(bucket = "docs", path = "notes.txt")
+```
+
+### downloadPublic
+
+Like [`download`](#download) but reads from the public endpoint; no token
+required. Same two overloads (`download` defaults to `true` in the parameterized one).
+
+```kotlin
+suspend fun downloadPublic(bucket: String, path: String): SupabaseResult<String>
+
+suspend fun downloadPublic(
+    bucket: String,
+    path: String,
+    download: Boolean = true,
+    fileName: String? = null,
+): SupabaseResult<String>
+```
+
+**Returns** `SupabaseResult<String>` — `Success` with the decoded text, `Failure` on error.
+
+```kotlin
+val text = storage.downloadPublic("public-docs", "readme.txt")
+```
+
+### downloadBytes
+
+Downloads an object's raw bytes from the authenticated endpoint. Prefer this over
+[`download`](#download) for any non-text content. An empty object returns an empty
+`ByteArray`, not a failure. Two overloads — plain and with an image
+[`transform`](#imagetransformoptions) (the render endpoint):
+
+```kotlin
+suspend fun downloadBytes(
+    bucket: String,
+    path: String,
+    download: Boolean = false,
+    fileName: String? = null,
+): SupabaseResult<ByteArray>
+
+suspend fun downloadBytes(
+    bucket: String,
+    path: String,
+    transform: ImageTransformOptions,
+    download: Boolean = false,
+    fileName: String? = null,
+): SupabaseResult<ByteArray>
+```
+
+- `bucket` / `path` — the object to read.
+- `transform` — server-side image resize/format/quality (render endpoint).
+- `download` — request an attachment response. Default `false`.
+- `fileName` — suggested attachment file name. Default `null`.
+
+**Returns** `SupabaseResult<ByteArray>` — `Success` with the bytes, `Failure` on error.
+
+```kotlin
+val bytes = storage.downloadBytes("avatars", "jane/profile.png")
+val thumb = storage.downloadBytes(
+    "avatars", "jane/profile.png",
+    transform = ImageTransformOptions(width = 64, height = 64),
+)
+```
+
+### downloadPublicBytes
+
+Binary download from the public endpoint. Same two overloads as
+[`downloadBytes`](#downloadbytes) (plain and with `transform`, the public render endpoint).
+
+```kotlin
+suspend fun downloadPublicBytes(
+    bucket: String,
+    path: String,
+    download: Boolean = false,
+    fileName: String? = null,
+): SupabaseResult<ByteArray>
+
+suspend fun downloadPublicBytes(
+    bucket: String,
+    path: String,
+    transform: ImageTransformOptions,
+    download: Boolean = false,
+    fileName: String? = null,
+): SupabaseResult<ByteArray>
+```
+
+**Returns** `SupabaseResult<ByteArray>` — `Success` with the bytes, `Failure` on error.
+
+```kotlin
+val bytes = storage.downloadPublicBytes("public-images", "logo.png")
+```
+
+### info
+
+Fetches an object's metadata ([`FileObject`](#fileobject)) without its body, via
+the authenticated info endpoint.
+
+```kotlin
+suspend fun info(bucket: String, path: String): SupabaseResult<FileObject>
+```
+
+- `bucket` / `path` — the object to inspect.
+
+**Returns** `SupabaseResult<FileObject>` — `Success` with the metadata, `Failure` (`404`) if the object does not exist.
+
+```kotlin
+val meta = storage.info("avatars", "jane/profile.png")
+```
+
+### infoPublic
+
+Like [`info`](#info) but from the public info endpoint.
+
+```kotlin
+suspend fun infoPublic(bucket: String, path: String): SupabaseResult<FileObject>
+```
+
+**Returns** `SupabaseResult<FileObject>` — `Success` with the metadata, `Failure` on error.
+
+```kotlin
+val meta = storage.infoPublic("public-images", "logo.png")
+```
+
+### exists
+
+Reports whether an object exists, via [`info`](#info). A `404` maps to
+`Success(false)`; any other failure (auth, network) is still surfaced as `Failure`.
+
+```kotlin
+suspend fun exists(bucket: String, path: String): SupabaseResult<Boolean>
+```
+
+**Returns** `SupabaseResult<Boolean>` — `Success(true/false)`, or `Failure` for non-404 errors.
+
+```kotlin
+val present = storage.exists("avatars", "jane/profile.png")
+```
+
+### existsPublic
+
+Like [`exists`](#exists) but probes the public endpoint via [`infoPublic`](#infopublic).
+
+```kotlin
+suspend fun existsPublic(bucket: String, path: String): SupabaseResult<Boolean>
+```
+
+**Returns** `SupabaseResult<Boolean>` — `Success(true/false)`, or `Failure` on error.
+
+```kotlin
+val present = storage.existsPublic("public-images", "logo.png")
+```
+
+### list
+
+Lists objects and folders under `prefix` in `bucket` (`POST /object/list`). This
+is the offset-paged listing; for cursor paging use [`listV2`](#listv2).
+
+```kotlin
+suspend fun list(
+    bucket: String,
+    prefix: String = "",
+    limit: Int = 100,
+    offset: Int = 0,
+    sortBy: String? = null,
+    sortOrder: SortOrder = SortOrder.ASC,
+    search: String? = null,
+): SupabaseResult<List<FileObject>>
+```
+
+- `bucket` — bucket to list.
+- `prefix` — folder path to list within; empty lists the bucket root. Default `""`.
+- `limit` — maximum entries to return. Default `100`.
+- `offset` — entries to skip, for paging. Default `0`.
+- `sortBy` — column to sort by; `null` leaves the server default ordering. Default `null`.
+- `sortOrder` — ascending or descending, applied when `sortBy` is set. Default `SortOrder.ASC`.
+- `search` — case-insensitive filter applied server-side to entry names. Default `null`.
+
+**Returns** `SupabaseResult<List<FileObject>>` — `Success` with the entries, `Failure` on error.
+
+```kotlin
+val entries = storage.list(bucket = "avatars", prefix = "jane")
+```
+
+### listV2
+
+Cursor-paged object listing (`POST /object/list-v2`) returning an
+[`ObjectListV2Result`](#objectlistv2result) that separates folders from objects
+and carries a `nextCursor`/`hasNext` for continuation. Prefer this over
+[`list`](#list) for large buckets or delimiter-style folder navigation.
+
+```kotlin
+suspend fun listV2(
+    bucket: String,
+    prefix: String? = null,
+    cursor: String? = null,
+    limit: Int? = null,
+    withDelimiter: Boolean? = null,
+    sortBy: String? = null,
+    sortOrder: SortOrder = SortOrder.ASC,
+): SupabaseResult<ObjectListV2Result>
+```
+
+- `bucket` — bucket to list.
+- `prefix` — folder path to list within; `null` lists the bucket root. Default `null`.
+- `cursor` — continuation cursor from a previous result's `nextCursor`. Default `null`.
+- `limit` — maximum entries to return in this page. Default `null`.
+- `withDelimiter` — when `true`, collapse nested keys into folder entries. Default `null`.
+- `sortBy` — column to sort by; `null` leaves the server default. Default `null`.
+- `sortOrder` — order applied when `sortBy` is set. Default `SortOrder.ASC`.
+
+**Returns** `SupabaseResult<ObjectListV2Result>` — `Success` with the page, `Failure` on error.
+
+```kotlin
+var page = storage.listV2(bucket = "avatars", withDelimiter = true).getOrThrow()
+while (page.hasNext) {
+    page = storage.listV2(bucket = "avatars", cursor = page.nextCursor).getOrThrow()
+}
+```
+
+### listOrThrow
+
+Extension form of [`list`](#list) that returns the `List<FileObject>` directly and
+**throws** on failure — the exception-channel variant for paging or try/catch callers.
+
+```kotlin
+suspend fun StorageClient.listOrThrow(
+    bucket: String,
+    prefix: String = "",
+    limit: Int = 100,
+    offset: Int = 0,
+    sortBy: String? = null,
+    sortOrder: SortOrder = SortOrder.ASC,
+    search: String? = null,
+): List<FileObject>
+```
+
+- Parameters mirror [`list`](#list).
+
+**Returns** `List<FileObject>` directly; throws on failure.
+
+```kotlin
+val entries = storage.listOrThrow(bucket = "avatars")
+```
+
+### listPaginator
+
+Extension that builds a demand-driven `Paginator<FileObject>` over the objects
+under `prefix`, fetching one offset-based page per `loadNext` via [`list`](#list).
+Nothing is fetched until `loadNext` is called; the accumulated entries and the
+loading/end/error state are exposed as `StateFlow`s.
+
+```kotlin
+fun StorageClient.listPaginator(
+    bucket: String,
+    prefix: String = "",
+    pageSize: Int = 100,
+    sortBy: String? = null,
+    sortOrder: SortOrder = SortOrder.ASC,
+    search: String? = null,
+): Paginator<FileObject>
+```
+
+- `bucket` — bucket to page over.
+- `prefix` — folder path to list within. Default `""`.
+- `pageSize` — entries per page; must be greater than 0. Default `100`.
+- `sortBy` / `sortOrder` / `search` — as in [`list`](#list).
+
+**Returns** a `Paginator<FileObject>`; a failure surfaces via `Paginator.error`.
+
+```kotlin
+val paginator = storage.listPaginator(bucket = "avatars", pageSize = 50)
+paginator.loadNext()
+```
+
+### move
+
+Moves (renames) the object at `fromPath` to `toPath` (`POST /object/move`),
+optionally across buckets. Unlike [`copy`](#copy), the source no longer exists
+afterward.
+
+```kotlin
+suspend fun move(
+    bucket: String,
+    fromPath: String,
+    toPath: String,
+    destinationBucket: String? = null,
+): SupabaseResult<Unit>
+```
+
+- `bucket` — source bucket.
+- `fromPath` — object key to move.
+- `toPath` — target object key.
+- `destinationBucket` — target bucket when moving across buckets; `null` moves within `bucket`. Default `null`.
+
+**Returns** `SupabaseResult<Unit>` — `Success` on success, `Failure` on error.
+
+```kotlin
+storage.move("avatars", "tmp/upload.png", "jane/profile.png")
+```
+
+### copy
+
+Copies the object at `fromPath` to `toPath` (`POST /object/copy`), optionally
+across buckets; the source is left in place (contrast [`move`](#move)).
+
+```kotlin
+suspend fun copy(
+    bucket: String,
+    fromPath: String,
+    toPath: String,
+    destinationBucket: String? = null,
+    copyMetadata: Boolean? = null,
+): SupabaseResult<Unit>
+```
+
+- `bucket` — source bucket.
+- `fromPath` — object key to copy.
+- `toPath` — target object key.
+- `destinationBucket` — target bucket when copying across buckets; `null` copies within `bucket`. Default `null`.
+- `copyMetadata` — when `true`, also copy the object's user metadata. Default `null`.
+
+**Returns** `SupabaseResult<Unit>` — `Success` on success, `Failure` on error.
+
+```kotlin
+storage.copy("avatars", "jane/profile.png", "jane/profile-backup.png")
+```
+
+### deleteObject
+
+Deletes a single object at `path` in `bucket`. For batch deletes prefer
+[`deleteObjects`](#deleteobjects).
+
+```kotlin
+suspend fun deleteObject(bucket: String, path: String): SupabaseResult<Unit>
+```
+
+- `bucket` / `path` — the object to delete.
+
+**Returns** `SupabaseResult<Unit>` — `Success` on deletion, `Failure` on error.
+
+```kotlin
+storage.deleteObject("avatars", "jane/profile.png")
+```
+
+### deleteObjects
+
+Deletes multiple objects by `paths` in one request and returns the
+[`FileObject`](#fileobject) entries the server reports as removed. Callers that
+don't need the removed set can ignore the value. A `vararg` extension overload is
+also provided.
+
+```kotlin
+suspend fun deleteObjects(bucket: String, paths: List<String>): SupabaseResult<List<FileObject>>
+
+// extension
+suspend fun StorageClient.deleteObjects(
+    bucket: String,
+    vararg paths: String,
+): SupabaseResult<List<FileObject>>
+```
+
+- `bucket` — bucket to delete from.
+- `paths` — object keys to remove.
+
+**Returns** `SupabaseResult<List<FileObject>>` — `Success` with the removed entries, `Failure` on error.
+
+```kotlin
+storage.deleteObjects("avatars", "jane/old.png", "jane/older.png")
+```
+
+---
+
+## URLs
+
+The URL builders compute a string locally and never hit the network. Signing
+operations (`createSignedUrl`, `createUploadSignedUrl`) are suspending and do call
+the server.
+
+### createSignedUrl
+
+Creates a time-limited signed download URL for a private object
+(`POST /object/sign`), letting an unauthenticated client read it until the URL
+expires.
+
+```kotlin
+suspend fun createSignedUrl(
+    bucket: String,
+    path: String,
+    expiresIn: Long,
+    download: Boolean = false,
+    fileName: String? = null,
+    transform: ImageTransformOptions? = null,
+): SupabaseResult<String>
+```
+
+- `bucket` / `path` — the object to sign.
+- `expiresIn` — lifetime of the signed URL in seconds.
+- `download` — when `true`, the URL carries the `download` param so the object is served as an attachment. Default `false`.
+- `fileName` — suggested attachment file name. Default `null`.
+- `transform` — optional image transform baked into the signed URL (render endpoint). Default `null`.
+
+**Returns** `SupabaseResult<String>` — `Success` with the signed URL, `Failure` on error.
+
+```kotlin
+val url = storage.createSignedUrl("avatars", "jane/profile.png", expiresIn = 3600)
+```
+
+### createSignedUrls
+
+Batch variant of [`createSignedUrl`](#createsignedurl): signs every path in
+one request and returns the URLs in the same order.
+
+```kotlin
+suspend fun createSignedUrls(
+    bucket: String,
+    paths: List<String>,
+    expiresIn: Long,
+    download: Boolean = false,
+    fileName: String? = null,
+): SupabaseResult<List<String>>
+```
+
+- `bucket` — bucket to sign within.
+- `paths` — object keys to sign.
+- `expiresIn` / `download` / `fileName` — as in [`createSignedUrl`](#createsignedurl).
+
+**Returns** `SupabaseResult<List<String>>` — `Success` with the URLs in order, `Failure` on error.
+
+```kotlin
+val urls = storage.createSignedUrls("avatars", listOf("a.png", "b.png"), expiresIn = 600)
+```
+
+### createSignedDownloadUrl / createSignedDownloadUrls
+
+Extension conveniences over [`createSignedUrl`](#createsignedurl) /
+[`createSignedUrls`](#createsignedurls) that always set `download = true`, so the
+object is served as an attachment.
+
+```kotlin
+suspend fun StorageClient.createSignedDownloadUrl(
+    bucket: String, path: String, expiresIn: Long, fileName: String? = null,
+): SupabaseResult<String>
+
+suspend fun StorageClient.createSignedDownloadUrl(
+    bucket: String, path: String, expiresIn: Long,
+    fileName: String? = null, transform: ImageTransformOptions? = null,
+): SupabaseResult<String>
+
+suspend fun StorageClient.createSignedDownloadUrls(
+    bucket: String, paths: List<String>, expiresIn: Long, fileName: String? = null,
+): SupabaseResult<List<String>>
+suspend fun StorageClient.createSignedDownloadUrls(
+    bucket: String, expiresIn: Long, vararg paths: String,
+): SupabaseResult<List<String>>
+suspend fun StorageClient.createSignedDownloadUrls(
+    bucket: String, expiresIn: Long, fileName: String?, vararg paths: String,
+): SupabaseResult<List<String>>
+```
+
+- `bucket` / `path` / `paths` — object(s) to sign.
+- `expiresIn` — URL lifetime in seconds.
+- `fileName` — suggested attachment file name. Default `null`.
+- `transform` — optional image transform (render endpoint). Default `null`.
+
+**Returns** `SupabaseResult<String>` (single) or `SupabaseResult<List<String>>` (batch) — `Success` with attachment URL(s), `Failure` on error.
+
+```kotlin
+val url = storage.createSignedDownloadUrl("docs", "report.pdf", expiresIn = 3600)
+```
+
+### createSignedDownloadUrlsByPath
+
+Like [`createSignedDownloadUrls`](#createsigneddownloadurl--createsigneddownloadurls)
+but returns a path-to-URL `Map` instead of a positional list.
+
+```kotlin
+suspend fun StorageClient.createSignedDownloadUrlsByPath(
+    bucket: String, paths: List<String>, expiresIn: Long, fileName: String? = null,
+): SupabaseResult<Map<String, String>>
+suspend fun StorageClient.createSignedDownloadUrlsByPath(
+    bucket: String, expiresIn: Long, vararg paths: String,
+): SupabaseResult<Map<String, String>>
+suspend fun StorageClient.createSignedDownloadUrlsByPath(
+    bucket: String, expiresIn: Long, fileName: String?, vararg paths: String,
+): SupabaseResult<Map<String, String>>
+```
+
+**Returns** `SupabaseResult<Map<String, String>>` — `Success` mapping each path to its signed URL, `Failure` on error.
+
+```kotlin
+val byPath = storage.createSignedDownloadUrlsByPath("docs", 600, "a.pdf", "b.pdf")
+```
+
+### createSignedRenderUrl / createSignedRenderUrls
+
+Extension conveniences that sign an inline (non-download) render URL applying an
+image [`transform`](#imagetransformoptions). The batch form signs sequentially and
+short-circuits to `Failure` on the first failing path.
+
+```kotlin
+suspend fun StorageClient.createSignedRenderUrl(
+    bucket: String, path: String, expiresIn: Long, transform: ImageTransformOptions,
+): SupabaseResult<String>
+
+suspend fun StorageClient.createSignedRenderUrls(
+    bucket: String, paths: List<String>, expiresIn: Long, transform: ImageTransformOptions,
+): SupabaseResult<List<String>>
+suspend fun StorageClient.createSignedRenderUrls(
+    bucket: String, expiresIn: Long, transform: ImageTransformOptions, vararg paths: String,
+): SupabaseResult<List<String>>
+```
+
+**Returns** `SupabaseResult<String>` / `SupabaseResult<List<String>>` — `Success` with render URL(s), `Failure` on error.
+
+```kotlin
+val url = storage.createSignedRenderUrl(
+    "avatars", "jane/profile.png", 600,
+    ImageTransformOptions(width = 200, height = 200),
+)
+```
+
+### createSignedRenderUrlsByPath
+
+Like [`createSignedRenderUrls`](#createsignedrenderurl--createsignedrenderurls) but
+returns a path-to-URL `Map`.
+
+```kotlin
+suspend fun StorageClient.createSignedRenderUrlsByPath(
+    bucket: String, paths: List<String>, expiresIn: Long, transform: ImageTransformOptions,
+): SupabaseResult<Map<String, String>>
+suspend fun StorageClient.createSignedRenderUrlsByPath(
+    bucket: String, expiresIn: Long, transform: ImageTransformOptions, vararg paths: String,
+): SupabaseResult<Map<String, String>>
+```
+
+**Returns** `SupabaseResult<Map<String, String>>` — `Success` mapping each path to its render URL, `Failure` on error.
+
+### createUploadSignedUrl
+
+Creates a signed *upload* token (`POST /object/upload/sign`) so a client without
+storage credentials can later upload to `path` via
+[`uploadToSignedUrl`](#uploadtosignedurl). Returns just the token.
+
+```kotlin
+suspend fun createUploadSignedUrl(
+    bucket: String,
+    path: String,
+    upsert: Boolean = false,
+): SupabaseResult<String>
+```
+
+- `bucket` / `path` — the upload target.
+- `upsert` — when `true`, the token permits overwriting an existing object. Default `false`.
+
+**Returns** `SupabaseResult<String>` — `Success` with the token, `Failure` on error.
+
+```kotlin
+val token = storage.createUploadSignedUrl("avatars", "jane/profile.png")
+```
+
+### createUploadSignedUrlWithPath
+
+Like [`createUploadSignedUrl`](#createuploadsignedurl) but returns the full
+[`UploadSignedUrl`](#uploadsignedurl) (absolute upload URL, token, and bound path)
+instead of only the token.
+
+```kotlin
+suspend fun createUploadSignedUrlWithPath(
+    bucket: String,
+    path: String,
+    upsert: Boolean = false,
+): SupabaseResult<UploadSignedUrl>
+```
+
+**Returns** `SupabaseResult<UploadSignedUrl>` — `Success` with the signed target, `Failure` on error.
+
+```kotlin
+val signed = storage.createUploadSignedUrlWithPath("avatars", "jane/profile.png")
+```
+
+### getSignedDownloadUrl
+
+Builds the signed download URL for a previously issued signed-URL `token`
+locally, without a network call.
+
+```kotlin
+fun getSignedDownloadUrl(
+    bucket: String,
+    path: String,
+    token: String,
+    download: Boolean = false,
+    fileName: String? = null,
+): String
+```
+
+- `bucket` / `path` — the object the token addresses.
+- `token` — the signed-URL token.
+- `download` — when `true`, append the `download` param. Default `false`.
+- `fileName` — suggested attachment file name. Default `null`.
+
+**Returns** the addressable `String` URL (no I/O, never fails).
+
+```kotlin
+val url = storage.getSignedDownloadUrl("avatars", "jane/profile.png", token)
+```
+
+### getPublicUrl
+
+Builds the public URL (`/object/public`) for `path` locally — no network call and
+no token. Only resolves for objects in a public bucket. Two overloads:
+
+```kotlin
+fun getPublicUrl(
+    bucket: String,
+    path: String,
+    transform: ImageTransformOptions? = null,
+): String
+
+fun getPublicUrl(
+    bucket: String,
+    path: String,
+    download: Boolean = false,
+    fileName: String? = null,
+    transform: ImageTransformOptions? = null,
+): String
+```
+
+- `bucket` / `path` — the object to address.
+- `download` — when `true`, append the `download` param. Default `false`.
+- `fileName` — suggested attachment file name. Default `null`.
+- `transform` — target the render endpoint with a server-side image transform. Default `null`.
+
+**Returns** the `String` URL (no I/O, never fails).
+
+```kotlin
+val url = storage.getPublicUrl("public-images", "logo.png")
+```
+
+### getAuthenticatedUrl
+
+Builds the authenticated URL (`/object/authenticated`) for `path` locally. The URL
+still requires valid credentials when fetched; this only composes the address. Two
+overloads matching [`getPublicUrl`](#getpublicurl).
+
+```kotlin
+fun getAuthenticatedUrl(
+    bucket: String, path: String, transform: ImageTransformOptions? = null,
+): String
+
+fun getAuthenticatedUrl(
+    bucket: String, path: String,
+    download: Boolean = false, fileName: String? = null,
+    transform: ImageTransformOptions? = null,
+): String
+```
+
+**Returns** the `String` URL (no I/O, never fails).
+
+```kotlin
+val url = storage.getAuthenticatedUrl("avatars", "jane/profile.png")
+```
+
+### getPublicRenderUrl
+
+Builds the public render/transform URL (`/render/image/public`) for `path`
+locally, applying `transform` as query params.
+
+```kotlin
+fun getPublicRenderUrl(
+    bucket: String,
+    path: String,
+    transform: ImageTransformOptions? = null,
+): String
+```
+
+**Returns** the `String` render URL (no I/O, never fails).
+
+```kotlin
+val url = storage.getPublicRenderUrl(
+    "public-images", "logo.png", ImageTransformOptions(width = 128),
+)
+```
+
+### getAuthenticatedRenderUrl
+
+Builds the authenticated render/transform URL (`/render/image/authenticated`) for
+`path` locally. The URL still requires credentials when fetched.
+
+```kotlin
+fun getAuthenticatedRenderUrl(
+    bucket: String,
+    path: String,
+    transform: ImageTransformOptions? = null,
+): String
+```
+
+**Returns** the `String` render URL (no I/O, never fails).
+
+```kotlin
+val url = storage.getAuthenticatedRenderUrl(
+    "avatars", "jane/profile.png", ImageTransformOptions(width = 128),
+)
+```
+
+### Bulk URL builders
+
+Extension helpers build URLs for many paths at once. Each comes in a `List<String>`
+overload, a `vararg` overload, and a `…ByPath` variant returning a path-to-URL
+`Map`. All are purely local (no network call); the authenticated variants still
+require credentials when fetched.
+
+```kotlin
+// public object URLs
+fun StorageClient.getPublicUrls(
+    bucket: String, paths: List<String>,
+    download: Boolean = false, fileName: String? = null,
+    transform: ImageTransformOptions? = null,
+): List<String>
+fun StorageClient.getPublicUrls(bucket: String, vararg paths: String): List<String>
+fun StorageClient.getPublicUrls(
+    bucket: String, download: Boolean = false, fileName: String? = null,
+    transform: ImageTransformOptions? = null, vararg paths: String,
+): List<String>
+fun StorageClient.getPublicUrlsByPath(/* same params */): Map<String, String>   // 3 overloads
+
+// authenticated object URLs
+fun StorageClient.getAuthenticatedUrls(/* same shape as getPublicUrls */): List<String>      // 3 overloads
+fun StorageClient.getAuthenticatedUrlsByPath(/* … */): Map<String, String>                   // 3 overloads
+
+// public render URLs
+fun StorageClient.getPublicRenderUrls(
+    bucket: String, paths: List<String>, transform: ImageTransformOptions? = null,
+): List<String>
+fun StorageClient.getPublicRenderUrls(
+    bucket: String, transform: ImageTransformOptions? = null, vararg paths: String,
+): List<String>
+fun StorageClient.getPublicRenderUrlsByPath(/* … */): Map<String, String>                    // 2 overloads
+
+// authenticated render URLs
+fun StorageClient.getAuthenticatedRenderUrls(/* same shape as getPublicRenderUrls */): List<String>   // 2 overloads
+fun StorageClient.getAuthenticatedRenderUrlsByPath(/* … */): Map<String, String>                      // 2 overloads
+```
+
+- `bucket` — bucket to address.
+- `paths` — object keys to build URLs for (positional `List` or `vararg`).
+- `download` / `fileName` — attachment control (object URL families only). Defaults `false` / `null`.
+- `transform` — server-side image transform. Default `null`.
+
+**Returns** `List<String>` in input order, or `Map<String, String>` keyed by path for the `…ByPath` variants.
+
+```kotlin
+val urls = storage.getPublicUrls("public-images", "a.png", "b.png")
+val byPath = storage.getAuthenticatedUrlsByPath("avatars", "x.png", "y.png")
+```
+
+### withCacheNonce
+
+Appends a cache-busting query param to a previously built storage URL (public,
+authenticated, signed, or render). Useful to force a CDN/browser to re-fetch an
+object overwritten at the same path. Returns the URL unchanged when `nonce` is
+`null`/blank.
+
+```kotlin
+fun withCacheNonce(url: String, nonce: String?, name: String = "cacheNonce"): String
+```
+
+- `url` — the storage URL to annotate.
+- `nonce` — the cache-busting value, appended verbatim (pass a URL-safe value); `null`/blank returns `url` unchanged.
+- `name` — the query-param name. Default `"cacheNonce"`.
+
+**Returns** the annotated `String` URL.
+
+```kotlin
+val fresh = withCacheNonce(url, nonce = updatedAtTimestamp)
+```
+
+---
+
+## Analytics buckets
+
+The analytics surface manages Apache-Iceberg-backed buckets and their catalog.
+
+### createAnalyticsBucket
+
+Creates an analytics (Iceberg) bucket. Use [`analyticsCatalog`](#analyticscatalog)
+afterward to manage its namespaces and tables.
+
+```kotlin
+suspend fun createAnalyticsBucket(name: String): SupabaseResult<AnalyticsBucket>
+```
+
+- `name` — the analytics bucket name.
+
+**Returns** `SupabaseResult<AnalyticsBucket>` — `Success` with the bucket, `Failure` on error.
+
+```kotlin
+val bucket = storage.createAnalyticsBucket("warehouse")
+```
+
+### listAnalyticsBuckets
+
+Lists analytics (Iceberg) buckets. Mirrors [`listBuckets`](#listbuckets)'s
+paging/sort/search semantics over the analytics-bucket endpoint.
+
+```kotlin
+suspend fun listAnalyticsBuckets(
+    limit: Int? = null,
+    offset: Int? = null,
+    sortColumn: String? = null,
+    sortOrder: SortOrder? = null,
+    search: String? = null,
+): SupabaseResult<List<AnalyticsBucket>>
+```
+
+- Parameters mirror [`listBuckets`](#listbuckets).
+
+**Returns** `SupabaseResult<List<AnalyticsBucket>>` — `Success` with the buckets, `Failure` on error.
+
+```kotlin
+val buckets = storage.listAnalyticsBuckets()
+```
+
+### deleteAnalyticsBucket
+
+Deletes the analytics (Iceberg) bucket `name`.
+
+```kotlin
+suspend fun deleteAnalyticsBucket(name: String): SupabaseResult<Unit>
+```
+
+**Returns** `SupabaseResult<Unit>` — `Success` on deletion, `Failure` on error.
+
+```kotlin
+storage.deleteAnalyticsBucket("warehouse")
+```
+
+### analyticsCatalog
+
+Returns an [`AnalyticsCatalogClient`](#analyticscatalogclient) scoped to the
+analytics bucket `bucketName` for managing its Iceberg namespaces and tables.
+Validates `bucketName` eagerly and throws `IllegalArgumentException` if it is blank
+or contains characters outside `[A-Za-z0-9._-]`.
+
+```kotlin
+fun analyticsCatalog(bucketName: String): AnalyticsCatalogClient
+```
+
+- `bucketName` — the analytics bucket the catalog targets (fixed at creation).
+
+**Returns** an [`AnalyticsCatalogClient`](#analyticscatalogclient).
+
+```kotlin
+val catalog = storage.analyticsCatalog("warehouse")
+```
+
+---
+
+## AnalyticsCatalogClient
+
+An Apache Iceberg REST catalog client scoped to one analytics bucket, exposing the
+namespace and table operations the Supabase analytics endpoint
+(`/storage/v1/iceberg`) speaks. Obtain one via
+[`analyticsCatalog`](#analyticscatalog).
+
+Most operations come in two flavours: a raw `…` variant returning the server's
+`JsonObject` verbatim (forward-compatible with Iceberg fields not yet modeled) and
+a `…Typed` variant deserializing into a model. Prefer the typed variants unless you
+need a spec field not yet mapped. Namespaces are multi-level and modeled as
+`List<String>` (for example `["analytics", "sales"]`). Every call returns a
+`SupabaseResult`.
+
+### getConfig / getConfigTyped
+
+Loads the raw Iceberg catalog config (`GET /v1/config`) for this bucket. The config
+carries the `defaults`/`overrides` property maps, including the route `prefix`.
+
+```kotlin
+suspend fun getConfig(): SupabaseResult<JsonObject>
+suspend fun getConfigTyped(): SupabaseResult<IcebergCatalogConfig>
+```
+
+**Returns** `SupabaseResult<JsonObject>` (raw) / `SupabaseResult<IcebergCatalogConfig>` (typed) — `Success` with the config, `Failure` on error.
+
+```kotlin
+val config = catalog.getConfigTyped()
+```
+
+### listNamespaces / listNamespacesTyped
+
+Lists namespaces under the catalog.
+
+```kotlin
+suspend fun listNamespaces(
+    parent: List<String>? = null,
+    pageToken: String? = null,
+    pageSize: Int? = null,
+): SupabaseResult<JsonObject>
+suspend fun listNamespacesTyped(
+    parent: List<String>? = null,
+    pageToken: String? = null,
+    pageSize: Int? = null,
+): SupabaseResult<IcebergNamespaceListResponse>
+```
+
+- `parent` — restrict results to direct children of this namespace; `null` lists from the catalog root. Default `null`.
+- `pageToken` — continuation token from a previous page. Default `null`.
+- `pageSize` — maximum namespaces to return in this page. Default `null`.
+
+**Returns** `SupabaseResult<JsonObject>` / `SupabaseResult<IcebergNamespaceListResponse>` — `Success` with the page, `Failure` on error.
+
+```kotlin
+val namespaces = catalog.listNamespacesTyped()
+```
+
+### createNamespace / createNamespaceTyped
+
+Creates a namespace with optional properties.
+
+```kotlin
+suspend fun createNamespace(
+    namespace: List<String>,
+    properties: Map<String, String> = emptyMap(),
+): SupabaseResult<JsonObject>
+suspend fun createNamespaceTyped(
+    request: IcebergCreateNamespaceRequest,
+): SupabaseResult<IcebergNamespaceMetadata>
+```
+
+- `namespace` — the multi-level namespace to create.
+- `properties` — initial namespace properties; omitted from the body when empty. Default `emptyMap()`.
+- `request` — the typed request object (typed overload).
+
+**Returns** `SupabaseResult<JsonObject>` / `SupabaseResult<IcebergNamespaceMetadata>` — `Success` on creation, `Failure` on error.
+
+```kotlin
+catalog.createNamespace(listOf("analytics", "sales"))
+```
+
+### deleteNamespace
+
+Drops a namespace from the catalog.
+
+```kotlin
+suspend fun deleteNamespace(namespace: List<String>): SupabaseResult<Unit>
+```
+
+- `namespace` — the namespace to drop.
+
+**Returns** `SupabaseResult<Unit>` — `Success` on deletion, `Failure` if missing or still containing tables.
+
+```kotlin
+catalog.deleteNamespace(listOf("analytics", "sales"))
+```
+
+### getNamespaceMetadata / getNamespaceMetadataTyped
+
+Loads a namespace's metadata (its property map).
+
+```kotlin
+suspend fun getNamespaceMetadata(namespace: List<String>): SupabaseResult<JsonObject>
+suspend fun getNamespaceMetadataTyped(namespace: List<String>): SupabaseResult<IcebergNamespaceMetadata>
+```
+
+- `namespace` — the namespace to inspect.
+
+**Returns** `SupabaseResult<JsonObject>` / `SupabaseResult<IcebergNamespaceMetadata>` — `Success` with the metadata, `Failure` on error.
+
+```kotlin
+val meta = catalog.getNamespaceMetadataTyped(listOf("analytics", "sales"))
+```
+
+### updateNamespaceProperties / updateNamespacePropertiesTyped
+
+Adds/updates and/or removes properties on a namespace in one call.
+
+```kotlin
+suspend fun updateNamespaceProperties(
+    namespace: List<String>,
+    removals: List<String>? = null,
+    updates: Map<String, String>? = null,
+): SupabaseResult<JsonObject>
+suspend fun updateNamespacePropertiesTyped(
+    namespace: List<String>,
+    request: IcebergUpdateNamespacePropertiesRequest,
+): SupabaseResult<IcebergUpdateNamespacePropertiesResponse>
+```
+
+- `namespace` — the namespace to mutate.
+- `removals` — property keys to remove. Default `null`.
+- `updates` — property keys to set or overwrite. Default `null`.
+- `request` — the typed request object (typed overload).
+
+**Returns** `SupabaseResult<JsonObject>` / `SupabaseResult<IcebergUpdateNamespacePropertiesResponse>` — `Success` reporting removed/updated/missing keys, `Failure` on error.
+
+```kotlin
+catalog.updateNamespaceProperties(
+    listOf("analytics", "sales"), updates = mapOf("owner" to "data-team"),
+)
+```
+
+### listTables / listTablesTyped
+
+Lists the tables in a namespace.
+
+```kotlin
+suspend fun listTables(
+    namespace: List<String>,
+    pageToken: String? = null,
+    pageSize: Int? = null,
+): SupabaseResult<JsonObject>
+suspend fun listTablesTyped(
+    namespace: List<String>,
+    pageToken: String? = null,
+    pageSize: Int? = null,
+): SupabaseResult<IcebergTableListResponse>
+```
+
+- `namespace` — the namespace to list.
+- `pageToken` — continuation token from a previous page. Default `null`.
+- `pageSize` — maximum table identifiers to return. Default `null`.
+
+**Returns** `SupabaseResult<JsonObject>` / `SupabaseResult<IcebergTableListResponse>` — `Success` with the page, `Failure` on error.
+
+```kotlin
+val tables = catalog.listTablesTyped(listOf("analytics", "sales"))
+```
+
+### createTable / createTableTyped
+
+Creates a table in a namespace.
+
+```kotlin
+suspend fun createTable(
+    namespace: List<String>,
+    request: JsonObject,
+): SupabaseResult<JsonObject>
+suspend fun createTableTyped(
+    namespace: List<String>,
+    request: IcebergTableCreateRequest,
+): SupabaseResult<IcebergTableMetadataResponse>
+```
+
+- `namespace` — the target namespace.
+- `request` — the create-table body (raw `JsonObject`, or typed [`IcebergTableCreateRequest`](#icebergtablecreaterequest)).
+
+**Returns** `SupabaseResult<JsonObject>` / `SupabaseResult<IcebergTableMetadataResponse>` — `Success` with the table metadata, `Failure` on error.
+
+```kotlin
+val table = catalog.createTableTyped(
+    listOf("analytics", "sales"),
+    IcebergTableCreateRequest(name = "orders", schema = schemaJson),
+)
+```
+
+### updateTable / updateTableTyped
+
+Commits requirements/updates to a table (the Iceberg commit-table endpoint).
+
+```kotlin
+suspend fun updateTable(
+    namespace: List<String>,
+    name: String,
+    request: JsonObject,
+): SupabaseResult<JsonObject>
+suspend fun updateTableTyped(
+    namespace: List<String>,
+    name: String,
+    request: IcebergTableCommitRequest,
+): SupabaseResult<IcebergTableMetadataResponse>
+```
+
+- `namespace` — the table's namespace.
+- `name` — the table name.
+- `request` — the commit body (raw `JsonObject`, or typed [`IcebergTableCommitRequest`](#icebergtablecommitrequest) of requirements + updates).
+
+**Returns** `SupabaseResult<JsonObject>` / `SupabaseResult<IcebergTableMetadataResponse>` — `Success` with updated metadata, `Failure` on error.
+
+```kotlin
+catalog.updateTableTyped(listOf("analytics", "sales"), "orders", commitRequest)
+```
+
+### deleteTable
+
+Drops a table from a namespace.
+
+```kotlin
+suspend fun deleteTable(
+    namespace: List<String>,
+    name: String,
+    purge: Boolean = false,
+): SupabaseResult<Unit>
+```
+
+- `namespace` — the table's namespace.
+- `name` — the table to drop.
+- `purge` — when `true`, ask the server to also delete the table's underlying data files. Default `false`.
+
+**Returns** `SupabaseResult<Unit>` — `Success` on deletion, `Failure` on error.
+
+```kotlin
+catalog.deleteTable(listOf("analytics", "sales"), "orders", purge = true)
+```
+
+### getTable / getTableTyped
+
+Loads a table's current metadata.
+
+```kotlin
+suspend fun getTable(
+    namespace: List<String>,
+    name: String,
+    snapshots: String? = null,
+): SupabaseResult<JsonObject>
+suspend fun getTableTyped(
+    namespace: List<String>,
+    name: String,
+    snapshots: String? = null,
+): SupabaseResult<IcebergTableMetadataResponse>
+```
+
+- `namespace` — the table's namespace.
+- `name` — the table name.
+- `snapshots` — optional snapshot-loading mode passed through to the server. Default `null`.
+
+**Returns** `SupabaseResult<JsonObject>` / `SupabaseResult<IcebergTableMetadataResponse>` — `Success` with the metadata, `Failure` on error.
+
+```kotlin
+val table = catalog.getTableTyped(listOf("analytics", "sales"), "orders")
+```
+
+### registerTable / registerTableTyped
+
+Registers an existing table (one whose metadata file already lives in storage)
+into a namespace.
+
+```kotlin
+suspend fun registerTable(
+    namespace: List<String>,
+    request: JsonObject,
+): SupabaseResult<JsonObject>
+suspend fun registerTableTyped(
+    namespace: List<String>,
+    request: IcebergTableRegisterRequest,
+): SupabaseResult<IcebergTableMetadataResponse>
+```
+
+- `namespace` — the target namespace.
+- `request` — the register body (raw `JsonObject`, or typed [`IcebergTableRegisterRequest`](#icebergtableregisterrequest) of name + metadata location).
+
+**Returns** `SupabaseResult<JsonObject>` / `SupabaseResult<IcebergTableMetadataResponse>` — `Success` with the table metadata, `Failure` on error.
+
+```kotlin
+catalog.registerTableTyped(
+    listOf("analytics", "sales"),
+    IcebergTableRegisterRequest(name = "orders", metadataLocation = location),
+)
+```
+
+### renameTable / renameTableTyped
+
+Renames/moves a table, optionally across namespaces.
+
+```kotlin
+suspend fun renameTable(request: JsonObject): SupabaseResult<Unit>
+suspend fun renameTableTyped(
+    source: IcebergTableIdentifier,
+    destination: IcebergTableIdentifier,
+): SupabaseResult<Unit>
+```
+
+- `request` — raw body holding `source`/`destination` identifiers (raw overload).
+- `source` — the table to move (typed overload).
+- `destination` — the new identifier (may live in a different namespace).
+
+**Returns** `SupabaseResult<Unit>` — `Success` on rename, `Failure` on error.
+
+```kotlin
+catalog.renameTableTyped(
+    IcebergTableIdentifier(listOf("analytics", "sales"), "orders"),
+    IcebergTableIdentifier(listOf("analytics", "sales"), "orders_v2"),
+)
+```
+
+---
+
+## Vectors (S3-Vectors)
+
+The S3-Vectors surface manages vector buckets, indexes, and the vectors within
+them.
+
+### createVectorBucket
+
+Creates an S3-Vectors bucket.
+
+```kotlin
+suspend fun createVectorBucket(vectorBucketName: String): SupabaseResult<Unit>
+```
+
+- `vectorBucketName` — the bucket name.
+
+**Returns** `SupabaseResult<Unit>` — `Success` on creation, `Failure` on error.
+
+```kotlin
+storage.createVectorBucket("embeddings")
+```
+
+### getVectorBucket
+
+Fetches an S3-Vectors bucket.
+
+```kotlin
+suspend fun getVectorBucket(vectorBucketName: String): SupabaseResult<VectorBucket>
+```
+
+**Returns** `SupabaseResult<VectorBucket>` — `Success` with the bucket, `Failure` if it does not exist.
+
+```kotlin
+val bucket = storage.getVectorBucket("embeddings")
+```
+
+### listVectorBuckets
+
+Lists S3-Vectors buckets.
+
+```kotlin
+suspend fun listVectorBuckets(
+    prefix: String? = null,
+    maxResults: Int? = null,
+    nextToken: String? = null,
+): SupabaseResult<VectorBucketListResponse>
+```
+
+- `prefix` — restrict results to bucket names starting with this prefix. Default `null`.
+- `maxResults` — maximum buckets to return in this page. Default `null`.
+- `nextToken` — continuation token from a previous response. Default `null`.
+
+**Returns** `SupabaseResult<VectorBucketListResponse>` — `Success` with the page, `Failure` on error.
+
+```kotlin
+val buckets = storage.listVectorBuckets()
+```
+
+### deleteVectorBucket
+
+Deletes an S3-Vectors bucket.
+
+```kotlin
+suspend fun deleteVectorBucket(vectorBucketName: String): SupabaseResult<Unit>
+```
+
+**Returns** `SupabaseResult<Unit>` — `Success` on deletion, `Failure` on error.
+
+```kotlin
+storage.deleteVectorBucket("embeddings")
+```
+
+### createVectorIndex
+
+Creates a vector index inside a bucket.
+
+```kotlin
+suspend fun createVectorIndex(
+    vectorBucketName: String,
+    indexName: String,
+    dataType: VectorDataType,
+    dimension: Int,
+    distanceMetric: VectorDistanceMetric,
+    metadataConfiguration: VectorMetadataConfiguration? = null,
+): SupabaseResult<Unit>
+```
+
+- `vectorBucketName` — the owning bucket.
+- `indexName` — the index name.
+- `dataType` — element type of stored vectors (see [`VectorDataType`](#vectordatatype)).
+- `dimension` — fixed dimensionality every stored vector must match.
+- `distanceMetric` — similarity metric used for queries (see [`VectorDistanceMetric`](#vectordistancemetric)).
+- `metadataConfiguration` — optional declaration of non-filterable metadata keys. Default `null`.
+
+**Returns** `SupabaseResult<Unit>` — `Success` on creation, `Failure` on error.
+
+```kotlin
+storage.createVectorIndex(
+    "embeddings", "docs",
+    dataType = VectorDataType.FLOAT32,
+    dimension = 1536,
+    distanceMetric = VectorDistanceMetric.COSINE,
+)
+```
+
+### getVectorIndex
+
+Fetches a vector index, including its dimension and metric.
+
+```kotlin
+suspend fun getVectorIndex(
+    vectorBucketName: String,
+    indexName: String,
+): SupabaseResult<VectorIndex>
+```
+
+**Returns** `SupabaseResult<VectorIndex>` — `Success` with the index, `Failure` on error.
+
+```kotlin
+val index = storage.getVectorIndex("embeddings", "docs")
+```
+
+### listVectorIndexes
+
+Lists the vector indexes in a bucket.
+
+```kotlin
+suspend fun listVectorIndexes(
+    vectorBucketName: String,
+    prefix: String? = null,
+    maxResults: Int? = null,
+    nextToken: String? = null,
+): SupabaseResult<VectorIndexListResponse>
+```
+
+- `vectorBucketName` — the bucket to list.
+- `prefix` — restrict results to index names starting with this prefix. Default `null`.
+- `maxResults` — maximum indexes to return in this page. Default `null`.
+- `nextToken` — continuation token from a previous response. Default `null`.
+
+**Returns** `SupabaseResult<VectorIndexListResponse>` — `Success` with the page, `Failure` on error.
+
+```kotlin
+val indexes = storage.listVectorIndexes("embeddings")
+```
+
+### deleteVectorIndex
+
+Deletes a vector index from a bucket.
+
+```kotlin
+suspend fun deleteVectorIndex(
+    vectorBucketName: String,
+    indexName: String,
+): SupabaseResult<Unit>
+```
+
+**Returns** `SupabaseResult<Unit>` — `Success` on deletion, `Failure` on error.
+
+```kotlin
+storage.deleteVectorIndex("embeddings", "docs")
+```
+
+### putVectors
+
+Inserts or overwrites vectors in an index. The batch must contain between 1 and
+500 vectors; an out-of-range size throws `IllegalArgumentException` before any
+request is sent.
+
+```kotlin
+suspend fun putVectors(
+    vectorBucketName: String,
+    indexName: String,
+    vectors: List<VectorObject>,
+): SupabaseResult<Unit>
+```
+
+- `vectorBucketName` — the owning bucket.
+- `indexName` — the target index.
+- `vectors` — 1..500 [`VectorObject`](#vectorobject) entries to store.
+
+**Returns** `SupabaseResult<Unit>` — `Success` on write, `Failure` on error.
+
+```kotlin
+storage.putVectors(
+    "embeddings", "docs",
+    listOf(VectorObject(key = "doc-1", data = VectorData(floats))),
+)
+```
+
+### getVectors
+
+Fetches vectors by key.
+
+```kotlin
+suspend fun getVectors(
+    vectorBucketName: String,
+    indexName: String,
+    keys: List<String>,
+    returnData: Boolean? = null,
+    returnMetadata: Boolean? = null,
+): SupabaseResult<List<VectorMatch>>
+```
+
+- `vectorBucketName` / `indexName` — the index to read from.
+- `keys` — the vector keys to fetch.
+- `returnData` — when `true`, include each vector's raw data. Default `null`.
+- `returnMetadata` — when `true`, include each vector's metadata. Default `null`.
+
+**Returns** `SupabaseResult<List<VectorMatch>>` — `Success` with the matches, `Failure` on error.
+
+```kotlin
+val vectors = storage.getVectors("embeddings", "docs", listOf("doc-1"), returnData = true)
+```
+
+### listVectors
+
+Lists vectors in an index, optionally sharded for parallel scans.
+
+```kotlin
+suspend fun listVectors(
+    vectorBucketName: String,
+    indexName: String,
+    maxResults: Int? = null,
+    nextToken: String? = null,
+    returnData: Boolean? = null,
+    returnMetadata: Boolean? = null,
+    segmentCount: Int? = null,
+    segmentIndex: Int? = null,
+): SupabaseResult<VectorListResponse>
+```
+
+- `vectorBucketName` / `indexName` — the index to scan.
+- `maxResults` — maximum vectors to return in this page. Default `null`.
+- `nextToken` — continuation token from a previous response. Default `null`.
+- `returnData` — include each vector's raw data. Default `null`.
+- `returnMetadata` — include each vector's metadata. Default `null`.
+- `segmentCount` — split the index into this many segments (1..16) for parallel listing; out-of-range values throw `IllegalArgumentException`. Default `null`.
+- `segmentIndex` — which segment (`0 until segmentCount`) this call scans. Default `null`.
+
+**Returns** `SupabaseResult<VectorListResponse>` — `Success` with the page, `Failure` on error.
+
+```kotlin
+val page = storage.listVectors("embeddings", "docs", maxResults = 100)
+```
+
+### queryVectors
+
+Runs a nearest-neighbor search against an index.
+
+```kotlin
+suspend fun queryVectors(
+    vectorBucketName: String,
+    indexName: String,
+    queryVector: VectorData,
+    topK: Int? = null,
+    filter: JsonObject? = null,
+    returnDistance: Boolean? = null,
+    returnMetadata: Boolean? = null,
+): SupabaseResult<VectorQueryResponse>
+```
+
+- `vectorBucketName` / `indexName` — the index to query.
+- `queryVector` — the query [`VectorData`](#vectordata).
+- `topK` — number of closest matches to return. Default `null`.
+- `filter` — optional metadata filter expression to restrict candidates. Default `null`.
+- `returnDistance` — include each match's distance score. Default `null`.
+- `returnMetadata` — include each match's metadata. Default `null`.
+
+**Returns** `SupabaseResult<VectorQueryResponse>` — `Success` with ranked matches, `Failure` on error.
+
+```kotlin
+val results = storage.queryVectors(
+    "embeddings", "docs", VectorData(queryFloats), topK = 5, returnDistance = true,
+)
+```
+
+### deleteVectors
+
+Deletes vectors by key. The batch must contain between 1 and 500 keys; an
+out-of-range size throws `IllegalArgumentException` before any request is sent.
+
+```kotlin
+suspend fun deleteVectors(
+    vectorBucketName: String,
+    indexName: String,
+    keys: List<String>,
+): SupabaseResult<Unit>
+```
+
+- `vectorBucketName` / `indexName` — the index to delete from.
+- `keys` — 1..500 vector keys to remove.
+
+**Returns** `SupabaseResult<Unit>` — `Success` on deletion, `Failure` on error.
+
+```kotlin
+storage.deleteVectors("embeddings", "docs", listOf("doc-1"))
+```
+
+---
+
+## Resumable uploads
+
+### ResumableUpload
+
+A resumable (TUS) upload handle returned by
+[`createResumableUpload`](#createresumableupload). Uploads in chunks with
+server-side offset tracking, so an interrupted upload resumes from where it
+stopped. To pause, cancel the coroutine running [`await`](#resumableupload); to
+resume — even after an app restart — persist `uploadUrl` and create a new handle
+with `createResumableUpload(..., uploadUrl = saved)`, then call `await` again.
+
+```kotlin
+interface ResumableUpload {
+    val uploadUrl: String?
+    val progress: StateFlow<ResumableUploadProgress>
+    suspend fun await(): SupabaseResult<Unit>
+}
+```
+
+- `uploadUrl` — the TUS upload URL once the upload has been created (`null` beforehand). Persist this to resume later.
+- `progress` — a `StateFlow` of [`ResumableUploadProgress`](#resumableuploadprogress), updated after every chunk.
+- `await()` — runs (or resumes) the upload to completion; cancellable. **Returns** `SupabaseResult<Unit>` — `Success` when complete, `Failure` on error.
+
+```kotlin
+val handle = storage.createResumableUpload("videos", "clip.mp4", videoBytes)
+launch { handle.progress.collect { println(it.fraction) } }
+handle.await()
+```
+
+### ResumableUploadProgress
+
+Progress of a [`ResumableUpload`](#resumableupload).
+
+```kotlin
+data class ResumableUploadProgress(
+    val bytesUploaded: Long,
+    val totalBytes: Long,
+) {
+    val fraction: Float       // completion in 0f..1f
+    val isComplete: Boolean
+}
+```
+
+- `bytesUploaded` — bytes uploaded so far.
+- `totalBytes` — total bytes to upload.
+- `fraction` — completion fraction in `0f..1f` (`0f` when `totalBytes <= 0`).
+- `isComplete` — `true` once `bytesUploaded >= totalBytes` (and `totalBytes > 0`).
+
+### RESUMABLE_DEFAULT_CHUNK_SIZE
+
+The default and recommended chunk size for resumable uploads. Supabase requires
+6 MiB chunks for every part except the last.
+
+```kotlin
+const val RESUMABLE_DEFAULT_CHUNK_SIZE: Int = 6 * 1024 * 1024
+```
+
+---
+
+## Models
+
+### Bucket
+
+A storage bucket as returned by the bucket endpoints.
+
+```kotlin
+data class Bucket(
+    val id: String,
+    val name: String,
+    val public: Boolean = false,
+    val createdAt: String? = null,
+    val updatedAt: String? = null,
+    val fileSizeLimit: Long? = null,
+    val allowedMimeTypes: List<String>? = null,
+)
+```
+
+- `id` — the bucket's stable identifier and URL segment.
+- `name` — human-readable bucket name.
+- `public` — whether objects are readable via the public endpoint without a token.
+- `createdAt` / `updatedAt` — timestamps, when reported by the server.
+- `fileSizeLimit` — per-object size cap in bytes, when set.
+- `allowedMimeTypes` — whitelist of accepted content types, when set; `null` allows any.
+
+### FileObject
+
+A file or folder entry returned by the storage server. For folders, every field
+except `name` is typically `null`. The trailing fields (`size`, `contentType`,
+`etag`, `lastAccessedAt`, `cacheControl`) are populated by object-info and v2
+listing endpoints; older list responses omit them.
+
+```kotlin
+data class FileObject(
+    val name: String,
+    val id: String? = null,
+    val bucketId: String? = null,
+    val createdAt: String? = null,
+    val updatedAt: String? = null,
+    val metadata: JsonObject? = null,
+    val size: Long? = null,
+    val contentType: String? = null,
+    val etag: String? = null,
+    val lastAccessedAt: String? = null,
+    val cacheControl: String? = null,
+)
+```
+
+- `name` — the object name (or folder name).
+- `id` — the object id, when present.
+- `bucketId` — the id of the owning bucket, when present.
+- `createdAt` / `updatedAt` / `lastAccessedAt` — timestamps, when present.
+- `metadata` — free-form server metadata, when present.
+- `size` — the object size in bytes, when reported.
+- `contentType` — the stored MIME type, when reported.
+- `etag` — the entity tag, when reported.
+- `cacheControl` — the stored cache-control directive, when reported.
+
+### ObjectListV2Result
+
+Result of a cursor-paged v2 listing ([`listV2`](#listv2)), separating folders from
+objects and carrying continuation state.
+
+```kotlin
+data class ObjectListV2Result(
+    val hasNext: Boolean,
+    val folders: List<ObjectListV2Folder>,
+    val objects: List<ObjectListV2Object>,
+    val nextCursor: String? = null,
+)
+```
+
+- `hasNext` — whether more pages remain.
+- `folders` — the folder (common-prefix) entries in this page.
+- `objects` — the object entries in this page.
+- `nextCursor` — cursor to pass back for the next page, when `hasNext`.
+
+### ObjectListV2Object
+
+A single object entry in a v2 listing.
+
+```kotlin
+data class ObjectListV2Object(
+    val name: String,
+    val key: String? = null,
+    val id: String,
+    val updatedAt: String? = null,
+    val createdAt: String? = null,
+    val lastAccessedAt: String? = null,
+    val metadata: JsonObject? = null,
+)
+```
+
+- `name` — the object name within its folder.
+- `key` — the full object key, when reported.
+- `id` — the object id.
+- `updatedAt` / `createdAt` / `lastAccessedAt` — timestamps, when reported.
+- `metadata` — free-form server metadata, when present.
+
+### ObjectListV2Folder
+
+A folder (common-prefix) entry in a v2 listing.
+
+```kotlin
+data class ObjectListV2Folder(
+    val name: String,
+    val key: String? = null,
+)
+```
+
+- `name` — the folder name.
+- `key` — the full prefix, when reported.
+
+### AnalyticsBucket
+
+An analytics (Iceberg) bucket.
+
+```kotlin
+data class AnalyticsBucket(
+    val name: String,
+    val type: String,
+    val format: String,
+    val createdAt: String? = null,
+    val updatedAt: String? = null,
+)
+```
+
+- `name` — the analytics bucket name.
+- `type` — the server-reported bucket type.
+- `format` — the table data format (e.g. Iceberg).
+- `createdAt` / `updatedAt` — timestamps, when reported.
+
+### UploadSignedUrl
+
+A signed upload target returned by
+[`createUploadSignedUrlWithPath`](#createuploadsignedurlwithpath).
+
+```kotlin
+data class UploadSignedUrl(
+    val url: String,
+    val token: String,
+    val path: String? = null,
+)
+```
+
+- `url` — the absolute URL to upload to.
+- `token` — the signed token authorizing the upload.
+- `path` — the object path the server bound to this token, when returned.
+
+### ImageTransformOptions
+
+Server-side image transform options applied by the render endpoints and by
+signed/public render URLs. Each field maps to a render query param; `null` fields
+are omitted, leaving the server default.
+
+```kotlin
+data class ImageTransformOptions(
+    val width: Int? = null,
+    val height: Int? = null,
+    val resize: ResizeMode? = null,
+    val format: String? = null,
+    val quality: Int? = null,
+)
+```
+
+- `width` — target width in pixels.
+- `height` — target height in pixels.
+- `resize` — how the image is fitted to `width`/`height` (see [`ResizeMode`](#resizemode)).
+- `format` — output format (e.g. `origin`, `webp`); server-defined values.
+- `quality` — output quality, typically `1..100` for lossy formats.
+
+### ResizeMode
+
+How a transformed image is fitted to the requested width/height. `value` is the
+literal sent to the render endpoint.
+
+```kotlin
+enum class ResizeMode(val value: String) {
+    COVER("cover"),       // fill the box, cropping overflow (preserves aspect ratio)
+    CONTAIN("contain"),   // fit within the box, letterboxing (preserves aspect ratio)
+    FILL("fill"),         // stretch to the box, ignoring aspect ratio
+}
+```
+
+### SortOrder
+
+Sort direction for listing operations. `value` is the literal sent to the storage API.
+
+```kotlin
+enum class SortOrder(val value: String) {
+    ASC("asc"),
+    DESC("desc"),
+}
+```
+
+## Iceberg catalog models
+
+### IcebergCatalogConfig
+
+Iceberg catalog configuration (`GET /v1/config`). `overrides` take precedence over
+`defaults`; both may carry the route `prefix` the catalog client uses.
+
+```kotlin
+data class IcebergCatalogConfig(
+    val defaults: Map<String, String> = emptyMap(),
+    val overrides: Map<String, String> = emptyMap(),
+)
+```
+
+- `defaults` — default catalog properties.
+- `overrides` — overriding catalog properties (take precedence over `defaults`).
+
+### IcebergNamespaceListResponse
+
+Response listing Iceberg namespaces, each a multi-level path.
+
+```kotlin
+data class IcebergNamespaceListResponse(
+    val namespaces: List<List<String>> = emptyList(),
+    val nextPageToken: String? = null,            // "next-page-token"
+    val nextPageTokenCamelCase: String? = null,   // "nextPageToken"
+) {
+    val resolvedNextPageToken: String?
+}
+```
+
+- `namespaces` — the namespace paths.
+- `nextPageToken` / `nextPageTokenCamelCase` — the next-page token in either casing the server may return.
+- `resolvedNextPageToken` — the next-page token regardless of casing, or `null` if absent.
+
+### IcebergCreateNamespaceRequest
+
+Request body to create an Iceberg namespace with initial properties.
+
+```kotlin
+data class IcebergCreateNamespaceRequest(
+    val namespace: List<String>,
+    val properties: Map<String, String> = emptyMap(),
+)
+```
+
+- `namespace` — the namespace to create.
+- `properties` — initial namespace properties.
+
+### IcebergNamespaceMetadata
+
+An Iceberg namespace and its property map.
+
+```kotlin
+data class IcebergNamespaceMetadata(
+    val namespace: List<String> = emptyList(),
+    val properties: Map<String, String> = emptyMap(),
+)
+```
+
+- `namespace` — the namespace path.
+- `properties` — the namespace property map.
+
+### IcebergUpdateNamespacePropertiesRequest
+
+Request body to mutate namespace properties.
+
+```kotlin
+data class IcebergUpdateNamespacePropertiesRequest(
+    val removals: List<String>? = null,
+    val updates: Map<String, String>? = null,
+)
+```
+
+- `removals` — property keys to remove.
+- `updates` — property keys to set or overwrite.
+
+### IcebergUpdateNamespacePropertiesResponse
+
+Outcome of a namespace-properties update.
+
+```kotlin
+data class IcebergUpdateNamespacePropertiesResponse(
+    val removed: List<String> = emptyList(),
+    val updated: List<String> = emptyList(),
+    val missing: List<String> = emptyList(),
+)
+```
+
+- `removed` — keys removed.
+- `updated` — keys set/overwritten.
+- `missing` — keys requested but not found.
+
+### IcebergTableIdentifier
+
+Fully qualifies an Iceberg table by namespace and name.
+
+```kotlin
+data class IcebergTableIdentifier(
+    val namespace: List<String>,
+    val name: String,
+)
+```
+
+- `namespace` — the table's namespace path.
+- `name` — the table name.
+
+### IcebergTableListResponse
+
+Response listing the tables in a namespace by identifier.
+
+```kotlin
+data class IcebergTableListResponse(
+    val identifiers: List<IcebergTableIdentifier> = emptyList(),
+    val nextPageToken: String? = null,            // "next-page-token"
+    val nextPageTokenCamelCase: String? = null,   // "nextPageToken"
+) {
+    val resolvedNextPageToken: String?
+}
+```
+
+- `identifiers` — the table identifiers.
+- `nextPageToken` / `nextPageTokenCamelCase` — the next-page token in either casing.
+- `resolvedNextPageToken` — the next-page token regardless of casing, or `null`.
+
+### IcebergTableCreateRequest
+
+Request body to create an Iceberg table.
+
+```kotlin
+data class IcebergTableCreateRequest(
+    val name: String,
+    val schema: JsonObject,
+    val location: String? = null,
+    val partitionSpec: JsonObject? = null,
+    val writeOrder: JsonObject? = null,
+    val properties: Map<String, String> = emptyMap(),
+)
+```
+
+- `name` — the table name within the target namespace.
+- `schema` — the Iceberg schema as a raw JSON object.
+- `location` — optional explicit base location for the table's data.
+- `partitionSpec` — optional partition spec as a raw JSON object.
+- `writeOrder` — optional sort/write order as a raw JSON object.
+- `properties` — initial table properties.
+
+### IcebergTableCommitRequest
+
+Request body for an Iceberg table commit: requirements that must hold and metadata
+updates to apply atomically, each as raw JSON objects per the Iceberg spec.
+
+```kotlin
+data class IcebergTableCommitRequest(
+    val requirements: List<JsonObject> = emptyList(),
+    val updates: List<JsonObject> = emptyList(),
+)
+```
+
+- `requirements` — preconditions that must hold for the commit.
+- `updates` — metadata updates to apply.
+
+### IcebergTableRegisterRequest
+
+Request body to register an existing table.
+
+```kotlin
+data class IcebergTableRegisterRequest(
+    val name: String,
+    val metadataLocation: String,   // "metadata-location"
+)
+```
+
+- `name` — the table name.
+- `metadataLocation` — storage location of the existing metadata file.
+
+### IcebergTableMetadataResponse
+
+Response carrying an Iceberg table's metadata.
+
+```kotlin
+data class IcebergTableMetadataResponse(
+    val name: String? = null,
+    val metadata: JsonObject? = null,
+    val config: Map<String, String> = emptyMap(),
+    val metadataLocation: String? = null,   // "metadata-location"
+)
+```
+
+- `name` — the table name, when reported.
+- `metadata` — the table metadata document as a raw JSON object.
+- `config` — access/IO config the client should use for this table.
+- `metadataLocation` — storage location of the metadata file, when reported.
+
+## Vector models
+
+### VectorBucket
+
+An S3-Vectors bucket.
+
+```kotlin
+data class VectorBucket(
+    val vectorBucketName: String,
+    val creationTime: Long? = null,
+    val encryptionConfiguration: JsonObject? = null,
+)
+```
+
+- `vectorBucketName` — the bucket name.
+- `creationTime` — creation time as an epoch value, when reported.
+- `encryptionConfiguration` — server encryption config as a raw JSON object, when present.
+
+### VectorBucketResponse
+
+Envelope wrapping a single [`VectorBucket`](#vectorbucket) in the get-bucket response.
+
+```kotlin
+data class VectorBucketResponse(val vectorBucket: VectorBucket)
+```
+
+- `vectorBucket` — the wrapped bucket.
+
+### VectorBucketListItem
+
+One entry in a vector-bucket listing: just the bucket name.
+
+```kotlin
+data class VectorBucketListItem(val vectorBucketName: String)
+```
+
+- `vectorBucketName` — the bucket name.
+
+### VectorBucketListResponse
+
+Response listing vector buckets.
+
+```kotlin
+data class VectorBucketListResponse(
+    val vectorBuckets: List<VectorBucketListItem>,
+    val nextToken: String? = null,
+)
+```
+
+- `vectorBuckets` — the bucket entries.
+- `nextToken` — continuation token when more remain.
+
+### VectorIndex
+
+A vector index's definition.
+
+```kotlin
+data class VectorIndex(
+    val indexName: String,
+    val vectorBucketName: String,
+    val dataType: VectorDataType = VectorDataType.UNKNOWN,
+    val dimension: Int,
+    val distanceMetric: VectorDistanceMetric = VectorDistanceMetric.UNKNOWN,
+    val metadataConfiguration: VectorMetadataConfiguration? = null,
+    val creationTime: Long? = null,
+)
+```
+
+- `indexName` — the index name.
+- `vectorBucketName` — the owning bucket.
+- `dataType` — element type of stored vectors.
+- `dimension` — fixed dimensionality of stored vectors.
+- `distanceMetric` — similarity metric used for queries.
+- `metadataConfiguration` — non-filterable metadata declaration, when set.
+- `creationTime` — creation time as an epoch value, when reported.
+
+### VectorIndexResponse
+
+Envelope wrapping a single [`VectorIndex`](#vectorindex) in the get-index response.
+
+```kotlin
+data class VectorIndexResponse(val index: VectorIndex)
+```
+
+- `index` — the wrapped index.
+
+### VectorIndexListItem
+
+One entry in a vector-index listing: just the index name.
+
+```kotlin
+data class VectorIndexListItem(val indexName: String)
+```
+
+- `indexName` — the index name.
+
+### VectorIndexListResponse
+
+Response listing indexes.
+
+```kotlin
+data class VectorIndexListResponse(
+    val indexes: List<VectorIndexListItem>,
+    val nextToken: String? = null,
+)
+```
+
+- `indexes` — the index entries.
+- `nextToken` — continuation token when more remain.
+
+### VectorMetadataConfiguration
+
+Declares which metadata keys are non-filterable for an index, so queries cannot
+filter on them.
+
+```kotlin
+data class VectorMetadataConfiguration(
+    val nonFilterableMetadataKeys: List<String>? = null,
+)
+```
+
+- `nonFilterableMetadataKeys` — keys excluded from query filtering.
+
+### VectorData
+
+A vector value: its `float32` components. Length must match the index's dimension.
+
+```kotlin
+data class VectorData(val float32: List<Double>)
+```
+
+- `float32` — the vector components.
+
+### VectorObject
+
+A vector to store in an index.
+
+```kotlin
+data class VectorObject(
+    val key: String,
+    val data: VectorData,
+    val metadata: JsonObject? = null,
+)
+```
+
+- `key` — the unique key identifying this vector within the index.
+- `data` — the vector components.
+- `metadata` — optional metadata, used for filtering and retrieval.
+
+### VectorMatch
+
+A vector returned from a get/list/query, with optionally included data and metadata.
+
+```kotlin
+data class VectorMatch(
+    val key: String,
+    val data: VectorData? = null,
+    val metadata: JsonObject? = null,
+    val distance: Double? = null,
+)
+```
+
+- `key` — the vector's key.
+- `data` — the vector components, when requested via `returnData`.
+- `metadata` — the vector's metadata, when requested via `returnMetadata`.
+- `distance` — the distance/score to the query vector, populated by query results.
+
+### VectorListResponse
+
+Response listing vectors.
+
+```kotlin
+data class VectorListResponse(
+    val vectors: List<VectorMatch>,
+    val nextToken: String? = null,
+)
+```
+
+- `vectors` — the listed vectors.
+- `nextToken` — continuation token when more remain.
+
+### VectorQueryResponse
+
+Result of a vector query: the matching vectors ranked by similarity, plus the metric used.
+
+```kotlin
+data class VectorQueryResponse(
+    val vectors: List<VectorMatch>,
+    val distanceMetric: VectorDistanceMetric? = VectorDistanceMetric.UNKNOWN,
+)
+```
+
+- `vectors` — the matches ranked by similarity.
+- `distanceMetric` — the metric the index used, when reported.
+
+### VectorDataType
+
+Element type of stored vectors. Currently only single-precision floats are supported.
+
+```kotlin
+enum class VectorDataType { FLOAT32, UNKNOWN }
+```
+
+- `FLOAT32` — 32-bit IEEE float components.
+- `UNKNOWN` — fallback for a data type this client does not recognize.
+
+### VectorDistanceMetric
+
+Similarity metric a vector index uses to rank query matches.
+
+```kotlin
+enum class VectorDistanceMetric { COSINE, EUCLIDEAN, DOTPRODUCT, UNKNOWN }
+```
+
+- `COSINE` — cosine similarity (angle between vectors).
+- `EUCLIDEAN` — Euclidean (L2) distance.
+- `DOTPRODUCT` — dot-product (inner product) similarity.
+- `UNKNOWN` — fallback for a metric this client does not recognize.

--- a/website/pages/reference/sync.mdx
+++ b/website/pages/reference/sync.mdx
@@ -1,0 +1,709 @@
+---
+title: Offline Sync — API Reference
+description: Full public API of the offline-sync family — the transport-agnostic SyncEngine and its model/store interfaces (supabase-sync-core), the SQLDelight-backed local store (supabase-sync-sqldelight), the Supabase PostgREST + Realtime remote source (supabase-sync), and the Paging 3 bridge (supabase-sync-paging).
+---
+
+import { Callout } from 'nextra/components'
+
+# Offline Sync — API Reference
+
+The offline-sync family is an offline-first sync layer for `supabase-kmp`. Each
+table runs a **pull → merge → push** cycle: changed rows are pulled from the
+remote since the last position, merged into a local database (resolving
+conflicts row-by-row), then queued local edits are pushed back. Incremental
+pulls resume from a **keyset cursor** on the composite `(updatedAt, id)`, so the
+sync stays stable even when many rows share the same modification timestamp.
+
+The layer is split across four Maven artifacts so you only depend on what you
+use:
+
+| Artifact | Provides |
+| --- | --- |
+| `io.github.androidpoet:supabase-sync-core` | The transport-agnostic engine, the domain model, and the `LocalStore` / `RemoteSource` / `TableAdapter` seams. No Supabase or database dependency. |
+| `io.github.androidpoet:supabase-sync-sqldelight` | An on-device `LocalStore` backed by SQLDelight — durable synced rows, pull cursors, and the outbox across iOS, macOS, and the JVM. |
+| `io.github.androidpoet:supabase-sync` | A `RemoteSource` over Supabase PostgREST (pull/push) and Realtime (live deltas). |
+| `io.github.androidpoet:supabase-sync-paging` | A Paging 3 bridge: a typed per-table façade exposing local-first `PagingData` streams and optimistic writes. |
+
+<Callout type="info">
+The engine talks only to the `LocalStore` and `RemoteSource` interfaces, so the
+same logic that drives Supabase today drives anything else behind those seams
+tomorrow. Mix-and-match: core alone is usable with a hand-written store and
+source.
+</Callout>
+
+## `supabase-sync-core`
+
+Artifact: `io.github.androidpoet:supabase-sync-core`. All symbols live under the
+package `io.github.androidpoet.supabase.sync`.
+
+### `Record`
+
+The transport-neutral form of a synced row.
+
+```kotlin
+data class Record(
+    val id: String,
+    val updatedAt: Long,
+    val deleted: Boolean = false,
+    val fields: JsonObject,
+)
+```
+
+- `id` — the row's primary key as a string.
+- `updatedAt` — the **server-set** modification time (epoch millis). This is what
+  last-write-wins compares and what the cursor keyset advances on.
+- `deleted` — a soft-delete tombstone. Deletions propagate as tombstoned rows so
+  an incremental "changed since" pull can still observe them; a hard delete would
+  be invisible to such a query.
+- `fields` — the domain payload as a `kotlinx.serialization` `JsonObject`.
+
+### `Cursor`
+
+A per-table pull position.
+
+```kotlin
+data class Cursor(
+    val updatedAt: Long,
+    val id: String = "",
+)
+```
+
+- `updatedAt` — the high-water modification time reached so far (epoch millis).
+- `id` — the tie-breaker id at that timestamp; defaults to the empty string (the
+  low bound), so a cursor of just an `updatedAt` is valid.
+
+Incremental pulls resume *after* this point using a keyset on `(updatedAt, id)`:
+rows where `updatedAt > cursor.updatedAt`, plus rows at exactly
+`cursor.updatedAt` whose `id > cursor.id`. The composite (rather than a bare
+timestamp high-water mark) is what keeps the pull from skipping or re-looping
+rows written in the same millisecond.
+
+### `ChangeKind`
+
+```kotlin
+enum class ChangeKind { UPSERT, DELETE }
+```
+
+The kind of local mutation queued in the outbox.
+
+### `PendingChange`
+
+A local mutation waiting to be pushed to the remote.
+
+```kotlin
+data class PendingChange(
+    val record: Record,
+    val kind: ChangeKind,
+)
+```
+
+- `record` — the row payload to push (for a `DELETE`, a tombstone).
+- `kind` — whether the change is an upsert or a delete.
+
+### `PullResult`
+
+What a single `RemoteSource.pull` returned.
+
+```kotlin
+data class PullResult(
+    val changed: List<Record>,
+    val nextCursor: Cursor?,
+)
+```
+
+- `changed` — the rows that changed since the supplied cursor.
+- `nextCursor` — the position to resume from next time, or `null` to leave the
+  stored cursor unchanged (e.g. when nothing changed). Returning `null` must
+  never force a full re-sync.
+
+### `PushResult`
+
+Per-id outcome of a push.
+
+```kotlin
+data class PushResult(
+    val accepted: List<String>,
+    val rejected: List<String> = emptyList(),
+)
+```
+
+- `accepted` — ids the server accepted; the engine clears these from the outbox.
+- `rejected` — ids the server rejected; left pending. Defaults to empty.
+
+### `SyncResult`
+
+Summary of one full `SyncEngine.sync` cycle.
+
+```kotlin
+data class SyncResult(
+    val pulled: Int,
+    val pushed: Int,
+    val rejected: Int,
+)
+```
+
+- `pulled` — rows merged in from the remote across all drained pages.
+- `pushed` — local changes the server accepted.
+- `rejected` — local changes the server rejected.
+
+### `PullProgress`
+
+Outcome of one `SyncEngine.pullPage`.
+
+```kotlin
+data class PullProgress(
+    val pulled: Int,
+    val hasMore: Boolean,
+)
+```
+
+- `pulled` — how many rows this page carried.
+- `hasMore` — whether another page likely follows (true only when the server both
+  advanced the cursor and returned rows).
+
+### `Page<T>`
+
+One page of rows from a `LocalStore` offset list query.
+
+```kotlin
+data class Page<T>(
+    val items: List<T>,
+    val offset: Long,
+    val limit: Long,
+    val total: Long,
+) {
+    val hasMore: Boolean
+}
+```
+
+- `items` — the rows in this page.
+- `offset` / `limit` — echo the request.
+- `total` — the full live row count for the table (for "page x of y").
+- `hasMore` — computed: `true` when `offset + items.size < total`.
+
+### `LocalStore`
+
+The local-database side of sync: it stores synced rows, remembers each table's
+pull cursor, and holds the outbox of local changes still to push.
+
+```kotlin
+interface LocalStore {
+    suspend fun upsert(table: String, records: List<Record>)
+    suspend fun get(table: String, id: String): Record?
+    suspend fun cursor(table: String): Cursor?
+    suspend fun setCursor(table: String, cursor: Cursor?)
+    suspend fun pending(table: String): List<PendingChange>
+    suspend fun enqueue(table: String, change: PendingChange)
+    suspend fun clearPending(table: String, ids: List<String>)
+    suspend fun page(table: String, limit: Long, offset: Long): Page<Record>
+    suspend fun pageAfter(table: String, afterId: String?, limit: Long): List<Record>
+    suspend fun count(table: String): Long
+}
+```
+
+- `upsert` — the **pull** path: applies remote `records`. Implementations apply a
+  monotonic guard per row (a record older than the stored one is skipped), so
+  re-applying an earlier pull never clobbers newer local state. Not for local
+  edits — use `enqueue`.
+- `get` — the row `id` in `table`, or `null` if absent.
+- `cursor` — the last pull position stored for `table`, or `null` if it has never
+  synced.
+- `setCursor` — persists the pull position (`null` clears it).
+- `pending` — local changes for `table` still waiting to be pushed.
+- `enqueue` — the **optimistic write** path: in one transaction it applies the row
+  (unguarded, so the user's edit always wins locally) and appends the change to
+  the outbox. The outbox holds one entry per row id (latest intent wins), so
+  re-editing a row before it syncs replaces its pending entry.
+- `clearPending` — removes outbox entries for `ids` after they were pushed or
+  superseded.
+- `page` — offset page of live (non-tombstone) rows, ordered by id. Drives
+  `SyncStore.paged`.
+- `pageAfter` — keyset page: the next `limit` live rows after `afterId` (`null` =
+  first page), ordered by id.
+- `count` — total live row count for `table`.
+
+### `RemoteSource`
+
+The remote-API side of sync.
+
+```kotlin
+interface RemoteSource {
+    suspend fun pull(table: String, since: Cursor?): PullResult
+    suspend fun push(table: String, changes: List<PendingChange>): PushResult
+    fun changes(table: String): Flow<Record>
+}
+```
+
+- `pull` — fetches rows changed since `since` (all rows when `null`) and reports
+  the cursor to resume from.
+- `push` — sends local `changes` and reports which were accepted.
+- `changes` — a live stream of remote deltas, one `Record` per change.
+
+### `TableAdapter`
+
+The seam that makes a consumer's own typed table the single source of truth for a
+synced table, on any local database. A `LocalStore` reads and writes domain rows
+only through this adapter; the adapter handles only the domain `JsonObject`
+fields, while sync metadata (server `updatedAt`, the tombstone) stays the store's
+responsibility. Methods are synchronous; the store calls them from its `suspend`
+functions.
+
+```kotlin
+interface TableAdapter {
+    val table: String
+    fun upsert(id: String, fields: JsonObject)
+    fun get(id: String): JsonObject?
+    fun delete(id: String)
+    fun page(limit: Long, offset: Long): List<Pair<String, JsonObject>>
+    fun pageAfter(afterId: String?, limit: Long): List<Pair<String, JsonObject>>
+    fun count(): Long
+}
+```
+
+- `table` — the table name as the engine/remote knows it.
+- `upsert` — inserts or replaces the row `id` with `fields`.
+- `get` — the row `id`'s fields, or `null` if absent.
+- `delete` — removes the row `id`.
+- `page` — offset pagination, rows ordered by id as `(id, fields)` pairs.
+- `pageAfter` — keyset pagination: the next `limit` rows with id greater than
+  `afterId` (`null` = start).
+- `count` — total row count (feeds `Page.total`).
+
+### `ConflictResolver`
+
+Decides the winner when a local pending change and an incoming remote record touch
+the same row.
+
+```kotlin
+fun interface ConflictResolver {
+    fun resolve(local: Record, remote: Record): Record
+}
+```
+
+Implement it (it is a functional interface) for field-level merges or any custom
+policy, and register per table on a `ResolverRegistry`.
+
+### `LastWriteWins`
+
+The default resolver.
+
+```kotlin
+object LastWriteWins : ConflictResolver {
+    override fun resolve(local: Record, remote: Record): Record
+}
+```
+
+Higher `Record.updatedAt` wins; ties go to the remote, since the server is
+authoritative.
+
+### `ResolverRegistry`
+
+Maps tables to their resolver, falling back to a default for unregistered tables.
+
+```kotlin
+class ResolverRegistry(default: ConflictResolver = LastWriteWins) {
+    fun register(table: String, resolver: ConflictResolver): ResolverRegistry
+    fun forTable(table: String): ConflictResolver
+}
+```
+
+- constructor `default` — the fallback resolver for unregistered tables
+  (`LastWriteWins` by default).
+- `register` — registers `resolver` for `table`; returns `this` for chaining.
+- `forTable` — the resolver for `table`, or the default if none was registered.
+
+### `SyncEngine`
+
+Orchestrates one offline-first sync cycle per table. Transport-agnostic — it
+talks only to a `LocalStore` and a `RemoteSource`.
+
+```kotlin
+class SyncEngine(
+    local: LocalStore,
+    remote: RemoteSource,
+    resolvers: ResolverRegistry = ResolverRegistry(),
+) {
+    suspend fun sync(table: String): SyncResult
+    suspend fun pullPage(table: String): PullProgress
+    fun observe(table: String): Flow<Record>
+}
+```
+
+- constructor `local` / `remote` — the store and source halves.
+- constructor `resolvers` — per-table conflict resolvers; defaults to
+  last-write-wins for every table.
+- `sync` — runs a full pull → merge → push cycle and returns a `SyncResult`. It
+  drains every pending remote page (bounded internally against a server that
+  never lowers `hasMore`) before pushing the outbox, then clears accepted ids. If
+  the remote version wins a conflict the local edit is dropped; otherwise the
+  resolved winner is re-queued so the merged value — not the stale original — is
+  what gets pushed.
+- `pullPage` — pulls and merges a single page (no push), advancing the table's
+  cursor; returns a `PullProgress`. Call repeatedly to walk a large table
+  page-by-page. Powers `SyncStore.pagedSynced`.
+- `observe` — a live `Flow` of the table's remote changes, each merged into the
+  local store as it arrives through the same conflict resolver as `sync`. Collect
+  it alongside periodic `sync` calls; still re-run `sync` on reconnect to backfill
+  deltas missed while disconnected.
+
+<Callout type="warning">
+`pull` and `push` propagate transport/server failures by throwing — a failed
+push leaves the outbox intact for the next cycle. Wrap `sync` / `pullPage` calls
+accordingly, or use the `SyncStore` façade in `supabase-sync-paging`, which folds
+failures into a `SyncStatus.ERROR` state.
+</Callout>
+
+### `createSyncEngine`
+
+The convention-matching factory that mirrors the SDK's other `create*` entry
+points.
+
+```kotlin
+fun createSyncEngine(
+    local: LocalStore,
+    remote: RemoteSource,
+    resolvers: ResolverRegistry = ResolverRegistry(),
+): SyncEngine
+```
+
+Equivalent to calling the `SyncEngine` constructor directly; prefer it for
+consistency.
+
+```kotlin
+val engine = createSyncEngine(
+    local = openOfflineSyncStore(driver),
+    remote = createSupabaseRemoteSource(database, realtime),
+    resolvers = ResolverRegistry().register("notes", LastWriteWins),
+)
+val result = engine.sync("notes")   // SyncResult(pulled, pushed, rejected)
+```
+
+## `supabase-sync-sqldelight`
+
+Artifact: `io.github.androidpoet:supabase-sync-sqldelight`. All symbols live under
+the package `io.github.androidpoet.supabase.sync.store`. The store is
+driver-agnostic: you bring your own SQLDelight `SqlDriver`, so the same code runs
+on iOS, macOS, and the JVM.
+
+<Callout type="info">
+The generated SQLDelight database type (the `...sync.store.db` package) is an
+internal implementation detail and is not part of the public API. Construct the
+store from a `SqlDriver` via `openOfflineSyncStore` or the public
+`SqlDelightLocalStore(driver, ...)` constructor — never from the generated type.
+</Callout>
+
+### `ColumnKind`
+
+The SQLite storage class of a column, and how its value maps to and from JSON.
+
+```kotlin
+enum class ColumnKind { TEXT, INTEGER, REAL, BOOL, JSON }
+```
+
+`BOOL` is stored as `INTEGER` (0/1); `JSON` columns are stored as `TEXT`,
+matching the schema the SQLDelight generator emits.
+
+### `Column`
+
+One column of a synced table.
+
+```kotlin
+data class Column(
+    val name: String,
+    val kind: ColumnKind,
+    val nullable: Boolean = false,
+)
+```
+
+- `name` — the column name.
+- `kind` — its storage/JSON mapping.
+- `nullable` — whether it accepts `null` (defaults to `false`).
+
+### `SqlDelightTableAdapter`
+
+A generic `TableAdapter` over any SQLite table reachable through a `SqlDriver`,
+driven entirely by a column descriptor. All JSON ↔ typed-column conversion lives
+here, so codegen only emits the trivial descriptor. Reads and writes go straight
+to the same SQLite table your `.sq` `CREATE TABLE` defines, so your typed queries
+and the sync engine share one set of rows.
+
+```kotlin
+class SqlDelightTableAdapter(
+    driver: SqlDriver,
+    table: String,
+    columns: List<Column>,
+    pk: String,
+) : TableAdapter
+```
+
+- `driver` — the SQLDelight driver to read/write through.
+- `table` — the SQLite table name.
+- `columns` — the column descriptor for the table.
+- `pk` — the primary-key column name.
+
+Implements every `TableAdapter` member (`table`, `upsert`, `get`, `delete`,
+`page`, `pageAfter`, `count`) against that table.
+
+### `SqlDelightLocalStore`
+
+A `LocalStore` backed by SQLDelight, so synced rows, pull cursors, and the outbox
+survive process restarts on every Kotlin/Native and JVM target. For each table you
+can register a `TableAdapter`: that table then becomes a single source of truth
+(rows live in your own typed table, with only sync metadata kept in a sidecar).
+Tables with no adapter fall back to a generic JSON blob cache — zero-config.
+
+```kotlin
+class SqlDelightLocalStore(
+    driver: SqlDriver,
+    adapters: Map<String, TableAdapter> = emptyMap(),
+) : LocalStore
+```
+
+- `driver` — your SQLDelight driver. The schema must already be created on it
+  (use `openOfflineSyncStore`, which does this for you).
+- `adapters` — per-table adapters; tables not in the map use the blob cache.
+
+Implements all of `LocalStore` (`upsert`, `get`, `cursor`, `setCursor`,
+`pending`, `enqueue`, `clearPending`, `page`, `pageAfter`, `count`) with the
+monotonic-apply guard on the pull path and an atomic apply-plus-enqueue on the
+optimistic-write path.
+
+### `openOfflineSyncStore`
+
+Creates the schema on the driver and returns a ready-to-use store.
+
+```kotlin
+fun openOfflineSyncStore(
+    driver: SqlDriver,
+    adapters: Map<String, TableAdapter> = emptyMap(),
+): SqlDelightLocalStore
+```
+
+- `driver` — your SQLDelight driver; the offline-sync schema is created on it.
+- `adapters` — optional per-table adapters.
+
+```kotlin
+val store = openOfflineSyncStore(
+    driver = driver,
+    adapters = mapOf(
+        "notes" to SqlDelightTableAdapter(
+            driver = driver,
+            table = "notes",
+            columns = listOf(
+                Column("id", ColumnKind.TEXT),
+                Column("body", ColumnKind.TEXT),
+                Column("pinned", ColumnKind.BOOL),
+            ),
+            pk = "id",
+        ),
+    ),
+)
+```
+
+## `supabase-sync`
+
+Artifact: `io.github.androidpoet:supabase-sync`. All symbols live under the
+package `io.github.androidpoet.supabase.sync.remote`. This module provides the
+`RemoteSource` half over a `supabase-kmp` `DatabaseClient` (PostgREST) and
+`RealtimeClient`.
+
+### `SyncColumns`
+
+Names of the three columns the engine needs on every synced Supabase table.
+
+```kotlin
+data class SyncColumns(
+    val id: String = "id",
+    val updatedAt: String = "updated_at",
+    val deleted: String = "deleted",
+)
+```
+
+- `id` — the primary-key column (stays a domain field, since it is part of the
+  row). Defaults to `"id"`.
+- `updatedAt` — the modification-time column. Must be an **integer epoch-millis**
+  column (`bigint`) so it compares as the `Long` the cursor keyset uses; a
+  `timestamptz` column won't compare correctly. Stripped out as sync metadata.
+  Defaults to `"updated_at"`.
+- `deleted` — a `boolean` soft-delete column defaulting to `false`. Deletes are
+  soft so an incremental "changed since" pull can still observe them. Stripped out
+  as sync metadata. Defaults to `"deleted"`.
+
+### `SupabaseRemoteSource`
+
+The `RemoteSource` backed by Supabase: incremental pulls and bulk upserts over
+PostgREST and a live delta stream over Realtime.
+
+```kotlin
+class SupabaseRemoteSource(
+    database: DatabaseClient,
+    realtime: RealtimeClient,
+    columns: SyncColumns = SyncColumns(),
+    schema: String = "public",
+    pageSize: Int = 1000,
+) : RemoteSource {
+    suspend fun pull(table: String, since: Cursor?): PullResult
+    suspend fun push(table: String, changes: List<PendingChange>): PushResult
+    fun changes(table: String): Flow<Record>
+}
+```
+
+- `database` — the PostgREST client for pulls and pushes.
+- `realtime` — the Realtime client for the live stream.
+- `columns` — the id / updated-at / deleted column names (defaults to
+  `SyncColumns()`).
+- `schema` — the Postgres schema the tables live in (`"public"` by default).
+- `pageSize` — max rows fetched per `pull`; if more changed, the advanced cursor
+  lets the next `sync` pick up the remainder. Defaults to `1000`.
+- `pull` — fetches rows whose `(updatedAt, id)` is greater than `since` (all rows
+  when `null`), ordered by that keyset and capped at `pageSize`, and returns the
+  new high-water cursor (or `null` when nothing changed). Throws on a
+  transport/server error.
+- `push` — bulk-upserts the outbox records with `on_conflict` on the id column. A
+  push is all-or-nothing per request: on success every id is accepted; an error
+  throws and leaves the outbox intact. Deletes are soft (the record carries
+  `deleted = true`).
+- `changes` — a cold `Flow` of the table's Realtime `postgres_changes`, each
+  emitted as a `Record` (a DELETE surfaces as a tombstone). Connects the client if
+  needed and tears the channel down when collection stops.
+
+Build `database` and `realtime` from the same client and share one auth token so
+Row Level Security applies to both the pulled rows and the Realtime subscription.
+
+### `createSupabaseRemoteSource`
+
+The convention-matching factory mirroring the SDK's other `create*` entry points.
+
+```kotlin
+fun createSupabaseRemoteSource(
+    database: DatabaseClient,
+    realtime: RealtimeClient,
+    columns: SyncColumns = SyncColumns(),
+    schema: String = "public",
+    pageSize: Int = 1000,
+): SupabaseRemoteSource
+```
+
+Same parameters and defaults as the constructor; prefer it for consistency.
+
+```kotlin
+val remote = createSupabaseRemoteSource(
+    database = client.database,
+    realtime = client.realtime,
+    columns = SyncColumns(updatedAt = "updated_at_ms"),
+)
+```
+
+## `supabase-sync-paging`
+
+Artifact: `io.github.androidpoet:supabase-sync-paging`. All symbols live under the
+package `io.github.androidpoet.supabase.sync.paging`. This module is the Paging 3
+bridge: a typed per-table façade an app binds directly to its UI.
+
+<Callout type="info">
+The Paging 3 surface is **Int-keyed** (page sizes are `Int`), matching the
+Paging 3 API, while the underlying `LocalStore` pages with `Long` limits/offsets
+and the engine advances `Long`-based keyset cursors. The Int/Long split at this
+boundary is intentional — the façade bridges the Int-based Paging 3 API onto the
+Long-based store and cursor model.
+</Callout>
+
+### `SyncStatus`
+
+```kotlin
+enum class SyncStatus { IDLE, SYNCING, ERROR }
+```
+
+Where the store is in its current sync cycle — bind it to a spinner or error
+banner.
+
+### `DefaultJson`
+
+The lenient, default-encoding `Json` used when no custom instance is supplied.
+
+```kotlin
+val DefaultJson: Json
+```
+
+Configured with `ignoreUnknownKeys = true` and `encodeDefaults = true`.
+
+### `SyncStore<T>`
+
+The one always-in-sync model an app touches per table: a value of type `T` is the
+same on screen, in the local database, and on the wire. The UI binds `paged` or
+`observe` and calls `upsert` / `delete`; it never touches the network or SQL.
+Reads reflect a local write immediately (optimistic), and the change is pushed in
+the background through the engine's outbox. Writes are single-flighted: a burst of
+edits collapses to at most one follow-up sync.
+
+```kotlin
+class SyncStore<T : Any>(
+    table: String,
+    local: LocalStore,
+    engine: SyncEngine,
+    serializer: KSerializer<T>,
+    idOf: (T) -> String,
+    scope: CoroutineScope,
+    now: () -> Long,
+    json: Json = DefaultJson,
+) {
+    val status: StateFlow<SyncStatus>
+    fun observe(id: String): Flow<T?>
+    fun paged(pageSize: Int = 20): Flow<PagingData<T>>
+    fun pagedSynced(pageSize: Int = 20): Flow<PagingData<T>>
+    suspend fun get(id: String): T?
+    suspend fun upsert(value: T)
+    suspend fun delete(id: String)
+    suspend fun sync(): SyncResult
+}
+```
+
+- `table` — the table name to sync.
+- `local` / `engine` — the store and engine this façade drives.
+- `serializer` — the `kotlinx.serialization` serializer for `T` (the row must
+  serialize to a JSON object).
+- `idOf` — extracts the primary-key string from a value of `T`.
+- `scope` — the coroutine scope the background sync loop runs on.
+- `now` — a wall-clock epoch-millis source (e.g.
+  `{ Clock.System.now().toEpochMilliseconds() }`), stamped on optimistic writes so
+  last-write-wins resolves correctly across devices.
+- `json` — the `Json` used to encode/decode rows (defaults to `DefaultJson`).
+- `status` — a `StateFlow` of the latest `SyncStatus` (`IDLE` / `SYNCING` /
+  `ERROR`).
+- `observe` — a reactive single row that re-emits whenever the row changes locally
+  or after a sync; emits `null` if absent or tombstoned.
+- `paged` — a Paging 3 `PagingData` stream over the **local** store, loading one
+  `pageSize` window at a time (never the whole table) and invalidating on any
+  local write or completed sync. Drops into a Compose `LazyColumn` via
+  `collectAsLazyPagingItems()`. `pageSize` defaults to `20`.
+- `pagedSynced` — like `paged`, but backed by a Paging 3 `RemoteMediator` that
+  pulls the next backend page on demand as the user scrolls (via
+  `SyncEngine.pullPage`) and writes it to the local store, so it is then available
+  offline. `pageSize` defaults to `20`.
+- `get` — a one-shot local read of the row `id`, or `null` if absent or
+  tombstoned.
+- `upsert` — optimistically inserts/replaces `value`: visible to reads at once,
+  queued to push on the next sync.
+- `delete` — optimistically deletes `id` via a soft-delete tombstone, queued to
+  push on the next sync.
+- `sync` — runs one pull → merge → push cycle, updating `status`, and returns the
+  `SyncResult`. Serialized so a manual call and the background trigger never
+  overlap.
+
+```kotlin
+val notes = SyncStore(
+    table = "notes",
+    local = store,
+    engine = engine,
+    serializer = Note.serializer(),
+    idOf = { it.id },
+    scope = appScope,
+    now = { Clock.System.now().toEpochMilliseconds() },
+)
+
+val list: Flow<PagingData<Note>> = notes.paged(20)   // local-first, auto-invalidating
+val one: Flow<Note?> = notes.observe(id)
+
+notes.upsert(Note(id = "n1", body = "buy milk"))
+notes.delete("n1")
+```


### PR DESCRIPTION
Adds a new **/reference** section to the docs site: one exhaustive, source-accurate page per published module, generated from the real 1.0.0 `*.klib.api` public-API dumps and KDoc.

### Pages
`core` · `client` · `auth` · `auth-admin` · `auth-native` (Google/Apple/Passkey) · `database` · `storage` · `realtime` · `functions` · `e2ee` · `sync` (core/sqldelight/sync/paging) · `codegen` — plus an overview index and nav wiring.

Each symbol is documented with its real signature, every parameter, return type (`SupabaseResult` Success/Failure semantics), and a short example. Reflects the 1.0 API hardening throughout (e.g. `selectTyped`, `deleteObjects`, `removeSubscription*`, `createAuthAdminClient`, `OtpVerifyResult`).

Also fixes a stale GeoJSON example in the database guide (`geojson = true` → `format = ResponseFormat.GEOJSON`).

Docs site builds clean (`pnpm build`, exit 0).